### PR TITLE
Add sozune validate command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +356,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +403,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1114,6 +1210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1578,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -2400,6 +2508,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "bollard",
+ "clap",
  "flate2",
  "futures-util",
  "http-body-util",
@@ -2430,6 +2539,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2860,6 +2975,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ tower-http = { version = "0.6", features = ["cors"] }
 flate2 = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
+clap = { version = "4", features = ["derive"] }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,11 @@ pub mod report;
 pub mod validate;
 
 #[derive(Parser, Debug)]
-#[command(name = "sozune", version, about = "Container-native HTTP/TCP/UDP proxy")]
+#[command(
+    name = "sozune",
+    version,
+    about = "Container-native HTTP/TCP/UDP proxy"
+)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+pub mod render;
+pub mod report;
 pub mod validate;
 
 #[derive(Parser, Debug)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,19 @@
+use clap::{Parser, Subcommand};
+
+pub mod validate;
+
+#[derive(Parser, Debug)]
+#[command(name = "sozune", version, about = "Container-native HTTP/TCP/UDP proxy")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Run the proxy (default when no subcommand is given).
+    Serve,
+    /// Inspect what sozune would route from configured providers, with
+    /// per-candidate diagnostics explaining any silent skip or fallback.
+    Validate(validate::ValidateArgs),
+}

--- a/src/cli/render/mod.rs
+++ b/src/cli/render/mod.rs
@@ -1,0 +1,1 @@
+pub mod tree;

--- a/src/cli/render/tree.rs
+++ b/src/cli/render/tree.rs
@@ -128,12 +128,7 @@ fn format_route(ep: &Entrypoint) -> String {
         Protocol::Udp => "udp",
     };
     let host = ep.config.hostnames.first().cloned().unwrap_or_default();
