### PR TITLE
Add read-only dashboard embedded in the sozune binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build dashboard
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2096,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,9 +2618,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "instant-acme",
+ "mime_guess",
  "notify",
  "rcgen",
  "reqwest",
+ "rust-embed",
  "rustls",
  "serde",
  "serde_json",
@@ -2982,6 +3028,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"] }
 sha2 = "0.10"
 subtle = "2"
+rust-embed = "8"
+mime_guess = "2"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all build build-dashboard run test fmt clean
+
+all: build
+
+build: build-dashboard
+	cargo build --release
+
+build-dashboard:
+	cd dashboard && bun install && bun run build
+
+run: build-dashboard
+	cargo run
+
+test:
+	cargo test
+	cd dashboard && bun run check && bun run lint
+
+fmt:
+	cargo fmt
+	cd dashboard && bun run format
+
+clean:
+	cargo clean
+	rm -rf dashboard/build dashboard/.svelte-kit

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+/build
+/.svelte-kit
+/package
+.env
+.env.*
+!.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/dashboard/biome.json
+++ b/dashboard/biome.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**/*.ts",
+      "**/*.js",
+      "**/*.json",
+      "!**/.svelte-kit",
+      "!**/build",
+      "!**/node_modules"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "useBlockStatements": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "none"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "sozune-dashboard",
       "devDependencies": {
+        "@biomejs/biome": "2.4.12",
         "@sveltejs/adapter-static": "^3.0.6",
         "@sveltejs/kit": "^2.8.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
@@ -16,6 +17,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -1,0 +1,219 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "sozune-dashboard",
+      "devDependencies": {
+        "@sveltejs/adapter-static": "^3.0.6",
+        "@sveltejs/kit": "^2.8.0",
+        "@sveltejs/vite-plugin-svelte": "^4.0.0",
+        "svelte": "^5.1.0",
+        "svelte-check": "^4.0.0",
+        "typescript": "^5.6.0",
+        "vite": "^5.4.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.1", "", { "os": "android", "cpu": "arm64" }, "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
+
+    "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
+
+    "@sveltejs/kit": ["@sveltejs/kit@2.57.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.6.4", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@4.0.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0", "debug": "^4.3.7", "deepmerge": "^4.3.1", "kleur": "^4.1.5", "magic-string": "^0.30.12", "vitefu": "^1.0.3" }, "peerDependencies": { "svelte": "^5.0.0-next.96 || ^5.0.0", "vite": "^5.0.0" } }, "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA=="],
+
+    "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@3.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0", "svelte": "^5.0.0-next.96 || ^5.0.0", "vite": "^5.0.0" } }, "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ=="],
+
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.2.5", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "svelte": ["svelte@5.55.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.4", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ=="],
+
+    "svelte-check": ["svelte-check@4.4.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "sozune-dashboard",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-static": "^3.0.6",
+    "@sveltejs/kit": "^2.8.0",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.1.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,9 +7,13 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write ."
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.12",
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.8.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/dashboard/src/app.css
+++ b/dashboard/src/app.css
@@ -1,0 +1,103 @@
+@import url('https://rsms.me/inter/inter.css');
+
+:root {
+  --bg-0: #0a0c10;
+  --bg-1: #0f1216;
+  --bg-2: #151a21;
+  --bg-3: #1c222b;
+  --bg-hover: #1f2631;
+  --border: #242b36;
+  --border-strong: #2f3847;
+
+  --fg-0: #e8ecf1;
+  --fg-1: #b6bdc9;
+  --fg-2: #7a8594;
+  --fg-3: #4d5663;
+
+  --accent: #5b8dff;
+  --accent-hover: #7aa1ff;
+  --accent-bg: rgba(91, 141, 255, 0.1);
+
+  --success: #3fb950;
+  --success-bg: rgba(63, 185, 80, 0.12);
+  --warning: #f0b429;
+  --warning-bg: rgba(240, 180, 41, 0.12);
+  --danger: #f85149;
+  --danger-bg: rgba(248, 81, 73, 0.12);
+
+  --radius-sm: 4px;
+  --radius: 6px;
+  --radius-lg: 10px;
+
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+
+  font-family: var(--font-sans);
+  font-feature-settings: 'cv11', 'ss01', 'ss03';
+  color-scheme: dark;
+}
+
+@supports (font-variation-settings: normal) {
+  :root {
+    font-family: 'Inter var', var(--font-sans);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-0);
+  color: var(--fg-0);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+input,
+select,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+code,
+.mono {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--accent-hover);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--bg-3);
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
+}

--- a/dashboard/src/app.d.ts
+++ b/dashboard/src/app.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  namespace App {}
+}
+
+export {};

--- a/dashboard/src/app.html
+++ b/dashboard/src/app.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>sozune dashboard</title>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,0 +1,95 @@
+const TOKEN_KEY = 'sozune.token';
+const BASE_URL_KEY = 'sozune.baseUrl';
+const DEFAULT_BASE_URL = 'http://127.0.0.1:3035';
+
+export function getToken(): string | null {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  if (token) {
+    localStorage.setItem(TOKEN_KEY, token);
+  } else {
+    localStorage.removeItem(TOKEN_KEY);
+  }
+}
+
+export function getBaseUrl(): string {
+  if (typeof localStorage === 'undefined') {
+    return DEFAULT_BASE_URL;
+  }
+  return localStorage.getItem(BASE_URL_KEY) ?? DEFAULT_BASE_URL;
+}
+
+export function setBaseUrl(url: string): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  localStorage.setItem(BASE_URL_KEY, url);
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = getToken();
+  const headers = new Headers(init.headers);
+  headers.set('Accept', 'application/json');
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const res = await fetch(`${getBaseUrl()}${path}`, { ...init, headers });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}${text ? `: ${text}` : ''}`);
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}
+
+export type Protocol = 'Http' | 'Tcp' | 'Udp';
+
+export interface EntrypointConfig {
+  hostnames: string[];
+  port: number;
+  tls: boolean;
+  strip_prefix: boolean;
+  https_redirect?: boolean;
+  priority: number;
+  sticky_session?: boolean;
+  compress?: boolean;
+  headers?: Record<string, string>;
+  backend_timeout?: number | null;
+  [key: string]: unknown;
+}
+
+export interface Entrypoint {
+  id: string;
+  name: string;
+  protocol: Protocol;
+  backends: string[];
+  config: EntrypointConfig;
+  source?: string | null;
+  backend_weights?: Record<string, number>;
+}
+
+export function listEntrypoints(): Promise<Entrypoint[]> {
+  return request<Entrypoint[]>('/entrypoints');
+}
+
+export function getEntrypoint(id: string): Promise<Entrypoint> {
+  return request<Entrypoint>(`/entrypoints/${encodeURIComponent(id)}`);
+}
+
+export function health(): Promise<unknown> {
+  return request<unknown>('/health');
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,24 +1,7 @@
-const TOKEN_KEY = 'sozune.token';
+import { clearAuth, getCredentials } from './auth';
+
 const BASE_URL_KEY = 'sozune.baseUrl';
 const DEFAULT_BASE_URL = 'http://127.0.0.1:3035';
-
-export function getToken(): string | null {
-  if (typeof localStorage === 'undefined') {
-    return null;
-  }
-  return localStorage.getItem(TOKEN_KEY);
-}
-
-export function setToken(token: string): void {
-  if (typeof localStorage === 'undefined') {
-    return;
-  }
-  if (token) {
-    localStorage.setItem(TOKEN_KEY, token);
-  } else {
-    localStorage.removeItem(TOKEN_KEY);
-  }
-}
 
 export function getBaseUrl(): string {
   if (typeof localStorage === 'undefined') {
@@ -34,18 +17,31 @@ export function setBaseUrl(url: string): void {
   localStorage.setItem(BASE_URL_KEY, url);
 }
 
+function basicHeader(name: string, password: string): string {
+  return `Basic ${btoa(`${name}:${password}`)}`;
+}
+
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const token = getToken();
+  const credentials = getCredentials();
   const headers = new Headers(init.headers);
   headers.set('Accept', 'application/json');
   if (init.body && !headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json');
   }
-  if (token) {
-    headers.set('Authorization', `Bearer ${token}`);
+  if (credentials) {
+    headers.set('Authorization', basicHeader(credentials.name, credentials.password));
   }
 
   const res = await fetch(`${getBaseUrl()}${path}`, { ...init, headers });
+
+  if (res.status === 401) {
+    clearAuth();
+    if (typeof window !== 'undefined' && !window.location.pathname.endsWith('/login')) {
+      window.location.assign('./login');
+    }
+    throw new Error('401 Unauthorized');
+  }
+
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`${res.status} ${res.statusText}${text ? `: ${text}` : ''}`);
@@ -54,6 +50,28 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
     return undefined as T;
   }
   return (await res.json()) as T;
+}
+
+/** Validate a credential pair against `/me`. Used by the login page only —
+ *  callers elsewhere should rely on the persisted credentials. */
+export async function validateCredentials(
+  baseUrl: string,
+  name: string,
+  password: string
+): Promise<{ name: string; role: 'admin' | 'read-only' }> {
+  const res = await fetch(`${baseUrl}/me`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: basicHeader(name, password)
+    }
+  });
+  if (res.status === 401) {
+    throw new Error('Invalid credentials');
+  }
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as { name: string; role: 'admin' | 'read-only' };
 }
 
 export type Protocol = 'Http' | 'Tcp' | 'Udp';
@@ -92,4 +110,8 @@ export function getEntrypoint(id: string): Promise<Entrypoint> {
 
 export function health(): Promise<unknown> {
   return request<unknown>('/health');
+}
+
+export function me(): Promise<{ name: string; role: 'admin' | 'read-only' }> {
+  return request<{ name: string; role: 'admin' | 'read-only' }>('/me');
 }

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -1,0 +1,71 @@
+import { type Readable, writable } from 'svelte/store';
+
+const CREDENTIALS_KEY = 'sozune.credentials';
+
+export type Role = 'admin' | 'read-only';
+
+export interface Identity {
+  name: string;
+  role: Role;
+}
+
+interface StoredCredentials {
+  name: string;
+  password: string;
+  role: Role;
+}
+
+function readSession(): StoredCredentials | null {
+  if (typeof sessionStorage === 'undefined') {
+    return null;
+  }
+  const raw = sessionStorage.getItem(CREDENTIALS_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as StoredCredentials;
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(value: StoredCredentials | null): void {
+  if (typeof sessionStorage === 'undefined') {
+    return;
+  }
+  if (value) {
+    sessionStorage.setItem(CREDENTIALS_KEY, JSON.stringify(value));
+  } else {
+    sessionStorage.removeItem(CREDENTIALS_KEY);
+  }
+}
+
+const initial = readSession();
+const internal = writable<StoredCredentials | null>(initial);
+
+/** Public read-only view of the current identity (no password). */
+export const identity: Readable<Identity | null> = {
+  subscribe: (run) => internal.subscribe((c) => run(c ? { name: c.name, role: c.role } : null))
+};
+
+export function setAuth(name: string, password: string, role: Role): void {
+  const value = { name, password, role };
+  writeSession(value);
+  internal.set(value);
+}
+
+export function clearAuth(): void {
+  writeSession(null);
+  internal.set(null);
+}
+
+/** Returns the raw credentials needed to forge `Authorization: Basic`. */
+export function getCredentials(): { name: string; password: string } | null {
+  const c = readSession();
+  return c ? { name: c.name, password: c.password } : null;
+}
+
+export function isAuthenticated(): boolean {
+  return readSession() !== null;
+}

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import '../app.css';
+  import { page } from '$app/stores';
+
+  let { children } = $props();
+
+  const nav = [
+    { href: './', label: 'Entrypoints', icon: 'grid' },
+    { href: './certificates', label: 'Certificates', icon: 'lock' },
+    { href: './health', label: 'Health', icon: 'pulse' },
+    { href: './settings', label: 'Settings', icon: 'gear' }
+  ];
+
+  function isActive(href: string): boolean {
+    const current = $page.url.pathname.replace(/\/$/, '');
+    const target = href.replace(/^\.\//, '/').replace(/\/$/, '');
+    if (target === '') return current === '';
+    return current === target || current.startsWith(target + '/');
+  }
+</script>
+
+<div class="shell">
+  <aside class="sidebar">
+    <div class="brand">
+      <div class="logo">s</div>
+      <div class="brand-text">
+        <div class="brand-name">sozune</div>
+        <div class="brand-sub">dashboard</div>
+      </div>
+    </div>
+
+    <nav>
+      {#each nav as item}
+        <a href={item.href} class="nav-item" class:active={isActive(item.href)}>
+          <span class="nav-icon" data-icon={item.icon}>
+            {#if item.icon === 'grid'}
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="2" width="5" height="5" rx="1"/><rect x="9" y="2" width="5" height="5" rx="1"/><rect x="2" y="9" width="5" height="5" rx="1"/><rect x="9" y="9" width="5" height="5" rx="1"/></svg>
+            {:else if item.icon === 'lock'}
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="7" width="10" height="7" rx="1"/><path d="M5 7V4.5a3 3 0 0 1 6 0V7"/></svg>
+            {:else if item.icon === 'pulse'}
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 8h3l2-5 3 10 2-5h4"/></svg>
+            {:else if item.icon === 'gear'}
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="2.5"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M3.05 12.95l1.4-1.4M11.55 4.45l1.4-1.4"/></svg>
+            {/if}
+          </span>
+          <span>{item.label}</span>
+        </a>
+      {/each}
+    </nav>
+
+    <div class="sidebar-footer">
+      <div class="version mono">v0.10.0</div>
+    </div>
+  </aside>
+
+  <main class="main">
+    {@render children()}
+  </main>
+</div>
+
+<style>
+  .shell {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 100vh;
+  }
+
+  .sidebar {
+    background: var(--bg-1);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 0.75rem;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.25rem 0.5rem 1.25rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .logo {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--accent), #3a6fd9);
+    color: white;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 1.05rem;
+    box-shadow: 0 2px 8px rgba(91, 141, 255, 0.3);
+  }
+
+  .brand-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: -0.01em;
+  }
+
+  .brand-sub {
+    font-size: 0.7rem;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 0.5rem;
+  }
+
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: var(--radius);
+    color: var(--fg-1);
+    font-size: 0.825rem;
+    font-weight: 500;
+    transition: background 0.1s, color 0.1s;
+  }
+  .nav-item:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .nav-item.active {
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+
+  .nav-icon {
+    display: grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+  }
+  .nav-icon :global(svg) {
+    width: 16px;
+    height: 16px;
+  }
+
+  .sidebar-footer {
+    margin-top: auto;
+    padding: 0.75rem 0.625rem 0.25rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .version {
+    color: var(--fg-3);
+    font-size: 0.7rem;
+  }
+
+  .main {
+    padding: 2rem 2.5rem;
+    max-width: 1400px;
+    width: 100%;
+  }
+</style>

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import '../app.css';
   import { page } from '$app/stores';
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { clearAuth, identity, isAuthenticated } from '$lib/auth';
 
   let { children } = $props();
 
@@ -17,46 +20,70 @@
     if (target === '') return current === '';
     return current === target || current.startsWith(target + '/');
   }
+
+  let onLoginPage = $derived($page.url.pathname.endsWith('/login'));
+
+  onMount(() => {
+    if (!onLoginPage && !isAuthenticated()) {
+      goto('./login');
+    }
+  });
+
+  function logout() {
+    clearAuth();
+    goto('./login');
+  }
 </script>
 
-<div class="shell">
-  <aside class="sidebar">
-    <div class="brand">
-      <div class="logo">s</div>
-      <div class="brand-text">
-        <div class="brand-name">sozune</div>
-        <div class="brand-sub">dashboard</div>
+{#if onLoginPage}
+  {@render children()}
+{:else}
+  <div class="shell">
+    <aside class="sidebar">
+      <div class="brand">
+        <div class="logo">s</div>
+        <div class="brand-text">
+          <div class="brand-name">sozune</div>
+          <div class="brand-sub">dashboard</div>
+        </div>
       </div>
-    </div>
 
-    <nav>
-      {#each nav as item}
-        <a href={item.href} class="nav-item" class:active={isActive(item.href)}>
-          <span class="nav-icon" data-icon={item.icon}>
-            {#if item.icon === 'grid'}
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="2" width="5" height="5" rx="1"/><rect x="9" y="2" width="5" height="5" rx="1"/><rect x="2" y="9" width="5" height="5" rx="1"/><rect x="9" y="9" width="5" height="5" rx="1"/></svg>
-            {:else if item.icon === 'lock'}
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="7" width="10" height="7" rx="1"/><path d="M5 7V4.5a3 3 0 0 1 6 0V7"/></svg>
-            {:else if item.icon === 'pulse'}
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 8h3l2-5 3 10 2-5h4"/></svg>
-            {:else if item.icon === 'gear'}
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="2.5"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M3.05 12.95l1.4-1.4M11.55 4.45l1.4-1.4"/></svg>
-            {/if}
-          </span>
-          <span>{item.label}</span>
-        </a>
-      {/each}
-    </nav>
+      <nav>
+        {#each nav as item}
+          <a href={item.href} class="nav-item" class:active={isActive(item.href)}>
+            <span class="nav-icon" data-icon={item.icon}>
+              {#if item.icon === 'grid'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="2" width="5" height="5" rx="1"/><rect x="9" y="2" width="5" height="5" rx="1"/><rect x="2" y="9" width="5" height="5" rx="1"/><rect x="9" y="9" width="5" height="5" rx="1"/></svg>
+              {:else if item.icon === 'lock'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="7" width="10" height="7" rx="1"/><path d="M5 7V4.5a3 3 0 0 1 6 0V7"/></svg>
+              {:else if item.icon === 'pulse'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 8h3l2-5 3 10 2-5h4"/></svg>
+              {:else if item.icon === 'gear'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="2.5"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M3.05 12.95l1.4-1.4M11.55 4.45l1.4-1.4"/></svg>
+              {/if}
+            </span>
+            <span>{item.label}</span>
+          </a>
+        {/each}
+      </nav>
 
-    <div class="sidebar-footer">
-      <div class="version mono">v0.10.0</div>
-    </div>
-  </aside>
+      <div class="sidebar-footer">
+        {#if $identity}
+          <div class="user">
+            <div class="user-name">{$identity.name}</div>
+            <div class="user-role">{$identity.role}</div>
+          </div>
+          <button class="logout" onclick={logout}>Sign out</button>
+        {/if}
+        <div class="version mono">v0.10.0</div>
+      </div>
+    </aside>
 
-  <main class="main">
-    {@render children()}
-  </main>
-</div>
+    <main class="main">
+      {@render children()}
+    </main>
+  </div>
+{/if}
 
 <style>
   .shell {
@@ -153,6 +180,41 @@
     margin-top: auto;
     padding: 0.75rem 0.625rem 0.25rem;
     border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .user {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .user-name {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--fg-0);
+  }
+
+  .user-role {
+    font-size: 0.7rem;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .logout {
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--fg-1);
+    font-size: 0.75rem;
+    padding: 0.4rem 0.625rem;
+    text-align: left;
+  }
+  .logout:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
   }
 
   .version {

--- a/dashboard/src/routes/+layout.ts
+++ b/dashboard/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = false;

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,0 +1,538 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { listEntrypoints, getToken, type Entrypoint } from '$lib/api';
+
+  let entrypoints = $state<Entrypoint[]>([]);
+  let error = $state<string | null>(null);
+  let loading = $state(true);
+  let lastRefresh = $state<Date | null>(null);
+  let search = $state('');
+  let protocolFilter = $state<'all' | 'Http' | 'Tcp' | 'Udp'>('all');
+
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  const filtered = $derived(
+    entrypoints.filter((ep) => {
+      if (protocolFilter !== 'all' && ep.protocol !== protocolFilter) return false;
+      if (!search) return true;
+      const q = search.toLowerCase();
+      return (
+        ep.name.toLowerCase().includes(q) ||
+        ep.id.toLowerCase().includes(q) ||
+        ep.config.hostnames.some((h) => h.toLowerCase().includes(q)) ||
+        ep.backends.some((b) => b.toLowerCase().includes(q))
+      );
+    })
+  );
+
+  const stats = $derived({
+    total: entrypoints.length,
+    http: entrypoints.filter((e) => e.protocol === 'Http').length,
+    tcp: entrypoints.filter((e) => e.protocol === 'Tcp').length,
+    backends: entrypoints.reduce((n, e) => n + e.backends.length, 0),
+    tls: entrypoints.filter((e) => e.config.tls).length
+  });
+
+  async function load(silent = false) {
+    if (!silent) loading = true;
+    try {
+      entrypoints = await listEntrypoints();
+      error = null;
+      lastRefresh = new Date();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      loading = false;
+      error = 'no token configured — open Settings';
+      return;
+    }
+    void load();
+    poll = setInterval(() => void load(true), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) clearInterval(poll);
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) return '';
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) return 'just now';
+    if (s < 60) return `${s}s ago`;
+    return `${Math.floor(s / 60)}m ago`;
+  }
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Entrypoints</h1>
+    <p class="subtitle">Routes served by the proxy</p>
+  </div>
+  <div class="header-actions">
+    {#if lastRefresh}
+      <span class="refresh-meta">updated {timeAgo(lastRefresh)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={() => load()} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">Entrypoints</div>
+    <div class="stat-value">{stats.total}</div>
+    <div class="stat-sub">{stats.http} HTTP · {stats.tcp} TCP</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Backends</div>
+    <div class="stat-value">{stats.backends}</div>
+    <div class="stat-sub">across all entrypoints</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">TLS enabled</div>
+    <div class="stat-value">{stats.tls}</div>
+    <div class="stat-sub">{stats.total ? Math.round((stats.tls / stats.total) * 100) : 0}% of routes</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Status</div>
+    <div class="stat-value healthy">
+      <span class="dot"></span> live
+    </div>
+    <div class="stat-sub">polling every 5s</div>
+  </div>
+</section>
+
+<section class="toolbar">
+  <div class="search">
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="7" cy="7" r="5"/><path d="M11 11l3 3" stroke-linecap="round"/></svg>
+    <input type="text" placeholder="search by name, hostname, backend…" bind:value={search} />
+  </div>
+  <div class="filters">
+    {#each ['all', 'Http', 'Tcp', 'Udp'] as p}
+      <button
+        class="filter-chip"
+        class:active={protocolFilter === p}
+        onclick={() => (protocolFilter = p as typeof protocolFilter)}
+      >
+        {p}
+      </button>
+    {/each}
+  </div>
+</section>
+
+{#if error}
+  <div class="alert">
+    <strong>error</strong> {error}
+  </div>
+{/if}
+
+<section class="table-wrap">
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Protocol</th>
+        <th>Hostnames</th>
+        <th>Backends</th>
+        <th>Features</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#if loading && entrypoints.length === 0}
+        <tr><td colspan="6" class="empty">loading…</td></tr>
+      {:else if filtered.length === 0}
+        <tr><td colspan="6" class="empty">no entrypoints match</td></tr>
+      {:else}
+        {#each filtered as ep (ep.id)}
+          <tr class="clickable" onclick={() => goto(`/entrypoints/${encodeURIComponent(ep.id)}`)}>
+            <td>
+              <div class="cell-name">{ep.name}</div>
+              <div class="cell-id mono">{ep.id}</div>
+            </td>
+            <td>
+              <span class="badge badge-{ep.protocol.toLowerCase()}">{ep.protocol.toUpperCase()}</span>
+            </td>
+            <td>
+              {#if ep.config.hostnames.length === 0}
+                <span class="muted">—</span>
+              {:else}
+                <div class="hostnames">
+                  {#each ep.config.hostnames.slice(0, 2) as h}
+                    <span class="host mono">{h}</span>
+                  {/each}
+                  {#if ep.config.hostnames.length > 2}
+                    <span class="more">+{ep.config.hostnames.length - 2}</span>
+                  {/if}
+                </div>
+              {/if}
+            </td>
+            <td>
+              <div class="backends-cell">
+                <span class="backend-count mono">{ep.backends.length}</span>
+                <div class="health-bar" title="{ep.backends.length} backends">
+                  {#each ep.backends as _b, i}
+                    <span class="health-seg" style="animation-delay: {i * 40}ms"></span>
+                  {/each}
+                </div>
+              </div>
+            </td>
+            <td>
+              <div class="features">
+                {#if ep.config.tls}<span class="chip">TLS</span>{/if}
+                {#if ep.config.https_redirect}<span class="chip">→HTTPS</span>{/if}
+                {#if ep.config.sticky_session}<span class="chip">sticky</span>{/if}
+                {#if ep.config.compress}<span class="chip">gzip</span>{/if}
+                {#if ep.config.strip_prefix}<span class="chip">strip</span>{/if}
+              </div>
+            </td>
+            <td>
+              <span class="source mono">{ep.source ?? 'api'}</span>
+            </td>
+          </tr>
+        {/each}
+      {/if}
+    </tbody>
+  </table>
+</section>
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+    margin-right: 0.25rem;
+  }
+  .btn-secondary {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    transition: background 0.1s, border-color 0.1s;
+    background: var(--bg-2);
+    color: var(--fg-1);
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-top: 0.25rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat-value.healthy {
+    color: var(--success);
+    font-size: 1.05rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.6rem;
+    margin-bottom: 0.1rem;
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 0 3px var(--success-bg);
+    animation: pulse 2s infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+  .stat-sub {
+    font-size: 0.75rem;
+    color: var(--fg-3);
+    margin-top: 0.25rem;
+  }
+
+  .toolbar {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    align-items: center;
+  }
+  .search {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .search :global(svg) {
+    position: absolute;
+    left: 0.75rem;
+    width: 14px;
+    height: 14px;
+    color: var(--fg-3);
+    pointer-events: none;
+  }
+  .search input {
+    width: 100%;
+    padding: 0.55rem 0.75rem 0.55rem 2.1rem;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--fg-0);
+    outline: none;
+    transition: border-color 0.1s;
+  }
+  .search input:focus {
+    border-color: var(--accent);
+  }
+  .search input::placeholder {
+    color: var(--fg-3);
+  }
+
+  .filters {
+    display: flex;
+    gap: 4px;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 3px;
+  }
+  .filter-chip {
+    padding: 0.35rem 0.75rem;
+    background: transparent;
+    border: none;
+    color: var(--fg-2);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+  .filter-chip:hover {
+    color: var(--fg-0);
+  }
+  .filter-chip.active {
+    background: var(--bg-3);
+    color: var(--fg-0);
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+
+  .table-wrap {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  thead {
+    background: var(--bg-2);
+  }
+  th {
+    text-align: left;
+    padding: 0.65rem 1rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+    border-bottom: 1px solid var(--border);
+  }
+  td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.825rem;
+    vertical-align: middle;
+  }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  tbody tr {
+    transition: background 0.08s;
+  }
+  tbody tr:hover {
+    background: var(--bg-2);
+  }
+  tbody tr.clickable {
+    cursor: pointer;
+  }
+
+  .empty {
+    text-align: center;
+    color: var(--fg-3);
+    padding: 2rem !important;
+  }
+
+  .cell-name {
+    font-weight: 500;
+    color: var(--fg-0);
+  }
+  .cell-id {
+    color: var(--fg-3);
+    font-size: 0.7rem;
+    margin-top: 2px;
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    font-family: var(--font-mono);
+  }
+  .badge-http {
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+  .badge-tcp {
+    background: rgba(240, 180, 41, 0.12);
+    color: var(--warning);
+  }
+  .badge-udp {
+    background: rgba(187, 115, 255, 0.12);
+    color: #bb73ff;
+  }
+
+  .hostnames {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+  .host {
+    background: var(--bg-3);
+    padding: 2px 7px;
+    border-radius: 4px;
+    font-size: 0.72rem;
+    color: var(--fg-1);
+  }
+  .more {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+  }
+
+  .backends-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+  }
+  .backend-count {
+    font-weight: 600;
+    color: var(--fg-0);
+    min-width: 14px;
+  }
+  .health-bar {
+    display: flex;
+    gap: 2px;
+    flex: 1;
+    max-width: 80px;
+  }
+  .health-seg {
+    flex: 1;
+    height: 8px;
+    background: var(--success);
+    border-radius: 2px;
+    opacity: 0;
+    animation: fade-in 0.4s forwards;
+  }
+  @keyframes fade-in {
+    to { opacity: 1; }
+  }
+
+  .features {
+    display: flex;
+    gap: 3px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 0.68rem;
+    font-family: var(--font-mono);
+    font-weight: 500;
+  }
+
+  .source {
+    color: var(--fg-2);
+    font-size: 0.72rem;
+  }
+
+  .muted {
+    color: var(--fg-3);
+  }
+
+</style>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
-  import { listEntrypoints, getToken, type Entrypoint } from '$lib/api';
+  import { listEntrypoints, type Entrypoint } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth';
 
   let entrypoints = $state<Entrypoint[]>([]);
   let error = $state<string | null>(null);
@@ -48,9 +49,8 @@
   }
 
   onMount(() => {
-    if (!getToken()) {
-      loading = false;
-      error = 'no token configured — open Settings';
+    if (!isAuthenticated()) {
+      goto('./login');
       return;
     }
     void load();

--- a/dashboard/src/routes/certificates/+page.svelte
+++ b/dashboard/src/routes/certificates/+page.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { listEntrypoints, getToken, type Entrypoint } from '$lib/api';
+
+  let entrypoints = $state<Entrypoint[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  interface HostRow {
+    hostname: string;
+    entrypoints: string[];
+    httpsRedirect: boolean;
+  }
+
+  const tlsHosts = $derived.by<HostRow[]>(() => {
+    const map = new Map<string, HostRow>();
+    for (const ep of entrypoints) {
+      if (!ep.config.tls) continue;
+      for (const host of ep.config.hostnames) {
+        const existing = map.get(host);
+        if (existing) {
+          existing.entrypoints.push(ep.name);
+          existing.httpsRedirect ||= !!ep.config.https_redirect;
+        } else {
+          map.set(host, {
+            hostname: host,
+            entrypoints: [ep.name],
+            httpsRedirect: !!ep.config.https_redirect
+          });
+        }
+      }
+    }
+    return [...map.values()].sort((a, b) => a.hostname.localeCompare(b.hostname));
+  });
+
+  const stats = $derived({
+    tlsHosts: tlsHosts.length,
+    tlsEntrypoints: entrypoints.filter((e) => e.config.tls).length,
+    redirects: entrypoints.filter((e) => e.config.https_redirect).length
+  });
+
+  async function load(silent = false) {
+    if (!silent) loading = true;
+    try {
+      entrypoints = await listEntrypoints();
+      error = null;
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      loading = false;
+      error = 'no token configured — open Settings';
+      return;
+    }
+    void load();
+    poll = setInterval(() => void load(true), 10000);
+  });
+
+  onDestroy(() => {
+    if (poll) clearInterval(poll);
+  });
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Certificates</h1>
+    <p class="subtitle">TLS hosts served by the proxy</p>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">TLS hosts</div>
+    <div class="stat-value">{stats.tlsHosts}</div>
+    <div class="stat-sub">unique hostnames served over TLS</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">TLS entrypoints</div>
+    <div class="stat-value">{stats.tlsEntrypoints}</div>
+    <div class="stat-sub">entrypoints with tls enabled</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">HTTPS redirects</div>
+    <div class="stat-value">{stats.redirects}</div>
+    <div class="stat-sub">entrypoints forcing https</div>
+  </div>
+</section>
+
+<div class="notice">
+  <strong>heads up</strong>
+  Certificate introspection (issuer, expiry, ACME state) will land once the API
+  exposes <code>GET /certificates</code>. For now, this view lists hosts derived
+  from TLS-enabled entrypoints.
+</div>
+
+{#if error}
+  <div class="alert">
+    <strong>error</strong> {error}
+  </div>
+{/if}
+
+<section class="table-wrap">
+  <table>
+    <thead>
+      <tr>
+        <th>Hostname</th>
+        <th>Entrypoints</th>
+        <th>HTTPS redirect</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#if loading && entrypoints.length === 0}
+        <tr><td colspan="4" class="empty">loading…</td></tr>
+      {:else if tlsHosts.length === 0}
+        <tr><td colspan="4" class="empty">no TLS hosts configured</td></tr>
+      {:else}
+        {#each tlsHosts as row (row.hostname)}
+          <tr>
+            <td class="mono">{row.hostname}</td>
+            <td>
+              <div class="chips">
+                {#each row.entrypoints as ep}
+                  <span class="chip">{ep}</span>
+                {/each}
+              </div>
+            </td>
+            <td>
+              {#if row.httpsRedirect}
+                <span class="badge ok">enabled</span>
+              {:else}
+                <span class="muted">—</span>
+              {/if}
+            </td>
+            <td class="mono source">ACME / staging</td>
+          </tr>
+        {/each}
+      {/if}
+    </tbody>
+  </table>
+</section>
+
+<style>
+  .page-header {
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-top: 0.25rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat-sub {
+    font-size: 0.75rem;
+    color: var(--fg-3);
+    margin-top: 0.25rem;
+  }
+
+  .notice {
+    background: var(--accent-bg);
+    border: 1px solid rgba(91, 141, 255, 0.3);
+    color: var(--fg-1);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.8rem;
+    line-height: 1.55;
+  }
+  .notice strong {
+    color: var(--accent);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+  }
+  .notice code {
+    background: var(--bg-3);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--fg-0);
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+
+  .table-wrap {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  thead {
+    background: var(--bg-2);
+  }
+  th {
+    text-align: left;
+    padding: 0.65rem 1rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+    border-bottom: 1px solid var(--border);
+  }
+  td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.825rem;
+    vertical-align: middle;
+  }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  tbody tr:hover {
+    background: var(--bg-2);
+  }
+
+  .empty {
+    text-align: center;
+    color: var(--fg-3);
+    padding: 2rem !important;
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .chip {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.72rem;
+    font-family: var(--font-mono);
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+  }
+  .badge.ok {
+    background: var(--success-bg);
+    color: var(--success);
+  }
+
+  .muted {
+    color: var(--fg-3);
+  }
+
+  .source {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+  }
+</style>

--- a/dashboard/src/routes/certificates/+page.svelte
+++ b/dashboard/src/routes/certificates/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { listEntrypoints, getToken, type Entrypoint } from '$lib/api';
+  import { goto } from '$app/navigation';
+  import { listEntrypoints, type Entrypoint } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth';
 
   let entrypoints = $state<Entrypoint[]>([]);
   let loading = $state(true);
@@ -53,9 +55,8 @@
   }
 
   onMount(() => {
-    if (!getToken()) {
-      loading = false;
-      error = 'no token configured — open Settings';
+    if (!isAuthenticated()) {
+      goto('./login');
       return;
     }
     void load();

--- a/dashboard/src/routes/entrypoints/[id]/+page.svelte
+++ b/dashboard/src/routes/entrypoints/[id]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { page } from '$app/stores';
-  import { getEntrypoint, getToken, type Entrypoint } from '$lib/api';
+  import { goto } from '$app/navigation';
+  import { getEntrypoint, type Entrypoint } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth';
 
   let entrypoint = $state<Entrypoint | null>(null);
   let loading = $state(true);
@@ -30,9 +32,8 @@
   }
 
   onMount(() => {
-    if (!getToken()) {
-      loading = false;
-      error = 'no token configured — open Settings';
+    if (!isAuthenticated()) {
+      goto('./login');
       return;
     }
     void load();

--- a/dashboard/src/routes/entrypoints/[id]/+page.svelte
+++ b/dashboard/src/routes/entrypoints/[id]/+page.svelte
@@ -1,0 +1,441 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { page } from '$app/stores';
+  import { getEntrypoint, getToken, type Entrypoint } from '$lib/api';
+
+  let entrypoint = $state<Entrypoint | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let lastRefresh = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  const id = $derived($page.params.id ?? '');
+
+  async function load(silent = false) {
+    if (!id) {
+      return;
+    }
+    if (!silent) {
+      loading = true;
+    }
+    try {
+      entrypoint = await getEntrypoint(id);
+      error = null;
+      lastRefresh = new Date();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    if (!getToken()) {
+      loading = false;
+      error = 'no token configured — open Settings';
+      return;
+    }
+    void load();
+    poll = setInterval(() => void load(true), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) {
+      return '';
+    }
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) {
+      return 'just now';
+    }
+    if (s < 60) {
+      return `${s}s ago`;
+    }
+    return `${Math.floor(s / 60)}m ago`;
+  }
+</script>
+
+<header class="page-header">
+  <div>
+    <a href="/" class="back">← Entrypoints</a>
+    <h1>{entrypoint?.name ?? id}</h1>
+    <p class="subtitle mono">{id}</p>
+  </div>
+  <div class="header-actions">
+    {#if lastRefresh}
+      <span class="refresh-meta">updated {timeAgo(lastRefresh)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={() => load()} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+{#if error}
+  <div class="alert">
+    <strong>error</strong> {error}
+  </div>
+{/if}
+
+{#if entrypoint}
+  <section class="grid">
+    <div class="card">
+      <h2>Overview</h2>
+      <dl>
+        <dt>Protocol</dt>
+        <dd><span class="badge badge-{entrypoint.protocol.toLowerCase()}">{entrypoint.protocol.toUpperCase()}</span></dd>
+        <dt>Port</dt>
+        <dd class="mono">{entrypoint.config.port}</dd>
+        <dt>Priority</dt>
+        <dd class="mono">{entrypoint.config.priority}</dd>
+        <dt>Source</dt>
+        <dd class="mono">{entrypoint.source ?? 'api'}</dd>
+      </dl>
+    </div>
+
+    <div class="card">
+      <h2>Features</h2>
+      <div class="feature-grid">
+        <div class="feature" class:on={entrypoint.config.tls}>
+          <span>TLS</span>
+          <span class="state">{entrypoint.config.tls ? 'on' : 'off'}</span>
+        </div>
+        <div class="feature" class:on={entrypoint.config.https_redirect}>
+          <span>HTTPS redirect</span>
+          <span class="state">{entrypoint.config.https_redirect ? 'on' : 'off'}</span>
+        </div>
+        <div class="feature" class:on={entrypoint.config.sticky_session}>
+          <span>Sticky session</span>
+          <span class="state">{entrypoint.config.sticky_session ? 'on' : 'off'}</span>
+        </div>
+        <div class="feature" class:on={entrypoint.config.compress}>
+          <span>Gzip</span>
+          <span class="state">{entrypoint.config.compress ? 'on' : 'off'}</span>
+        </div>
+        <div class="feature" class:on={entrypoint.config.strip_prefix}>
+          <span>Strip prefix</span>
+          <span class="state">{entrypoint.config.strip_prefix ? 'on' : 'off'}</span>
+        </div>
+        <div class="feature" class:on={entrypoint.config.backend_timeout != null}>
+          <span>Backend timeout</span>
+          <span class="state mono">
+            {entrypoint.config.backend_timeout == null
+              ? 'default'
+              : entrypoint.config.backend_timeout === 0
+                ? '∞'
+                : `${entrypoint.config.backend_timeout}s`}
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Hostnames</h2>
+    {#if entrypoint.config.hostnames.length === 0}
+      <p class="muted">no hostnames configured</p>
+    {:else}
+      <div class="chips">
+        {#each entrypoint.config.hostnames as host}
+          <span class="chip mono">{host}</span>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <section class="card">
+    <h2>Backends</h2>
+    {#if entrypoint.backends.length === 0}
+      <p class="muted">no backends</p>
+    {:else}
+      <table class="backends-table">
+        <thead>
+          <tr>
+            <th>Address</th>
+            <th>Weight</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each entrypoint.backends as backend}
+            <tr>
+              <td class="mono">{backend}</td>
+              <td class="mono">{entrypoint.backend_weights?.[backend] ?? 1}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  {#if entrypoint.config.headers && Object.keys(entrypoint.config.headers).length > 0}
+    <section class="card">
+      <h2>Custom headers</h2>
+      <table class="kv-table">
+        <tbody>
+          {#each Object.entries(entrypoint.config.headers) as [k, v]}
+            <tr>
+              <td class="mono k">{k}</td>
+              <td class="mono">{v}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
+  {/if}
+
+  <section class="card">
+    <h2>Raw config</h2>
+    <pre class="mono">{JSON.stringify(entrypoint, null, 2)}</pre>
+  </section>
+{:else if !loading && !error}
+  <div class="empty-state">
+    entrypoint not found
+  </div>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+    gap: 1rem;
+  }
+  .back {
+    display: inline-block;
+    color: var(--fg-2);
+    font-size: 0.78rem;
+    margin-bottom: 0.5rem;
+  }
+  .back:hover {
+    color: var(--fg-0);
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.1rem 1.25rem;
+    margin-bottom: 1rem;
+  }
+  .card h2 {
+    margin: 0 0 0.9rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem 1rem;
+    align-items: center;
+  }
+  dt {
+    color: var(--fg-2);
+    font-size: 0.78rem;
+  }
+  dd {
+    margin: 0;
+    font-size: 0.825rem;
+    color: var(--fg-0);
+  }
+
+  .feature-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+  }
+  .feature {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4rem 0.625rem;
+    background: var(--bg-2);
+    border-radius: var(--radius-sm);
+    font-size: 0.78rem;
+    color: var(--fg-2);
+  }
+  .feature.on {
+    background: var(--success-bg);
+    color: var(--fg-0);
+  }
+  .feature .state {
+    font-size: 0.72rem;
+    color: var(--fg-3);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .feature.on .state {
+    color: var(--success);
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+  .chip {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 3px 9px;
+    border-radius: 4px;
+    font-size: 0.76rem;
+  }
+
+  .backends-table,
+  .kv-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .backends-table th {
+    text-align: left;
+    padding: 0.4rem 0.5rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+    border-bottom: 1px solid var(--border);
+  }
+  .backends-table td,
+  .kv-table td {
+    padding: 0.55rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.8rem;
+  }
+  .backends-table tbody tr:last-child td,
+  .kv-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+  .kv-table td.k {
+    color: var(--fg-2);
+    width: 30%;
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    font-family: var(--font-mono);
+  }
+  .badge-http {
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+  .badge-tcp {
+    background: rgba(240, 180, 41, 0.12);
+    color: var(--warning);
+  }
+  .badge-udp {
+    background: rgba(187, 115, 255, 0.12);
+    color: #bb73ff;
+  }
+
+  .muted {
+    color: var(--fg-3);
+    font-size: 0.82rem;
+    margin: 0;
+  }
+
+  pre {
+    margin: 0;
+    padding: 0.75rem 0.9rem;
+    background: var(--bg-0);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.76rem;
+    color: var(--fg-1);
+    overflow-x: auto;
+    line-height: 1.55;
+    max-height: 400px;
+  }
+
+  .empty-state {
+    text-align: center;
+    color: var(--fg-3);
+    padding: 3rem;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+
+  @media (max-width: 900px) {
+    .grid,
+    .feature-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/dashboard/src/routes/entrypoints/[id]/+page.ts
+++ b/dashboard/src/routes/entrypoints/[id]/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/dashboard/src/routes/health/+page.svelte
+++ b/dashboard/src/routes/health/+page.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { health, getBaseUrl } from '$lib/api';
+
+  type Status = 'pending' | 'ok' | 'fail';
+
+  let status = $state<Status>('pending');
+  let payload = $state<unknown>(null);
+  let errorMsg = $state<string | null>(null);
+  let lastCheck = $state<Date | null>(null);
+  let latencyMs = $state<number | null>(null);
+
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  async function check() {
+    const started = performance.now();
+    try {
+      payload = await health();
+      latencyMs = Math.round(performance.now() - started);
+      status = 'ok';
+      errorMsg = null;
+    } catch (e) {
+      status = 'fail';
+      latencyMs = null;
+      errorMsg = e instanceof Error ? e.message : String(e);
+      payload = null;
+    } finally {
+      lastCheck = new Date();
+    }
+  }
+
+  onMount(() => {
+    void check();
+    poll = setInterval(() => void check(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) clearInterval(poll);
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) return '';
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) return 'just now';
+    if (s < 60) return `${s}s ago`;
+    return `${Math.floor(s / 60)}m ago`;
+  }
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Health</h1>
+    <p class="subtitle">Liveness of the sozune admin API</p>
+  </div>
+  <div class="header-actions">
+    {#if lastCheck}
+      <span class="refresh-meta">checked {timeAgo(lastCheck)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={check} disabled={status === 'pending'}>
+      {status === 'pending' ? 'checking…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">Status</div>
+    <div class="stat-value" class:ok={status === 'ok'} class:fail={status === 'fail'}>
+      {#if status === 'ok'}
+        <span class="dot ok"></span> healthy
+      {:else if status === 'fail'}
+        <span class="dot fail"></span> unreachable
+      {:else}
+        <span class="dot pending"></span> checking
+      {/if}
+    </div>
+    <div class="stat-sub">polling every 5s</div>
+  </div>
+
+  <div class="stat-card">
+    <div class="stat-label">Latency</div>
+    <div class="stat-value mono">
+      {#if latencyMs !== null}
+        {latencyMs}<span class="unit">ms</span>
+      {:else}
+        —
+      {/if}
+    </div>
+    <div class="stat-sub">round-trip to /health</div>
+  </div>
+
+  <div class="stat-card wide">
+    <div class="stat-label">Endpoint</div>
+    <div class="stat-value mono small">{getBaseUrl()}/health</div>
+    <div class="stat-sub">from your browser</div>
+  </div>
+</section>
+
+{#if status === 'fail' && errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+    <p class="alert-hint">
+      Check that sozune is running, the API is enabled, and the base URL in
+      <a href="./settings">Settings</a> is correct.
+    </p>
+  </div>
+{/if}
+
+{#if status === 'ok' && payload !== null && payload !== undefined}
+  <section class="card">
+    <h2>Response payload</h2>
+    <pre class="mono">{JSON.stringify(payload, null, 2)}</pre>
+  </section>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-card.wide {
+    grid-column: span 2;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 0.35rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .stat-value.small {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--fg-1);
+    word-break: break-all;
+  }
+  .stat-value.ok {
+    color: var(--success);
+  }
+  .stat-value.fail {
+    color: var(--danger);
+  }
+  .unit {
+    font-size: 0.85rem;
+    color: var(--fg-2);
+    font-weight: 500;
+    margin-left: 2px;
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+  .dot.ok {
+    background: var(--success);
+    box-shadow: 0 0 0 3px var(--success-bg);
+    animation: pulse 2s infinite;
+  }
+  .dot.fail {
+    background: var(--danger);
+    box-shadow: 0 0 0 3px var(--danger-bg);
+  }
+  .dot.pending {
+    background: var(--fg-2);
+    box-shadow: 0 0 0 3px rgba(122, 133, 148, 0.18);
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+  .stat-sub {
+    font-size: 0.75rem;
+    color: var(--fg-3);
+    margin-top: 0.25rem;
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+  .alert-hint {
+    margin: 0.5rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.78rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.25rem 1.5rem;
+  }
+  .card h2 {
+    margin: 0 0 0.75rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--fg-1);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  pre {
+    margin: 0;
+    padding: 0.75rem 0.9rem;
+    background: var(--bg-0);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.78rem;
+    color: var(--fg-1);
+    overflow-x: auto;
+    line-height: 1.55;
+  }
+</style>

--- a/dashboard/src/routes/login/+page.svelte
+++ b/dashboard/src/routes/login/+page.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { setAuth, isAuthenticated } from '$lib/auth';
+  import { getBaseUrl, setBaseUrl, validateCredentials } from '$lib/api';
+
+  let name = $state('');
+  let password = $state('');
+  let baseUrl = $state('');
+  let pending = $state(false);
+  let error = $state('');
+
+  onMount(() => {
+    if (isAuthenticated()) {
+      goto('./');
+      return;
+    }
+    baseUrl = getBaseUrl();
+  });
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    error = '';
+    pending = true;
+    try {
+      setBaseUrl(baseUrl);
+      const id = await validateCredentials(baseUrl, name, password);
+      setAuth(id.name, password, id.role);
+      goto('./');
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<div class="login-shell">
+  <form class="card" onsubmit={submit}>
+    <div class="brand">
+      <div class="logo">s</div>
+      <div class="brand-text">
+        <div class="brand-name">sozune</div>
+        <div class="brand-sub">dashboard</div>
+      </div>
+    </div>
+
+    <h1>Sign in</h1>
+
+    <div class="field">
+      <label for="baseUrl">API base URL</label>
+      <input
+        id="baseUrl"
+        type="text"
+        class="mono"
+        placeholder="http://127.0.0.1:3035"
+        bind:value={baseUrl}
+        required
+      />
+    </div>
+
+    <div class="field">
+      <label for="name">Username</label>
+      <input id="name" type="text" autocomplete="username" bind:value={name} required />
+    </div>
+
+    <div class="field">
+      <label for="password">Password</label>
+      <input
+        id="password"
+        type="password"
+        autocomplete="current-password"
+        bind:value={password}
+        required
+      />
+    </div>
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <button class="btn-primary" type="submit" disabled={pending}>
+      {pending ? 'Signing in…' : 'Sign in'}
+    </button>
+  </form>
+</div>
+
+<style>
+  .login-shell {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: var(--bg-0);
+    padding: 1rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 2rem 2.25rem;
+    width: 100%;
+    max-width: 380px;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .logo {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--accent), #3a6fd9);
+    color: white;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 1.1rem;
+    box-shadow: 0 2px 8px rgba(91, 141, 255, 0.3);
+  }
+
+  .brand-name {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+  }
+
+  .brand-sub {
+    font-size: 0.7rem;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  h1 {
+    margin: 0 0 1.25rem;
+    font-size: 1.15rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .field {
+    margin-bottom: 1rem;
+  }
+
+  label {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--fg-1);
+    margin-bottom: 0.4rem;
+    font-weight: 500;
+  }
+
+  input {
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--fg-0);
+    outline: none;
+    transition: border-color 0.1s;
+  }
+
+  input:focus {
+    border-color: var(--accent);
+  }
+
+  input::placeholder {
+    color: var(--fg-3);
+  }
+
+  .error {
+    margin: 0 0 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: rgba(244, 99, 99, 0.1);
+    border: 1px solid rgba(244, 99, 99, 0.3);
+    border-radius: var(--radius);
+    color: var(--danger);
+    font-size: 0.78rem;
+  }
+
+  .btn-primary {
+    width: 100%;
+    border: none;
+    border-radius: var(--radius);
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    background: var(--accent);
+    color: white;
+    margin-top: 0.5rem;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+</style>

--- a/dashboard/src/routes/settings/+page.svelte
+++ b/dashboard/src/routes/settings/+page.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { getToken, setToken, getBaseUrl, setBaseUrl, health } from '$lib/api';
+  import { getBaseUrl, setBaseUrl, health } from '$lib/api';
 
-  let token = $state('');
   let baseUrl = $state('');
   let saved = $state(false);
   let testStatus = $state<'idle' | 'pending' | 'ok' | 'fail'>('idle');
   let testMessage = $state('');
 
   onMount(() => {
-    token = getToken() ?? '';
     baseUrl = getBaseUrl();
   });
 
   function save() {
-    setToken(token);
     setBaseUrl(baseUrl);
     saved = true;
     setTimeout(() => (saved = false), 2000);
@@ -24,7 +21,6 @@
     testStatus = 'pending';
     testMessage = '';
     try {
-      setToken(token);
       setBaseUrl(baseUrl);
       await health();
       testStatus = 'ok';
@@ -58,17 +54,10 @@
     <p class="hint">The host:port where the sozune API server listens.</p>
   </div>
 
-  <div class="field">
-    <label for="token">Bearer token</label>
-    <input
-      id="token"
-      type="password"
-      class="mono"
-      placeholder="leave empty if API has no token configured"
-      bind:value={token}
-    />
-    <p class="hint">Matches <code>api.token</code> from your sozune config.yaml.</p>
-  </div>
+  <p class="hint">
+    Credentials are entered on the <a href="./login">sign-in page</a> and stored in this browser
+    tab only.
+  </p>
 
   <div class="actions">
     <button class="btn-primary" onclick={save}>
@@ -148,11 +137,8 @@
     font-size: 0.72rem;
     color: var(--fg-3);
   }
-  .hint code {
-    background: var(--bg-3);
-    padding: 1px 5px;
-    border-radius: 3px;
-    color: var(--fg-1);
+  .hint a {
+    color: var(--accent);
   }
 
   .actions {

--- a/dashboard/src/routes/settings/+page.svelte
+++ b/dashboard/src/routes/settings/+page.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getToken, setToken, getBaseUrl, setBaseUrl, health } from '$lib/api';
+
+  let token = $state('');
+  let baseUrl = $state('');
+  let saved = $state(false);
+  let testStatus = $state<'idle' | 'pending' | 'ok' | 'fail'>('idle');
+  let testMessage = $state('');
+
+  onMount(() => {
+    token = getToken() ?? '';
+    baseUrl = getBaseUrl();
+  });
+
+  function save() {
+    setToken(token);
+    setBaseUrl(baseUrl);
+    saved = true;
+    setTimeout(() => (saved = false), 2000);
+  }
+
+  async function testConnection() {
+    testStatus = 'pending';
+    testMessage = '';
+    try {
+      setToken(token);
+      setBaseUrl(baseUrl);
+      await health();
+      testStatus = 'ok';
+      testMessage = 'API reachable';
+    } catch (e) {
+      testStatus = 'fail';
+      testMessage = e instanceof Error ? e.message : String(e);
+    }
+  }
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Settings</h1>
+    <p class="subtitle">Connection to the sozune admin API</p>
+  </div>
+</header>
+
+<section class="card">
+  <h2>Connection</h2>
+
+  <div class="field">
+    <label for="baseUrl">API base URL</label>
+    <input
+      id="baseUrl"
+      type="text"
+      class="mono"
+      placeholder="http://127.0.0.1:3035"
+      bind:value={baseUrl}
+    />
+    <p class="hint">The host:port where the sozune API server listens.</p>
+  </div>
+
+  <div class="field">
+    <label for="token">Bearer token</label>
+    <input
+      id="token"
+      type="password"
+      class="mono"
+      placeholder="leave empty if API has no token configured"
+      bind:value={token}
+    />
+    <p class="hint">Matches <code>api.token</code> from your sozune config.yaml.</p>
+  </div>
+
+  <div class="actions">
+    <button class="btn-primary" onclick={save}>
+      {saved ? 'Saved ✓' : 'Save'}
+    </button>
+    <button class="btn-secondary" onclick={testConnection} disabled={testStatus === 'pending'}>
+      {testStatus === 'pending' ? 'testing…' : 'Test connection'}
+    </button>
+    {#if testStatus === 'ok'}
+      <span class="status ok">✓ {testMessage}</span>
+    {:else if testStatus === 'fail'}
+      <span class="status fail">✗ {testMessage}</span>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .page-header {
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem 1.75rem;
+    max-width: 640px;
+  }
+  h2 {
+    margin: 0 0 1.25rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--fg-1);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .field {
+    margin-bottom: 1.25rem;
+  }
+  label {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--fg-1);
+    margin-bottom: 0.4rem;
+    font-weight: 500;
+  }
+  input {
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--fg-0);
+    outline: none;
+    transition: border-color 0.1s;
+  }
+  input:focus {
+    border-color: var(--accent);
+  }
+  input::placeholder {
+    color: var(--fg-3);
+  }
+  .hint {
+    margin: 0.35rem 0 0;
+    font-size: 0.72rem;
+    color: var(--fg-3);
+  }
+  .hint code {
+    background: var(--bg-3);
+    padding: 1px 5px;
+    border-radius: 3px;
+    color: var(--fg-1);
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.625rem;
+    align-items: center;
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+  }
+  .btn-primary,
+  .btn-secondary {
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    padding: 0.5rem 1rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+  }
+  .btn-primary:hover {
+    background: var(--accent-hover);
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border-color: var(--border);
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .status {
+    font-size: 0.78rem;
+    font-weight: 500;
+  }
+  .status.ok {
+    color: var(--success);
+  }
+  .status.fail {
+    color: var(--danger);
+  }
+</style>

--- a/dashboard/static/favicon.svg
+++ b/dashboard/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#3b82f6"/><text x="16" y="22" font-family="system-ui,sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="white">s</text></svg>

--- a/dashboard/svelte.config.js
+++ b/dashboard/svelte.config.js
@@ -1,0 +1,21 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter({
+      pages: 'build',
+      assets: 'build',
+      fallback: 'index.html',
+      precompress: false,
+      strict: true
+    }),
+    paths: {
+      relative: true
+    }
+  }
+};
+
+export default config;

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,0 +1,9 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  server: {
+    port: 5173
+  }
+});

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -139,7 +139,12 @@ pub async fn serve(
                 .put(update_entrypoint)
                 .delete(delete_entrypoint),
         )
-        .route_layer(axum_middleware::from_fn(require_admin))
+        .route_layer(axum_middleware::from_fn(require_admin));
+
+    let me_route = Router::new().route("/me", get(me));
+
+    let authed = protected
+        .merge(me_route)
         .route_layer(axum_middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -147,7 +152,7 @@ pub async fn serve(
 
     let mut app = Router::new()
         .route("/health", get(health))
-        .merge(protected)
+        .merge(authed)
         .with_state(state);
 
     if !config.cors_origins.is_empty() {
@@ -195,6 +200,28 @@ pub async fn serve(
 
 async fn health() -> (StatusCode, Json<serde_json::Value>) {
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
+}
+
+/// Returns the authenticated user's identity. The dashboard hits this on
+/// login to validate credentials and learn its role.
+async fn me(req: Request) -> (StatusCode, Json<serde_json::Value>) {
+    let identity = req.extensions().get::<Identity>().cloned();
+    match identity {
+        Some(id) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "name": id.name,
+                "role": match id.role {
+                    Role::Admin => "admin",
+                    Role::ReadOnly => "read-only",
+                },
+            })),
+        ),
+        None => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "missing identity"})),
+        ),
+    }
 }
 
 async fn list_entrypoints(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
@@ -437,7 +464,12 @@ mod tests {
                     .put(update_entrypoint)
                     .delete(delete_entrypoint),
             )
-            .route_layer(axum_middleware::from_fn(require_admin))
+            .route_layer(axum_middleware::from_fn(require_admin));
+
+        let me_route = Router::new().route("/me", get(me));
+
+        let authed = protected
+            .merge(me_route)
             .route_layer(axum_middleware::from_fn_with_state(
                 state.clone(),
                 auth_middleware,
@@ -445,7 +477,7 @@ mod tests {
 
         Router::new()
             .route("/health", get(health))
-            .merge(protected)
+            .merge(authed)
             .with_state(state)
     }
 
@@ -838,5 +870,58 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn me_returns_admin_identity() {
+        let app = test_app(test_state());
+
+        let response = app
+            .oneshot(
+                Request::get("/me")
+                    .header("authorization", admin_auth())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_to_json(response.into_body()).await;
+        assert_eq!(json["name"], "admin");
+        assert_eq!(json["role"], "admin");
+    }
+
+    #[tokio::test]
+    async fn me_returns_read_only_identity() {
+        let state = test_state_with_users(vec![user("viewer", "viewer-pass", Role::ReadOnly)]);
+        let app = test_app(state);
+
+        let response = app
+            .oneshot(
+                Request::get("/me")
+                    .header("authorization", basic("viewer", "viewer-pass"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_to_json(response.into_body()).await;
+        assert_eq!(json["name"], "viewer");
+        assert_eq!(json["role"], "read-only");
+    }
+
+    #[tokio::test]
+    async fn me_requires_auth() {
+        let app = test_app(test_state());
+
+        let response = app
+            .oneshot(Request::get("/me").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ pub struct AppConfig {
     pub acme: Option<AcmeConfig>,
     #[serde(default)]
     pub middleware: MiddlewareConfig,
+    #[serde(default)]
+    pub dashboard: DashboardConfig,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -153,6 +155,30 @@ pub struct HttpsConfig {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+pub struct DashboardConfig {
+    #[serde(default, deserialize_with = "deserialize_dashboard_enabled_with_env")]
+    pub enabled: bool,
+    #[serde(
+        default = "default_dashboard_listen_address",
+        deserialize_with = "deserialize_dashboard_listen_address_with_env"
+    )]
+    pub listen_address: String,
+}
+
+impl Default for DashboardConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_address: default_dashboard_listen_address(),
+        }
+    }
+}
+
+fn default_dashboard_listen_address() -> String {
+    "127.0.0.1:8081".to_string()
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct MiddlewareConfig {
     #[serde(
         default = "default_middleware_port",
@@ -227,6 +253,7 @@ impl Default for AppConfig {
             proxy: Default::default(),
             acme: None,
             middleware: Default::default(),
+            dashboard: Default::default(),
         }
     }
 }
@@ -495,6 +522,17 @@ deserialize_with_env!(
     "SOZUNE_PROVIDER_HTTP_POLL_INTERVAL",
     u64,
     default_http_provider_poll_interval
+);
+
+deserialize_bool_with_env!(
+    deserialize_dashboard_enabled_with_env,
+    "SOZUNE_DASHBOARD_ENABLED",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_dashboard_listen_address_with_env,
+    "SOZUNE_DASHBOARD_LISTEN_ADDRESS",
+    default_dashboard_listen_address
 );
 
 #[cfg(test)]

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -1,0 +1,1 @@
+pub mod server;

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -1,0 +1,79 @@
+use crate::config::DashboardConfig;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::Path;
+use axum::http::{StatusCode, Uri, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use rust_embed::RustEmbed;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use tracing::info;
+
+#[derive(RustEmbed)]
+#[folder = "dashboard/build/"]
+struct Assets;
+
+pub async fn serve(config: DashboardConfig) -> anyhow::Result<()> {
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/{*path}", get(asset));
+
+    let addr = SocketAddr::from_str(&config.listen_address).map_err(|e| {
+        anyhow::anyhow!(
+            "Invalid dashboard listen address '{}': {}",
+            config.listen_address,
+            e
+        )
+    })?;
+
+    info!("Dashboard listening on http://{}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn index() -> Response {
+    serve_file("index.html")
+}
+
+async fn asset(Path(path): Path<String>, uri: Uri) -> Response {
+    if let Some(response) = try_serve(&path) {
+        return response;
+    }
+
+    let trimmed = uri.path().trim_start_matches('/');
+    if !trimmed.is_empty()
+        && let Some(response) = try_serve(trimmed)
+    {
+        return response;
+    }
+
+    serve_file("index.html")
+}
+
+fn try_serve(path: &str) -> Option<Response> {
+    if Assets::get(path).is_some() {
+        Some(serve_file(path))
+    } else {
+        None
+    }
+}
+
+fn serve_file(path: &str) -> Response {
+    match Assets::get(path) {
+        Some(content) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, mime.as_ref())
+                .body(Body::from(content.data.into_owned()))
+                .unwrap_or_else(|_| {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "failed to build response").into_response()
+                })
+        }
+        None => (StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -71,7 +71,11 @@ fn serve_file(path: &str) -> Response {
                 .header(header::CONTENT_TYPE, mime.as_ref())
                 .body(Body::from(content.data.into_owned()))
                 .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "failed to build response").into_response()
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to build response",
+                    )
+                        .into_response()
                 })
         }
         None => (StatusCode::NOT_FOUND, "not found").into_response(),

--- a/src/dashboard/server.rs
+++ b/src/dashboard/server.rs
@@ -54,12 +54,21 @@ async fn asset(Path(path): Path<String>, uri: Uri) -> Response {
     serve_file("index.html")
 }
 
+/// Resolve an embedded asset using the conventions adapter-static produces:
+/// `foo` → `foo`, `foo.html`, or `foo/index.html` (in that order).
 fn try_serve(path: &str) -> Option<Response> {
     if Assets::get(path).is_some() {
-        Some(serve_file(path))
-    } else {
-        None
+        return Some(serve_file(path));
     }
+    let with_html = format!("{path}.html");
+    if Assets::get(&with_html).is_some() {
+        return Some(serve_file(&with_html));
+    }
+    let index = format!("{}/index.html", path.trim_end_matches('/'));
+    if Assets::get(&index).is_some() {
+        return Some(serve_file(&index));
+    }
+    None
 }
 
 fn serve_file(path: &str) -> Response {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod acme;
 mod api;
 mod cli;
 mod config;
+mod dashboard;
 mod labels;
 mod middleware;
 mod model;
@@ -139,6 +140,16 @@ async fn serve() -> anyhow::Result<()> {
         Ok::<(), anyhow::Error>(())
     });
 
+    let dashboard_config = config.dashboard.clone();
+    let dashboard_task = tokio::spawn(async move {
+        if dashboard_config.enabled {
+            info!("Starting Dashboard server");
+            dashboard::server::serve(dashboard_config).await?;
+        }
+
+        Ok::<(), anyhow::Error>(())
+    });
+
     // Start backend health checker
     let health_task = tokio::spawn({
         let storage_health = Arc::clone(&storage);
@@ -229,6 +240,7 @@ async fn serve() -> anyhow::Result<()> {
     let secondary_tasks_future = async {
         tokio::try_join!(
             api_task,
+            dashboard_task,
             provider_task,
             acme_task,
             middleware_task,
@@ -249,11 +261,16 @@ async fn serve() -> anyhow::Result<()> {
         },
         result = secondary_tasks_future => {
             signal_handle.close();
-            let (api_result, provider_result, acme_result, middleware_result, health_result) = result?;
+            let (api_result, dashboard_result, provider_result, acme_result, middleware_result, health_result) = result?;
 
             match api_result {
                 Ok(_) => debug!("API task completed successfully"),
                 Err(e) => error!("API task failed: {}", e),
+            }
+
+            match dashboard_result {
+                Ok(_) => debug!("Dashboard task completed successfully"),
+                Err(e) => error!("Dashboard task failed: {}", e),
             }
 
             match provider_result {


### PR DESCRIPTION
Introduces a dashboard UI for sozune. The dashboard is built with SvelteKit, embedded into the sozune binary, and served on its own port. It runs in read-only mode, exposing what the proxy is currently serving without letting users create or modify resources.