-    let path_str = ep
-        .config
-        .path
-        .as_ref()
-        .map(format_path)
-        .unwrap_or_default();
+    let path_str = ep.config.path.as_ref().map(format_path).unwrap_or_default();
     let backends = ep.backends.join(", ");
     format!(
         "{}://{}:{}{}  →  {}",
@@ -235,10 +230,7 @@ mod tests {
         let c = candidate(
             "docker",
             "broken",
-            &[
-                ("sozune.enable", "true"),
-                ("sozune.http.web.port", "8080"),
-            ],
+            &[("sozune.enable", "true"), ("sozune.http.web.port", "8080")],
         );
         let report = ValidationReport {
             candidates: vec![report_for(c)],

--- a/src/cli/render/tree.rs
+++ b/src/cli/render/tree.rs
@@ -1,0 +1,320 @@
+use crate::cli::report::{CandidateReport, Status, ValidationReport};
+use crate::labels::diagnostic::{Diagnostic, Severity};
+use crate::model::{Entrypoint, PathConfig, PathRuleType, Protocol};
+use std::fmt::Write;
+
+pub fn render(report: &ValidationReport, min_severity: Severity) -> String {
+    let mut out = String::new();
+    let mut by_provider: std::collections::BTreeMap<&str, Vec<&CandidateReport>> =
+        std::collections::BTreeMap::new();
+    for c in &report.candidates {
+        by_provider.entry(c.provider.as_str()).or_default().push(c);
+    }
+
+    for (provider, mut candidates) in by_provider {
+        candidates.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        writeln!(&mut out, "{provider}").unwrap();
+
+        let last_idx = candidates.len().saturating_sub(1);
+        for (i, candidate) in candidates.iter().enumerate() {
+            let is_last = i == last_idx;
+            render_candidate(&mut out, candidate, is_last, min_severity);
+            if !is_last {
+                writeln!(&mut out, "│").unwrap();
+            }
+        }
+        writeln!(&mut out).unwrap();
+    }
+
+    let s = report.summary();
+    writeln!(
+        &mut out,
+        "{} routed · {} degraded · {} skipped",
+        s.routed, s.degraded, s.skipped
+    )
+    .unwrap();
+    if has_diagnostics(report, min_severity) {
+        writeln!(
+            &mut out,
+            "Run `sozune validate --explain <CODE>` for details on a diagnostic code."
+        )
+        .unwrap();
+    }
+    out
+}
+
+fn render_candidate(
+    out: &mut String,
+    candidate: &CandidateReport,
+    is_last: bool,
+    min_severity: Severity,
+) {
+    let branch = if is_last { "└─" } else { "├─" };
+    let cont = if is_last { "  " } else { "│ " };
+
+    let glyph = match candidate.status {
+        Status::Routed => "✓",
+        Status::Degraded => "⚠",
+        Status::Skipped => "✗",
+    };
+    let suffix = match candidate.status {
+        Status::Routed => String::new(),
+        Status::Degraded => "  ·  degraded".into(),
+        Status::Skipped => "  ·  skipped".into(),
+    };
+
+    let short_id = if candidate.id.len() > 12 {
+        format!(" ({})", &candidate.id[..12])
+    } else if candidate.id.is_empty() || candidate.id == candidate.display_name {
+        String::new()
+    } else {
+        format!(" ({})", candidate.id)
+    };
+
+    writeln!(
+        out,
+        "{branch} {glyph} {name}{id}{suffix}",
+        name = candidate.display_name,
+        id = short_id,
+    )
+    .unwrap();
+
+    // Routing summary line per entrypoint.
+    let mut sorted_eps: Vec<&Entrypoint> = candidate.entrypoints.values().collect();
+    sorted_eps.sort_by(|a, b| a.id.cmp(&b.id));
+    for ep in &sorted_eps {
+        writeln!(out, "{cont}     {}", format_route(ep)).unwrap();
+    }
+
+    // Diagnostics, filtered by min_severity.
+    let visible: Vec<&Diagnostic> = candidate
+        .diagnostics
+        .iter()
+        .filter(|d| severity_at_least(d.severity(), min_severity))
+        .collect();
+
+    if visible.is_empty() {
+        return;
+    }
+
+    writeln!(out, "{cont}    │").unwrap();
+    let last_diag = visible.len().saturating_sub(1);
+    for (i, diag) in visible.iter().enumerate() {
+        let dlast = i == last_diag;
+        let dbranch = if dlast { "└─" } else { "├─" };
+        let dcont = if dlast { "   " } else { "│  " };
+        let header = format_diag_header(diag);
+        writeln!(out, "{cont}    {dbranch} {} {header}", diag.code.as_str()).unwrap();
+        writeln!(out, "{cont}    {dcont}      {}", diag.message).unwrap();
+        if let Some(hint) = &diag.hint {
+            writeln!(out, "{cont}    {dcont}      → {hint}").unwrap();
+        }
+        if !dlast {
+            writeln!(out, "{cont}    │").unwrap();
+        }
+    }
+}
+
+fn format_route(ep: &Entrypoint) -> String {
+    let scheme = match ep.protocol {
+        Protocol::Http => {
+            if ep.config.tls {
+                "https"
+            } else {
+                "http"
+            }
+        }
+        Protocol::Tcp => "tcp",
+        Protocol::Udp => "udp",
+    };
+    let host = ep.config.hostnames.first().cloned().unwrap_or_default();
+    let path_str = ep
+        .config
+        .path
+        .as_ref()
+        .map(format_path)
+        .unwrap_or_default();
+    let backends = ep.backends.join(", ");
+    format!(
+        "{}://{}:{}{}  →  {}",
+        scheme, host, ep.config.port, path_str, backends
+    )
+}
+
+fn format_path(p: &PathConfig) -> String {
+    match p.rule_type {
+        PathRuleType::Prefix | PathRuleType::Exact => p.value.clone(),
+        PathRuleType::Regex => format!(" (regex: {})", p.value),
+    }
+}
+
+fn format_diag_header(diag: &Diagnostic) -> String {
+    match (&diag.label, &diag.value) {
+        (Some(label), Some(value)) => format!("{label} = {value:?}"),
+        (Some(label), None) => label.clone(),
+        (None, Some(value)) => format!("{value:?}"),
+        (None, None) => String::new(),
+    }
+}
+
+fn severity_at_least(d: Severity, min: Severity) -> bool {
+    severity_rank(d) >= severity_rank(min)
+}
+
+fn severity_rank(s: Severity) -> u8 {
+    match s {
+        Severity::Info => 0,
+        Severity::Warn => 1,
+        Severity::Error => 2,
+    }
+}
+
+fn has_diagnostics(report: &ValidationReport, min: Severity) -> bool {
+    report
+        .candidates
+        .iter()
+        .flat_map(|c| c.diagnostics.iter())
+        .any(|d| severity_at_least(d.severity(), min))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::report::CandidateReport;
+    use crate::labels::candidate::Candidate;
+    use crate::labels::diagnostic::DiagnosticCode;
+    use crate::labels::parse;
+    use std::collections::HashMap;
+
+    fn candidate(provider: &'static str, name: &str, labels: &[(&str, &str)]) -> Candidate {
+        Candidate {
+            provider,
+            id: format!("{name}-id"),
+            display_name: name.into(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            networks: vec![crate::labels::candidate::NetworkInfo {
+                name: "bridge".into(),
+                ip: Some("172.18.0.4".into()),
+            }],
+            enabled_default: false,
+        }
+    }
+
+    fn report_for(c: Candidate) -> CandidateReport {
+        let r = parse(&c);
+        CandidateReport::from_parse(&c, r.entrypoints, r.diagnostics)
+    }
+
+    #[test]
+    fn routed_candidate_renders_route_line() {
+        let c = candidate(
+            "docker",
+            "my-api",
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+                ("sozune.http.web.port", "8080"),
+            ],
+        );
+        let report = ValidationReport {
+            candidates: vec![report_for(c)],
+        };
+        let out = render(&report, Severity::Warn);
+        assert!(out.contains("docker"));
+        assert!(out.contains("✓ my-api"));
+        assert!(out.contains("http://example.com:8080"));
+        assert!(out.contains("172.18.0.4"));
+        assert!(out.contains("1 routed · 0 degraded · 0 skipped"));
+    }
+
+    #[test]
+    fn skipped_candidate_shows_e002_with_hint() {
+        let c = candidate(
+            "docker",
+            "broken",
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.port", "8080"),
+            ],
+        );
+        let report = ValidationReport {
+            candidates: vec![report_for(c)],
+        };
+        let out = render(&report, Severity::Warn);
+        assert!(out.contains("✗ broken"));
+        assert!(out.contains("skipped"));
+        assert!(out.contains("E002"));
+        assert!(out.contains("→"));
+    }
+
+    #[test]
+    fn degraded_candidate_emits_warn_glyph() {
+        let c = candidate(
+            "docker",
+            "weird",
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+                ("sozune.http.web.port", "abc"),
+            ],
+        );
+        let report = ValidationReport {
+            candidates: vec![report_for(c)],
+        };
+        let out = render(&report, Severity::Warn);
+        assert!(out.contains("⚠ weird"));
+        assert!(out.contains("degraded"));
+        assert!(out.contains("W001"));
+    }
+
+    #[test]
+    fn min_severity_filters_diagnostics() {
+        let c = candidate(
+            "docker",
+            "api",
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+            ],
+        );
+        let report = ValidationReport {
+            candidates: vec![report_for(c)],
+        };
+        // I-codes are emitted (path defaulted, port defaulted), but Warn
+        // filter should hide them.
+        let warn = render(&report, Severity::Warn);
+        assert!(!warn.contains("I001"));
+        assert!(!warn.contains("I002"));
+
+        let info = render(&report, Severity::Info);
+        assert!(info.contains("I001") || info.contains("I002"));
+    }
+
+    #[test]
+    fn groups_by_provider() {
+        let c1 = candidate(
+            "docker",
+            "a",
+            &[("sozune.enable", "true"), ("sozune.http.x.host", "a.io")],
+        );
+        let c2 = candidate(
+            "file",
+            "b",
+            &[("sozune.enable", "true"), ("sozune.http.x.host", "b.io")],
+        );
+        let report = ValidationReport {
+            candidates: vec![report_for(c1), report_for(c2)],
+        };
+        let out = render(&report, Severity::Warn);
+        let docker_pos = out.find("docker").unwrap();
+        let file_pos = out.find("file").unwrap();
+        assert!(docker_pos < file_pos);
+        // Make sure unused import warning doesn't fire and the helper
+        // produces a non-empty diagnostic header for completeness.
+        let _ = DiagnosticCode::E002MissingHost.as_str();
+        let _: HashMap<String, Entrypoint> = HashMap::new();
+    }
+}

--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -1,0 +1,74 @@
+use crate::labels::candidate::Candidate;
+use crate::labels::diagnostic::{Diagnostic, Severity};
+use crate::model::Entrypoint;
+use std::collections::HashMap;
+
+/// Final, render-ready view of validating one candidate.
+pub struct CandidateReport {
+    pub provider: String,
+    pub id: String,
+    pub display_name: String,
+    pub status: Status,
+    pub entrypoints: HashMap<String, Entrypoint>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Status {
+    Routed,
+    Degraded,
+    Skipped,
+}
+
+impl CandidateReport {
+    pub fn from_parse(
+        candidate: &Candidate,
+        entrypoints: HashMap<String, Entrypoint>,
+        diagnostics: Vec<Diagnostic>,
+    ) -> Self {
+        let has_error = diagnostics.iter().any(|d| d.severity() == Severity::Error);
+        let has_warn = diagnostics.iter().any(|d| d.severity() == Severity::Warn);
+
+        let status = if entrypoints.is_empty() || has_error {
+            Status::Skipped
+        } else if has_warn {
+            Status::Degraded
+        } else {
+            Status::Routed
+        };
+
+        Self {
+            provider: candidate.provider.to_string(),
+            id: candidate.id.clone(),
+            display_name: candidate.display_name.clone(),
+            status,
+            entrypoints,
+            diagnostics,
+        }
+    }
+}
+
+pub struct ValidationReport {
+    pub candidates: Vec<CandidateReport>,
+}
+
+impl ValidationReport {
+    pub fn summary(&self) -> Summary {
+        let mut s = Summary::default();
+        for c in &self.candidates {
+            match c.status {
+                Status::Routed => s.routed += 1,
+                Status::Degraded => s.degraded += 1,
+                Status::Skipped => s.skipped += 1,
+            }
+        }
+        s
+    }
+}
+
+#[derive(Default)]
+pub struct Summary {
+    pub routed: usize,
+    pub degraded: usize,
+    pub skipped: usize,
+}

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -1,5 +1,13 @@
 use clap::{Args, ValueEnum};
 
+use crate::cli::render;
+use crate::cli::report::{CandidateReport, Status, ValidationReport};
+use crate::config::AppConfig;
+use crate::labels::diagnostic::Severity;
+use crate::labels::source::LabelSource;
+use crate::labels::{self, Candidate};
+use crate::provider::docker::DockerProvider;
+
 #[derive(Args, Debug)]
 pub struct ValidateArgs {
     /// Filter to a single provider (e.g. docker, file).
@@ -50,7 +58,94 @@ pub enum SeverityFilter {
     Info,
 }
 
-pub async fn run(_args: ValidateArgs) -> anyhow::Result<i32> {
-    eprintln!("sozune validate is not yet implemented");
-    Ok(2)
+impl SeverityFilter {
+    fn to_severity(self) -> Severity {
+        match self {
+            SeverityFilter::Error => Severity::Error,
+            SeverityFilter::Warn => Severity::Warn,
+            SeverityFilter::Info => Severity::Info,
+        }
+    }
+}
+
+pub async fn run(args: ValidateArgs) -> anyhow::Result<i32> {
+    if let Some(code) = &args.explain {
+        eprintln!("--explain {code}: not yet implemented");
+        return Ok(2);
+    }
+
+    let config = load_config().await?;
+    let candidates = collect_candidates(&config, args.provider.as_deref()).await?;
+    let mut report = build_report(candidates);
+
+    if let Some(id) = &args.id {
+        report
+            .candidates
+            .retain(|c| c.id == *id || c.display_name == *id);
+    }
+    if args.only_skipped {
+        report
+            .candidates
+            .retain(|c| c.status == Status::Skipped);
+    }
+
+    let min_severity = args.severity.to_severity();
+    let output = render::tree::render(&report, min_severity);
+    print!("{output}");
+
+    Ok(exit_code(&report))
+}
+
+async fn load_config() -> anyhow::Result<AppConfig> {
+    let config_path =
+        std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string());
+
+    if !tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
+        return Ok(AppConfig::default());
+    }
+    let content = tokio::fs::read_to_string(&config_path).await?;
+    Ok(serde_yaml::from_str(&content)?)
+}
+
+async fn collect_candidates(
+    config: &AppConfig,
+    provider_filter: Option<&str>,
+) -> anyhow::Result<Vec<Candidate>> {
+    let mut candidates = Vec::new();
+    let want = |name: &str| provider_filter.map_or(true, |p| p == name);
+
+    if want("docker") {
+        if let Some(docker_cfg) = &config.providers.docker {
+            if docker_cfg.enabled {
+                match DockerProvider::new(docker_cfg.clone()) {
+                    Ok(provider) => match provider.collect().await {
+                        Ok(mut cs) => candidates.append(&mut cs),
+                        Err(e) => eprintln!("docker: failed to collect candidates: {e}"),
+                    },
+                    Err(e) => eprintln!("docker: failed to connect: {e}"),
+                }
+            }
+        }
+    }
+
+    Ok(candidates)
+}
+
+fn build_report(candidates: Vec<Candidate>) -> ValidationReport {
+    let candidates = candidates
+        .into_iter()
+        .map(|c| {
+            let r = labels::parse(&c);
+            CandidateReport::from_parse(&c, r.entrypoints, r.diagnostics)
+        })
+        .collect();
+    ValidationReport { candidates }
+}
+
+fn exit_code(report: &ValidationReport) -> i32 {
+    if report.candidates.iter().any(|c| c.status == Status::Skipped) {
+        1
+    } else {
+        0
+    }
 }

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -25,30 +25,6 @@ pub struct ValidateArgs {
     /// Minimum diagnostic severity to display.
     #[arg(long, value_enum, default_value_t = SeverityFilter::Warn)]
     pub severity: SeverityFilter,
-
-    /// Render output as a table with diagnostics inline as sub-rows.
-    #[arg(long, conflicts_with_all = ["summary", "flat", "json"])]
-    pub table: bool,
-
-    /// One-line-per-candidate dense summary (codes only).
-    #[arg(long, conflicts_with_all = ["table", "flat", "json"])]
-    pub summary: bool,
-
-    /// Card per candidate with horizontal rules.
-    #[arg(long, conflicts_with_all = ["table", "summary", "json"])]
-    pub flat: bool,
-
-    /// Machine-readable JSON output for CI / scripts.
-    #[arg(long, conflicts_with_all = ["table", "summary", "flat"])]
-    pub json: bool,
-
-    /// Re-validate on provider events (Docker events, file changes).
-    #[arg(long)]
-    pub watch: bool,
-
-    /// Print documentation for a diagnostic code (e.g. W009) and exit.
-    #[arg(long, value_name = "CODE")]
-    pub explain: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -69,11 +45,6 @@ impl SeverityFilter {
 }
 
 pub async fn run(args: ValidateArgs) -> anyhow::Result<i32> {
-    if let Some(code) = &args.explain {
-        eprintln!("--explain {code}: not yet implemented");
-        return Ok(2);
-    }
-
     let config = load_config().await?;
     let candidates = collect_candidates(&config, args.provider.as_deref()).await?;
     let mut report = build_report(candidates);
@@ -84,9 +55,7 @@ pub async fn run(args: ValidateArgs) -> anyhow::Result<i32> {
             .retain(|c| c.id == *id || c.display_name == *id);
     }
     if args.only_skipped {
-        report
-            .candidates
-            .retain(|c| c.status == Status::Skipped);
+        report.candidates.retain(|c| c.status == Status::Skipped);
     }
 
     let min_severity = args.severity.to_severity();
@@ -97,8 +66,7 @@ pub async fn run(args: ValidateArgs) -> anyhow::Result<i32> {
 }
 
 async fn load_config() -> anyhow::Result<AppConfig> {
-    let config_path =
-        std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string());
+    let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string());
 
     if !tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
         return Ok(AppConfig::default());
@@ -143,7 +111,11 @@ fn build_report(candidates: Vec<Candidate>) -> ValidationReport {
 }
 
 fn exit_code(report: &ValidationReport) -> i32 {
-    if report.candidates.iter().any(|c| c.status == Status::Skipped) {
+    if report
+        .candidates
+        .iter()
+        .any(|c| c.status == Status::Skipped)
+    {
         1
     } else {
         0

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -1,0 +1,56 @@
+use clap::{Args, ValueEnum};
+
+#[derive(Args, Debug)]
+pub struct ValidateArgs {
+    /// Filter to a single provider (e.g. docker, file).
+    #[arg(long)]
+    pub provider: Option<String>,
+
+    /// Filter to a single candidate id.
+    #[arg(long)]
+    pub id: Option<String>,
+
+    /// Show only candidates that would not be routed.
+    #[arg(long)]
+    pub only_skipped: bool,
+
+    /// Minimum diagnostic severity to display.
+    #[arg(long, value_enum, default_value_t = SeverityFilter::Warn)]
+    pub severity: SeverityFilter,
+
+    /// Render output as a table with diagnostics inline as sub-rows.
+    #[arg(long, conflicts_with_all = ["summary", "flat", "json"])]
+    pub table: bool,
+
+    /// One-line-per-candidate dense summary (codes only).
+    #[arg(long, conflicts_with_all = ["table", "flat", "json"])]
+    pub summary: bool,
+
+    /// Card per candidate with horizontal rules.
+    #[arg(long, conflicts_with_all = ["table", "summary", "json"])]
+    pub flat: bool,
+
+    /// Machine-readable JSON output for CI / scripts.
+    #[arg(long, conflicts_with_all = ["table", "summary", "flat"])]
+    pub json: bool,
+
+    /// Re-validate on provider events (Docker events, file changes).
+    #[arg(long)]
+    pub watch: bool,
+
+    /// Print documentation for a diagnostic code (e.g. W009) and exit.
+    #[arg(long, value_name = "CODE")]
+    pub explain: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
+pub enum SeverityFilter {
+    Error,
+    Warn,
+    Info,
+}
+
+pub async fn run(_args: ValidateArgs) -> anyhow::Result<i32> {
+    eprintln!("sozune validate is not yet implemented");
+    Ok(2)
+}

--- a/src/labels/mod.rs
+++ b/src/labels/mod.rs
@@ -13,7 +13,9 @@ pub mod diagnostic;
 pub mod fields;
 pub mod network;
 pub mod parser;
+pub mod source;
 
 pub use candidate::{Candidate, NetworkInfo};
 pub use diagnostic::{Diagnostic, DiagnosticCode, ParseResult, Severity};
 pub use parser::parse;
+pub use source::LabelSource;

--- a/src/labels/source.rs
+++ b/src/labels/source.rs
@@ -1,0 +1,15 @@
+use super::candidate::Candidate;
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Implemented by providers that discover routing configuration through
+/// labels/tags/annotations (Docker, Nomad, Kubernetes). Providers that
+/// produce already-parsed entrypoints (file, http) do not implement this
+/// trait — they bypass the label parser entirely.
+#[async_trait]
+pub trait LabelSource: Send + Sync {
+    fn provider_name(&self) -> &'static str;
+
+    /// Produce one `Candidate` per discoverable unit (container, job, pod).
+    async fn collect(&self) -> Result<Vec<Candidate>>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use clap::Parser;
 use futures_util::stream::StreamExt;
 use signal_hook::consts::{SIGINT, SIGTERM};
 use signal_hook_tokio::Signals;
@@ -7,10 +8,12 @@ use std::sync::{Arc, RwLock};
 use tokio::sync::{Notify, mpsc};
 use tracing::{debug, error, info, warn};
 
+use crate::cli::{Cli, Command};
 use crate::config::AppConfig;
 
 mod acme;
 mod api;
+mod cli;
 mod config;
 mod labels;
 mod middleware;
@@ -22,6 +25,20 @@ pub use model::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    init_tracing();
+
+    match cli.command.unwrap_or(Command::Serve) {
+        Command::Serve => serve().await,
+        Command::Validate(args) => {
+            let exit = cli::validate::run(args).await?;
+            std::process::exit(exit);
+        }
+    }
+}
+
+fn init_tracing() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
@@ -31,7 +48,9 @@ async fn main() -> anyhow::Result<()> {
                 .add_directive("rustls=warn".parse().expect("valid log directive")),
         )
         .init();
+}
 
+async fn serve() -> anyhow::Result<()> {
     info!("Starting Sozune proxy");
 
     let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string());

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -1,6 +1,7 @@
 use crate::config::DockerConfig;
 use crate::labels::candidate::{Candidate, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
+use crate::labels::source::LabelSource;
 use crate::labels::{self};
 use crate::model::Entrypoint;
 use crate::provider::Provider;
@@ -35,6 +36,34 @@ impl Provider for DockerProvider {
 
     fn name(&self) -> &'static str {
         "docker"
+    }
+}
+
+#[async_trait]
+impl LabelSource for DockerProvider {
+    fn provider_name(&self) -> &'static str {
+        "docker"
+    }
+
+    async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
+        let containers = self
+            .docker
+            .list_containers(Some(ListContainersOptions {
+                all: false,
+                ..Default::default()
+            }))
+            .await?;
+
+        let mut candidates = Vec::with_capacity(containers.len());
+        for container in containers {
+            let Some(labels) = container.labels else {
+                continue;
+            };
+            let id = container.id.unwrap_or_default();
+            let networks = self.extract_networks(&id).await;
+            candidates.push(self.build_candidate(id, labels, networks));
+        }
+        Ok(candidates)
     }
 }
 

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -60,8 +60,21 @@ impl LabelSource for DockerProvider {
                 continue;
             };
             let id = container.id.unwrap_or_default();
+            let display_name = container
+                .names
+                .as_ref()
+                .and_then(|names| names.first().cloned())
+                .map(|n| n.trim_start_matches('/').to_string())
+                .unwrap_or_else(|| id.clone());
             let networks = self.extract_networks(&id).await;
-            candidates.push(self.build_candidate(id, labels, networks));
+            candidates.push(Candidate {
+                provider: "docker",
+                id,
+                display_name,
+                labels,
+                networks,
+                enabled_default: self.config.expose_by_default,
+            });
         }
         Ok(candidates)
     }


### PR DESCRIPTION
Adds a new `sozune validate` subcommand that lists every container the Docker provider sees and explains which ones would be routed and why the others wouldn't.

Builds on the labels module from #23 — this PR is just the CLI layer on top.

```
docker
├─ ✓ my-api (a3f8b2)
│      http://example.com:8080/api  →  172.18.0.4
├─ ⚠ my-degraded (c4d5e6)  ·  degraded
│      http://api.example.com:80  →  172.18.0.5
│     │
│     ├─ W001  sozune.http.web.port = "abc"
│     │        port is not a valid u16, falling back to 80
│     └─ W009  sozune.network = "frontend"
│              preferred network not attached, falling back
└─ ✗ my-broken  ·  skipped
     └─ E002  sozune.http.web.host  required label missing
              → add `sozune.http.web.host=<your-domain>`

1 routed · 1 degraded · 1 skipped
```

Filters: `--provider`, `--id`, `--only-skipped`, `--severity error|warn|info`.
Exit 0 when nothing is skipped, 1 otherwise.

## Test plan

- [x] `cargo test --bin sozune` (104/104)
- [x] Smoke-tested on a live compose stack with routed / degraded / skipped / disabled containers