### PR TITLE
Move label parsing into a shared module

### DIFF
--- a/src/labels/candidate.rs
+++ b/src/labels/candidate.rs
@@ -1,0 +1,17 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    pub provider: &'static str,
+    pub id: String,
+    pub display_name: String,
+    pub labels: HashMap<String, String>,
+    pub networks: Vec<NetworkInfo>,
+    pub enabled_default: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct NetworkInfo {
+    pub name: String,
+    pub ip: Option<String>,
+}

--- a/src/labels/diagnostic.rs
+++ b/src/labels/diagnostic.rs
@@ -1,0 +1,121 @@
+use crate::model::Entrypoint;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warn,
+    Info,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticCode {
+    // Errors — block routing
+    E001Disabled,
+    E002MissingHost,
+    E003InspectFailed,
+    E004NoServices,
+    // Warnings — silent fallbacks today
+    W001InvalidPort,
+    W002InvalidPriority,
+    W003InvalidTimeout,
+    W004InvalidRateLimit,
+    W005InvalidRedirectPolicy,
+    W006InvalidRedirectScheme,
+    W007MalformedBasicAuthEntry,
+    W008BlockedHeader,
+    W009NetworkNotFound,
+    W010NoIpFellBackToLocalhost,
+    W011EmptyBasicAuth,
+    W012InvalidProtocol,
+    // Info — surfaced only with --severity info
+    I001PathDefaulted,
+    I002PortDefaulted,
+}
+
+impl DiagnosticCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiagnosticCode::E001Disabled => "E001",
+            DiagnosticCode::E002MissingHost => "E002",
+            DiagnosticCode::E003InspectFailed => "E003",
+            DiagnosticCode::E004NoServices => "E004",
+            DiagnosticCode::W001InvalidPort => "W001",
+            DiagnosticCode::W002InvalidPriority => "W002",
+            DiagnosticCode::W003InvalidTimeout => "W003",
+            DiagnosticCode::W004InvalidRateLimit => "W004",
+            DiagnosticCode::W005InvalidRedirectPolicy => "W005",
+            DiagnosticCode::W006InvalidRedirectScheme => "W006",
+            DiagnosticCode::W007MalformedBasicAuthEntry => "W007",
+            DiagnosticCode::W008BlockedHeader => "W008",
+            DiagnosticCode::W009NetworkNotFound => "W009",
+            DiagnosticCode::W010NoIpFellBackToLocalhost => "W010",
+            DiagnosticCode::W011EmptyBasicAuth => "W011",
+            DiagnosticCode::W012InvalidProtocol => "W012",
+            DiagnosticCode::I001PathDefaulted => "I001",
+            DiagnosticCode::I002PortDefaulted => "I002",
+        }
+    }
+
+    pub fn severity(self) -> Severity {
+        match self.as_str().chars().next() {
+            Some('E') => Severity::Error,
+            Some('W') => Severity::Warn,
+            _ => Severity::Info,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub code: DiagnosticCode,
+    pub label: Option<String>,
+    pub value: Option<String>,
+    pub message: String,
+    pub hint: Option<String>,
+}
+
+impl Diagnostic {
+    pub fn new(code: DiagnosticCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            label: None,
+            value: None,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.code.severity()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ParseResult {
+    pub entrypoints: HashMap<String, Entrypoint>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|d| d.severity() == Severity::Error)
+    }
+}

--- a/src/labels/fields/auth.rs
+++ b/src/labels/fields/auth.rs
@@ -1,0 +1,151 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::model::{AuthConfig, BasicAuthUser};
+use std::collections::HashMap;
+
+/// Parse the `auth.basic` label, a comma-separated list of `username:hash`.
+/// Malformed entries (missing `:`) emit `W007` and are skipped. If all entries
+/// are malformed the result is `None` and `W011` is emitted.
+pub fn parse_auth(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<AuthConfig> {
+    let key = format!("{prefix}auth.basic");
+    let raw = labels.get(&key)?;
+    let mut users = Vec::new();
+
+    for entry in raw.split(',') {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match trimmed.split_once(':') {
+            Some((user, hash)) => users.push(BasicAuthUser {
+                username: user.to_string(),
+                password_hash: hash.to_string(),
+            }),
+            None => {
+                diagnostics.push(
+                    Diagnostic::new(
+                        DiagnosticCode::W007MalformedBasicAuthEntry,
+                        "basic auth entry missing ':', skipping",
+                    )
+                    .with_label(&key)
+                    .with_value(trimmed)
+                    .with_hint("expected `username:password_hash`"),
+                );
+            }
+        }
+    }
+
+    if users.is_empty() {
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticCode::W011EmptyBasicAuth,
+                "all basic auth entries were malformed, auth disabled",
+            )
+            .with_label(&key),
+        );
+        return None;
+    }
+
+    Some(AuthConfig { basic: Some(users) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn absent_returns_none_quietly() {
+        let mut diags = Vec::new();
+        assert!(parse_auth(&labels(&[]), "sozune.http.web.", &mut diags).is_none());
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn single_valid_user_parses() {
+        let mut diags = Vec::new();
+        let auth = parse_auth(
+            &labels(&[("sozune.http.web.auth.basic", "alice:hash1")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        let users = auth.basic.unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].username, "alice");
+        assert_eq!(users[0].password_hash, "hash1");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn multiple_users_split_on_comma() {
+        let mut diags = Vec::new();
+        let auth = parse_auth(
+            &labels(&[(
+                "sozune.http.web.auth.basic",
+                "alice:hash1,bob:hash2,carol:hash3",
+            )]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(auth.basic.unwrap().len(), 3);
+    }
+
+    #[test]
+    fn malformed_entry_emits_w007_and_is_skipped() {
+        let mut diags = Vec::new();
+        let auth = parse_auth(
+            &labels(&[(
+                "sozune.http.web.auth.basic",
+                "alice:hash1,bobnohash,carol:hash3",
+            )]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(auth.basic.unwrap().len(), 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::W007MalformedBasicAuthEntry);
+        assert_eq!(diags[0].value.as_deref(), Some("bobnohash"));
+    }
+
+    #[test]
+    fn all_malformed_emits_w011_and_returns_none() {
+        let mut diags = Vec::new();
+        let auth = parse_auth(
+            &labels(&[("sozune.http.web.auth.basic", "alicebobcarol")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert!(auth.is_none());
+        assert!(diags
+            .iter()
+            .any(|d| d.code == DiagnosticCode::W007MalformedBasicAuthEntry));
+        assert!(diags
+            .iter()
+            .any(|d| d.code == DiagnosticCode::W011EmptyBasicAuth));
+    }
+
+    #[test]
+    fn hash_with_colon_is_preserved() {
+        let mut diags = Vec::new();
+        let auth = parse_auth(
+            &labels(&[("sozune.http.web.auth.basic", "alice:$2y$10:cost:hash")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        let users = auth.basic.unwrap();
+        assert_eq!(users[0].password_hash, "$2y$10:cost:hash");
+    }
+}

--- a/src/labels/fields/core.rs
+++ b/src/labels/fields/core.rs
@@ -52,6 +52,66 @@ fn default_port_for(protocol: &str) -> u16 {
     }
 }
 
+/// Parse the priority label. Defaults to 0 when absent. Non-numeric values
+/// emit `W002` and also fall back to 0.
+pub fn parse_priority(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> i32 {
+    let key = format!("{prefix}priority");
+    match labels.get(&key) {
+        None => 0,
+        Some(raw) => match raw.parse::<i32>() {
+            Ok(p) => p,
+            Err(_) => {
+                diagnostics.push(
+                    Diagnostic::new(
+                        DiagnosticCode::W002InvalidPriority,
+                        "priority is not a valid integer, defaulting to 0",
+                    )
+                    .with_label(&key)
+                    .with_value(raw),
+                );
+                0
+            }
+        },
+    }
+}
+
+/// Parse the backendTimeout label (milliseconds). Returns `None` when absent
+/// or invalid; non-numeric values emit `W003`.
+pub fn parse_backend_timeout(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<u64> {
+    let key = format!("{prefix}backendTimeout");
+    let raw = labels.get(&key)?;
+    match raw.parse::<u64>() {
+        Ok(t) => Some(t),
+        Err(_) => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::W003InvalidTimeout,
+                    "backendTimeout is not a valid integer, no timeout applied",
+                )
+                .with_label(&key)
+                .with_value(raw)
+                .with_hint("expected milliseconds as a positive integer"),
+            );
+            None
+        }
+    }
+}
+
+/// Parse a boolean label. Treats `"true"` (case-sensitive) as true, anything
+/// else as false. No diagnostic — matches existing `map_or(false, |v| v == "true")`
+/// semantics.
+pub fn parse_bool(labels: &HashMap<String, String>, key: &str) -> bool {
+    labels.get(key).is_some_and(|v| v == "true")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,5 +187,82 @@ mod tests {
         );
         assert_eq!(port, 80);
         assert_eq!(diags[0].code, DiagnosticCode::W001InvalidPort);
+    }
+
+    #[test]
+    fn priority_defaults_to_zero_when_absent() {
+        let mut diags = Vec::new();
+        assert_eq!(parse_priority(&labels(&[]), "sozune.http.web.", &mut diags), 0);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn priority_parses_valid_int() {
+        let mut diags = Vec::new();
+        assert_eq!(
+            parse_priority(
+                &labels(&[("sozune.http.web.priority", "10")]),
+                "sozune.http.web.",
+                &mut diags,
+            ),
+            10,
+        );
+    }
+
+    #[test]
+    fn priority_invalid_emits_w002() {
+        let mut diags = Vec::new();
+        let p = parse_priority(
+            &labels(&[("sozune.http.web.priority", "high")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(p, 0);
+        assert_eq!(diags[0].code, DiagnosticCode::W002InvalidPriority);
+    }
+
+    #[test]
+    fn timeout_returns_none_when_absent() {
+        let mut diags = Vec::new();
+        assert_eq!(
+            parse_backend_timeout(&labels(&[]), "sozune.http.web.", &mut diags),
+            None,
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn timeout_parses_valid_value() {
+        let mut diags = Vec::new();
+        assert_eq!(
+            parse_backend_timeout(
+                &labels(&[("sozune.http.web.backendTimeout", "5000")]),
+                "sozune.http.web.",
+                &mut diags,
+            ),
+            Some(5000),
+        );
+    }
+
+    #[test]
+    fn timeout_invalid_emits_w003() {
+        let mut diags = Vec::new();
+        let t = parse_backend_timeout(
+            &labels(&[("sozune.http.web.backendTimeout", "soon")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(t, None);
+        assert_eq!(diags[0].code, DiagnosticCode::W003InvalidTimeout);
+    }
+
+    #[test]
+    fn bool_true_only_for_literal_true() {
+        let l = labels(&[("a", "true"), ("b", "True"), ("c", "1"), ("d", "false")]);
+        assert!(parse_bool(&l, "a"));
+        assert!(!parse_bool(&l, "b"));
+        assert!(!parse_bool(&l, "c"));
+        assert!(!parse_bool(&l, "d"));
+        assert!(!parse_bool(&l, "missing"));
     }
 }

--- a/src/labels/fields/core.rs
+++ b/src/labels/fields/core.rs
@@ -1,0 +1,131 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use std::collections::HashMap;
+
+/// Parse a port label, falling back to the protocol default when absent or
+/// non-numeric. Emits diagnostics describing the fallback so callers can
+/// surface them.
+///
+/// `prefix` is `sozune.<protocol>.<service>.` (trailing dot included).
+pub fn parse_port(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    protocol: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> u16 {
+    let key = format!("{prefix}port");
+    let default = default_port_for(protocol);
+
+    match labels.get(&key) {
+        None => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::I002PortDefaulted,
+                    format!("no port label, using protocol default ({default})"),
+                )
+                .with_label(&key),
+            );
+            default
+        }
+        Some(raw) => match raw.parse::<u16>() {
+            Ok(port) => port,
+            Err(_) => {
+                diagnostics.push(
+                    Diagnostic::new(
+                        DiagnosticCode::W001InvalidPort,
+                        format!("port is not a valid u16, falling back to {default}"),
+                    )
+                    .with_label(&key)
+                    .with_value(raw)
+                    .with_hint("port must be a positive integer between 0 and 65535"),
+                );
+                default
+            }
+        },
+    }
+}
+
+fn default_port_for(protocol: &str) -> u16 {
+    match protocol {
+        "http" => 80,
+        "https" => 443,
+        _ => 8080,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn returns_explicit_port_when_valid() {
+        let mut diags = Vec::new();
+        let port = parse_port(
+            &labels(&[("sozune.http.web.port", "8080")]),
+            "sozune.http.web.",
+            "http",
+            &mut diags,
+        );
+        assert_eq!(port, 8080);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn missing_port_emits_i002_and_uses_http_default() {
+        let mut diags = Vec::new();
+        let port = parse_port(&labels(&[]), "sozune.http.web.", "http", &mut diags);
+        assert_eq!(port, 80);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::I002PortDefaulted);
+    }
+
+    #[test]
+    fn missing_port_uses_https_default() {
+        let mut diags = Vec::new();
+        let port = parse_port(&labels(&[]), "sozune.https.web.", "https", &mut diags);
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn missing_port_uses_8080_for_unknown_protocol() {
+        let mut diags = Vec::new();
+        let port = parse_port(&labels(&[]), "sozune.tcp.db.", "tcp", &mut diags);
+        assert_eq!(port, 8080);
+    }
+
+    #[test]
+    fn non_numeric_port_emits_w001_and_falls_back() {
+        let mut diags = Vec::new();
+        let port = parse_port(
+            &labels(&[("sozune.http.web.port", "abc")]),
+            "sozune.http.web.",
+            "http",
+            &mut diags,
+        );
+        assert_eq!(port, 80);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::W001InvalidPort);
+        assert_eq!(diags[0].label.as_deref(), Some("sozune.http.web.port"));
+        assert_eq!(diags[0].value.as_deref(), Some("abc"));
+        assert!(diags[0].hint.is_some());
+    }
+
+    #[test]
+    fn out_of_range_port_emits_w001() {
+        let mut diags = Vec::new();
+        let port = parse_port(
+            &labels(&[("sozune.http.web.port", "99999")]),
+            "sozune.http.web.",
+            "http",
+            &mut diags,
+        );
+        assert_eq!(port, 80);
+        assert_eq!(diags[0].code, DiagnosticCode::W001InvalidPort);
+    }
+}

--- a/src/labels/fields/headers.rs
+++ b/src/labels/fields/headers.rs
@@ -1,0 +1,176 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::model::{HeaderConfig, HeaderDirection};
+use std::collections::HashMap;
+
+/// Headers that must not be injected from labels to prevent request smuggling,
+/// SSRF, and host header attacks.
+pub const BLOCKED_HEADERS: &[&str] = &[
+    "host",
+    "transfer-encoding",
+    "content-length",
+    "connection",
+    "upgrade",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+    "forwarded",
+    "cookie",
+    "authorization",
+    "proxy-authorization",
+    "proxy-connection",
+    "te",
+    "trailer",
+];
+
+/// Parse `headers.<name>`, `headers.response.<name>`, `headers.both.<name>`
+/// labels into `HeaderConfig` values. Headers in `BLOCKED_HEADERS` emit
+/// `W008` and are dropped.
+pub fn parse_headers(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Vec<HeaderConfig> {
+    let header_prefix = format!("{prefix}headers.");
+    let mut headers = Vec::new();
+
+    // Iterate in a deterministic order so diagnostics come out predictably.
+    let mut keys: Vec<&String> = labels.keys().collect();
+    keys.sort();
+
+    for key in keys {
+        let Some(remainder) = key.strip_prefix(&header_prefix) else {
+            continue;
+        };
+        let value = &labels[key];
+
+        let (direction, header_name) = if let Some(name) = remainder.strip_prefix("response.") {
+            (HeaderDirection::Response, name)
+        } else if let Some(name) = remainder.strip_prefix("both.") {
+            (HeaderDirection::Both, name)
+        } else {
+            (HeaderDirection::Request, remainder)
+        };
+
+        if BLOCKED_HEADERS
+            .iter()
+            .any(|blocked| blocked.eq_ignore_ascii_case(header_name))
+        {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::W008BlockedHeader,
+                    format!("header '{header_name}' is on the blocklist, dropped"),
+                )
+                .with_label(key)
+                .with_value(value)
+                .with_hint("blocked headers can enable request smuggling, SSRF, or host header attacks"),
+            );
+            continue;
+        }
+
+        headers.push(HeaderConfig {
+            name: header_name.to_string(),
+            value: value.clone(),
+            direction,
+        });
+    }
+
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn no_headers_returns_empty() {
+        let mut diags = Vec::new();
+        assert!(parse_headers(&labels(&[]), "sozune.http.web.", &mut diags).is_empty());
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn request_header_default_direction() {
+        let mut diags = Vec::new();
+        let h = parse_headers(
+            &labels(&[("sozune.http.web.headers.X-Source", "api")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].name, "X-Source");
+        assert_eq!(h[0].value, "api");
+        assert_eq!(h[0].direction, HeaderDirection::Request);
+    }
+
+    #[test]
+    fn response_direction_parsed() {
+        let mut diags = Vec::new();
+        let h = parse_headers(
+            &labels(&[("sozune.http.web.headers.response.X-Cache", "HIT")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(h[0].name, "X-Cache");
+        assert_eq!(h[0].direction, HeaderDirection::Response);
+    }
+
+    #[test]
+    fn both_direction_parsed() {
+        let mut diags = Vec::new();
+        let h = parse_headers(
+            &labels(&[("sozune.http.web.headers.both.X-Trace", "abc")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(h[0].name, "X-Trace");
+        assert_eq!(h[0].direction, HeaderDirection::Both);
+    }
+
+    #[test]
+    fn blocked_header_emits_w008() {
+        let mut diags = Vec::new();
+        let h = parse_headers(
+            &labels(&[("sozune.http.web.headers.Host", "evil.com")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert!(h.is_empty());
+        assert_eq!(diags[0].code, DiagnosticCode::W008BlockedHeader);
+    }
+
+    #[test]
+    fn blocked_header_case_insensitive() {
+        let mut diags = Vec::new();
+        let h = parse_headers(
+            &labels(&[("sozune.http.web.headers.AUTHORIZATION", "Bearer x")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert!(h.is_empty());
+        assert_eq!(diags[0].code, DiagnosticCode::W008BlockedHeader);
+    }
+
+    #[test]
+    fn unrelated_labels_ignored() {
+        let mut diags = Vec::new();
+        let h = parse_headers(
+            &labels(&[
+                ("sozune.http.web.port", "8080"),
+                ("sozune.http.web.headers.X-Foo", "bar"),
+                ("sozune.http.other.headers.X-Bar", "baz"),
+            ]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].name, "X-Foo");
+    }
+}

--- a/src/labels/fields/host.rs
+++ b/src/labels/fields/host.rs
@@ -1,0 +1,103 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use std::collections::HashMap;
+
+/// Parse the required `host` label, comma-separated. Emits `E002` and returns
+/// `None` when the label is absent — this blocks routing for the service.
+pub fn parse_hostnames(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Vec<String>> {
+    let key = format!("{prefix}host");
+    let raw = match labels.get(&key) {
+        Some(v) => v,
+        None => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::E002MissingHost,
+                    "required host label is missing",
+                )
+                .with_label(&key)
+                .with_hint(format!("add `{key}=<your-domain>` to enable routing")),
+            );
+            return None;
+        }
+    };
+
+    let hosts: Vec<String> = raw
+        .split(',')
+        .map(|h| h.trim().to_string())
+        .filter(|h| !h.is_empty())
+        .collect();
+
+    if hosts.is_empty() {
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticCode::E002MissingHost,
+                "host label is set but contains no usable hostname",
+            )
+            .with_label(&key)
+            .with_value(raw),
+        );
+        return None;
+    }
+
+    Some(hosts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn missing_host_emits_e002() {
+        let mut diags = Vec::new();
+        assert!(parse_hostnames(&labels(&[]), "sozune.http.web.", &mut diags).is_none());
+        assert_eq!(diags[0].code, DiagnosticCode::E002MissingHost);
+        assert!(diags[0].hint.is_some());
+    }
+
+    #[test]
+    fn single_host_parses() {
+        let mut diags = Vec::new();
+        let hosts = parse_hostnames(
+            &labels(&[("sozune.http.web.host", "example.com")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(hosts, vec!["example.com"]);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn comma_separated_hosts_split() {
+        let mut diags = Vec::new();
+        let hosts = parse_hostnames(
+            &labels(&[("sozune.http.web.host", "a.com, b.com ,c.com")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(hosts, vec!["a.com", "b.com", "c.com"]);
+    }
+
+    #[test]
+    fn empty_host_value_emits_e002() {
+        let mut diags = Vec::new();
+        assert!(parse_hostnames(
+            &labels(&[("sozune.http.web.host", "  , ,  ")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .is_none());
+        assert_eq!(diags[0].code, DiagnosticCode::E002MissingHost);
+    }
+}

--- a/src/labels/fields/mod.rs
+++ b/src/labels/fields/mod.rs
@@ -1,3 +1,8 @@
+pub mod auth;
 pub mod core;
+pub mod headers;
+pub mod host;
+pub mod path;
+pub mod ratelimit;
 pub mod redirect;
 

--- a/src/labels/fields/mod.rs
+++ b/src/labels/fields/mod.rs
@@ -1,0 +1,2 @@
+// Field parsers will be added incrementally — one module per label family.
+// See .issues/validate-command.md for the full plan.

--- a/src/labels/fields/mod.rs
+++ b/src/labels/fields/mod.rs
@@ -1,2 +1,3 @@
 pub mod core;
+pub mod redirect;
 

--- a/src/labels/fields/mod.rs
+++ b/src/labels/fields/mod.rs
@@ -1,2 +1,2 @@
-// Field parsers will be added incrementally — one module per label family.
-// See .issues/validate-command.md for the full plan.
+pub mod core;
+

--- a/src/labels/fields/path.rs
+++ b/src/labels/fields/path.rs
@@ -1,0 +1,105 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::model::{PathConfig, PathRuleType};
+use std::collections::HashMap;
+
+/// Parse path configuration from the three possible labels: `path`, `prefix`,
+/// `pathRegex`. Precedence: `path` > `prefix` > `pathRegex`. When none is set,
+/// defaults to `Prefix("/")` and emits `I001`.
+pub fn parse_path(
+    labels: &HashMap<String, String>,
+    prefix_key: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> PathConfig {
+    let exact = labels.get(&format!("{prefix_key}path"));
+    let prefix = labels.get(&format!("{prefix_key}prefix"));
+    let regex = labels.get(&format!("{prefix_key}pathRegex"));
+
+    match (exact, prefix, regex) {
+        (Some(p), _, _) => PathConfig {
+            rule_type: PathRuleType::Prefix,
+            value: p.clone(),
+        },
+        (None, Some(p), _) => PathConfig {
+            rule_type: PathRuleType::Prefix,
+            value: p.clone(),
+        },
+        (None, None, Some(r)) => PathConfig {
+            rule_type: PathRuleType::Regex,
+            value: r.clone(),
+        },
+        (None, None, None) => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::I001PathDefaulted,
+                    "no path/prefix/pathRegex label, defaulting to prefix \"/\"",
+                )
+                .with_label(format!("{prefix_key}path|prefix|pathRegex")),
+            );
+            PathConfig {
+                rule_type: PathRuleType::Prefix,
+                value: "/".to_string(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn explicit_path_wins_over_prefix() {
+        let mut diags = Vec::new();
+        let p = parse_path(
+            &labels(&[
+                ("sozune.http.web.path", "/api"),
+                ("sozune.http.web.prefix", "/legacy"),
+            ]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(p.rule_type, PathRuleType::Prefix);
+        assert_eq!(p.value, "/api");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn prefix_used_when_path_absent() {
+        let mut diags = Vec::new();
+        let p = parse_path(
+            &labels(&[("sozune.http.web.prefix", "/v1")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(p.rule_type, PathRuleType::Prefix);
+        assert_eq!(p.value, "/v1");
+    }
+
+    #[test]
+    fn regex_used_when_only_regex_set() {
+        let mut diags = Vec::new();
+        let p = parse_path(
+            &labels(&[("sozune.http.web.pathRegex", r"^/api/v\d+/.*")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(p.rule_type, PathRuleType::Regex);
+        assert_eq!(p.value, r"^/api/v\d+/.*");
+    }
+
+    #[test]
+    fn no_path_defaults_to_root_and_emits_i001() {
+        let mut diags = Vec::new();
+        let p = parse_path(&labels(&[]), "sozune.http.web.", &mut diags);
+        assert_eq!(p.rule_type, PathRuleType::Prefix);
+        assert_eq!(p.value, "/");
+        assert_eq!(diags[0].code, DiagnosticCode::I001PathDefaulted);
+    }
+}

--- a/src/labels/fields/ratelimit.rs
+++ b/src/labels/fields/ratelimit.rs
@@ -1,0 +1,162 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::model::RateLimitConfig;
+use std::collections::HashMap;
+
+/// Parse the `ratelimit.average` and `ratelimit.burst` labels.
+///
+/// - Both absent → returns `None` quietly.
+/// - Only average set → burst defaults to average.
+/// - Only burst set → invalid (no average means no rate limit), emits `W004`.
+/// - Either one non-numeric → emits `W004` and returns `None`.
+pub fn parse_rate_limit(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<RateLimitConfig> {
+    let avg_key = format!("{prefix}ratelimit.average");
+    let burst_key = format!("{prefix}ratelimit.burst");
+    let avg_raw = labels.get(&avg_key);
+    let burst_raw = labels.get(&burst_key);
+
+    if avg_raw.is_none() && burst_raw.is_none() {
+        return None;
+    }
+
+    let average = match avg_raw {
+        None => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::W004InvalidRateLimit,
+                    "ratelimit.burst set without ratelimit.average, ignoring",
+                )
+                .with_label(&avg_key)
+                .with_hint("set ratelimit.average to enable rate limiting"),
+            );
+            return None;
+        }
+        Some(raw) => match raw.parse::<u64>() {
+            Ok(n) => n,
+            Err(_) => {
+                diagnostics.push(
+                    Diagnostic::new(
+                        DiagnosticCode::W004InvalidRateLimit,
+                        "ratelimit.average is not a valid integer, rate limit disabled",
+                    )
+                    .with_label(&avg_key)
+                    .with_value(raw),
+                );
+                return None;
+            }
+        },
+    };
+
+    let burst = match burst_raw {
+        None => average,
+        Some(raw) => match raw.parse::<u64>() {
+            Ok(n) => n,
+            Err(_) => {
+                diagnostics.push(
+                    Diagnostic::new(
+                        DiagnosticCode::W004InvalidRateLimit,
+                        "ratelimit.burst is not a valid integer, falling back to average",
+                    )
+                    .with_label(&burst_key)
+                    .with_value(raw),
+                );
+                average
+            }
+        },
+    };
+
+    Some(RateLimitConfig { average, burst })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn absent_returns_none_quietly() {
+        let mut diags = Vec::new();
+        assert!(parse_rate_limit(&labels(&[]), "sozune.http.web.", &mut diags).is_none());
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn average_only_uses_average_as_burst() {
+        let mut diags = Vec::new();
+        let r = parse_rate_limit(
+            &labels(&[("sozune.http.web.ratelimit.average", "100")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(r.average, 100);
+        assert_eq!(r.burst, 100);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn average_and_burst_used_when_both_set() {
+        let mut diags = Vec::new();
+        let r = parse_rate_limit(
+            &labels(&[
+                ("sozune.http.web.ratelimit.average", "100"),
+                ("sozune.http.web.ratelimit.burst", "200"),
+            ]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(r.average, 100);
+        assert_eq!(r.burst, 200);
+    }
+
+    #[test]
+    fn burst_without_average_emits_w004() {
+        let mut diags = Vec::new();
+        assert!(parse_rate_limit(
+            &labels(&[("sozune.http.web.ratelimit.burst", "200")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .is_none());
+        assert_eq!(diags[0].code, DiagnosticCode::W004InvalidRateLimit);
+    }
+
+    #[test]
+    fn invalid_average_emits_w004() {
+        let mut diags = Vec::new();
+        assert!(parse_rate_limit(
+            &labels(&[("sozune.http.web.ratelimit.average", "abc")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .is_none());
+        assert_eq!(diags[0].code, DiagnosticCode::W004InvalidRateLimit);
+    }
+
+    #[test]
+    fn invalid_burst_falls_back_to_average() {
+        let mut diags = Vec::new();
+        let r = parse_rate_limit(
+            &labels(&[
+                ("sozune.http.web.ratelimit.average", "50"),
+                ("sozune.http.web.ratelimit.burst", "loads"),
+            ]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(r.average, 50);
+        assert_eq!(r.burst, 50);
+        assert_eq!(diags[0].code, DiagnosticCode::W004InvalidRateLimit);
+    }
+}

--- a/src/labels/fields/redirect.rs
+++ b/src/labels/fields/redirect.rs
@@ -1,0 +1,163 @@
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::model::{RedirectPolicy, RedirectScheme};
+use std::collections::HashMap;
+
+pub fn parse_redirect_policy(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<RedirectPolicy> {
+    let key = format!("{prefix}redirect");
+    let raw = labels.get(&key)?;
+    match raw.as_str() {
+        "forward" => Some(RedirectPolicy::Forward),
+        "permanent" => Some(RedirectPolicy::Permanent),
+        "unauthorized" => Some(RedirectPolicy::Unauthorized),
+        _ => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::W005InvalidRedirectPolicy,
+                    "redirect policy not recognized, ignoring",
+                )
+                .with_label(&key)
+                .with_value(raw)
+                .with_hint("expected one of: forward | permanent | unauthorized"),
+            );
+            None
+        }
+    }
+}
+
+pub fn parse_redirect_scheme(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<RedirectScheme> {
+    let key = format!("{prefix}redirectScheme");
+    let raw = labels.get(&key)?;
+    match raw.as_str() {
+        "use_same" => Some(RedirectScheme::UseSame),
+        "use_http" => Some(RedirectScheme::UseHttp),
+        "use_https" => Some(RedirectScheme::UseHttps),
+        _ => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::W006InvalidRedirectScheme,
+                    "redirect scheme not recognized, ignoring",
+                )
+                .with_label(&key)
+                .with_value(raw)
+                .with_hint("expected one of: use_same | use_http | use_https"),
+            );
+            None
+        }
+    }
+}
+
+pub fn parse_https_redirect_port(
+    labels: &HashMap<String, String>,
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<u16> {
+    let key = format!("{prefix}httpsRedirectPort");
+    let raw = labels.get(&key)?;
+    match raw.parse::<u16>() {
+        Ok(p) => Some(p),
+        Err(_) => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::W001InvalidPort,
+                    "httpsRedirectPort is not a valid u16, ignoring",
+                )
+                .with_label(&key)
+                .with_value(raw),
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn redirect_policy_parses_known_values() {
+        let mut diags = Vec::new();
+        assert_eq!(
+            parse_redirect_policy(
+                &labels(&[("sozune.http.web.redirect", "permanent")]),
+                "sozune.http.web.",
+                &mut diags,
+            ),
+            Some(RedirectPolicy::Permanent),
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn redirect_policy_unknown_emits_w005() {
+        let mut diags = Vec::new();
+        let r = parse_redirect_policy(
+            &labels(&[("sozune.http.web.redirect", "later")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(r, None);
+        assert_eq!(diags[0].code, DiagnosticCode::W005InvalidRedirectPolicy);
+    }
+
+    #[test]
+    fn redirect_policy_absent_returns_none_quietly() {
+        let mut diags = Vec::new();
+        assert_eq!(
+            parse_redirect_policy(&labels(&[]), "sozune.http.web.", &mut diags),
+            None,
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn redirect_scheme_parses_known_values() {
+        let mut diags = Vec::new();
+        assert_eq!(
+            parse_redirect_scheme(
+                &labels(&[("sozune.http.web.redirectScheme", "use_https")]),
+                "sozune.http.web.",
+                &mut diags,
+            ),
+            Some(RedirectScheme::UseHttps),
+        );
+    }
+
+    #[test]
+    fn redirect_scheme_unknown_emits_w006() {
+        let mut diags = Vec::new();
+        let r = parse_redirect_scheme(
+            &labels(&[("sozune.http.web.redirectScheme", "tls")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(r, None);
+        assert_eq!(diags[0].code, DiagnosticCode::W006InvalidRedirectScheme);
+    }
+
+    #[test]
+    fn https_redirect_port_invalid_emits_w001() {
+        let mut diags = Vec::new();
+        let p = parse_https_redirect_port(
+            &labels(&[("sozune.http.web.httpsRedirectPort", "abc")]),
+            "sozune.http.web.",
+            &mut diags,
+        );
+        assert_eq!(p, None);
+        assert_eq!(diags[0].code, DiagnosticCode::W001InvalidPort);
+    }
+}

--- a/src/labels/mod.rs
+++ b/src/labels/mod.rs
@@ -11,6 +11,7 @@
 pub mod candidate;
 pub mod diagnostic;
 pub mod fields;
+pub mod network;
 pub mod parser;
 
 pub use candidate::{Candidate, NetworkInfo};

--- a/src/labels/mod.rs
+++ b/src/labels/mod.rs
@@ -1,0 +1,18 @@
+//! Provider-agnostic label parsing and validation.
+//!
+//! Each provider (docker, file, nomad, k8s) produces `Candidate` values from its
+//! native source. The shared parser turns a `Candidate` into a `ParseResult`
+//! containing the entrypoints sozune would create plus a list of `Diagnostic`
+//! describing every silent fallback or skip the parser had to make.
+//!
+//! Both the runtime and `sozune validate` consume the same parser, so what
+//! validate reports cannot drift from what production actually does.
+
+pub mod candidate;
+pub mod diagnostic;
+pub mod fields;
+pub mod parser;
+
+pub use candidate::{Candidate, NetworkInfo};
+pub use diagnostic::{Diagnostic, DiagnosticCode, ParseResult, Severity};
+pub use parser::parse;

--- a/src/labels/network.rs
+++ b/src/labels/network.rs
@@ -1,0 +1,140 @@
+use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+
+const LOCALHOST_FALLBACK: &str = "127.0.0.1";
+
+/// Resolve the backend IP for a candidate.
+///
+/// Order:
+/// 1. If `sozune.network=<name>` is set, use the IP from that network.
+/// 2. Otherwise the first network with a non-empty IP.
+/// 3. Otherwise `127.0.0.1` with `W010`.
+///
+/// If a preferred network is requested but not attached, emits `W009` and
+/// continues with the fallback.
+pub fn resolve_ip(candidate: &Candidate, diagnostics: &mut Vec<Diagnostic>) -> String {
+    let preferred = candidate.labels.get("sozune.network").cloned();
+
+    if let Some(ref name) = preferred {
+        match find_network(&candidate.networks, name) {
+            Some(ip) => return ip,
+            None => {
+                diagnostics.push(
+                    Diagnostic::new(
+                        DiagnosticCode::W009NetworkNotFound,
+                        format!("preferred network '{name}' not attached, falling back"),
+                    )
+                    .with_label("sozune.network")
+                    .with_value(name)
+                    .with_hint("ensure the container is attached to this network"),
+                );
+            }
+        }
+    }
+
+    if let Some(ip) = first_available(&candidate.networks) {
+        return ip;
+    }
+
+    diagnostics.push(
+        Diagnostic::new(
+            DiagnosticCode::W010NoIpFellBackToLocalhost,
+            "no usable network IP found, using 127.0.0.1",
+        )
+        .with_hint("attach the container to a routable network"),
+    );
+    LOCALHOST_FALLBACK.to_string()
+}
+
+fn find_network(networks: &[NetworkInfo], name: &str) -> Option<String> {
+    networks
+        .iter()
+        .find(|n| n.name == name)
+        .and_then(|n| n.ip.clone())
+        .filter(|ip| !ip.is_empty())
+}
+
+fn first_available(networks: &[NetworkInfo]) -> Option<String> {
+    networks
+        .iter()
+        .filter_map(|n| n.ip.clone())
+        .find(|ip| !ip.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn candidate(labels: &[(&str, &str)], networks: Vec<NetworkInfo>) -> Candidate {
+        Candidate {
+            provider: "test",
+            id: "id".into(),
+            display_name: "name".into(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<HashMap<_, _>>(),
+            networks,
+            enabled_default: false,
+        }
+    }
+
+    fn net(name: &str, ip: Option<&str>) -> NetworkInfo {
+        NetworkInfo {
+            name: name.to_string(),
+            ip: ip.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn picks_preferred_network_when_present() {
+        let mut diags = Vec::new();
+        let c = candidate(
+            &[("sozune.network", "internal")],
+            vec![
+                net("bridge", Some("172.18.0.2")),
+                net("internal", Some("10.0.0.5")),
+            ],
+        );
+        assert_eq!(resolve_ip(&c, &mut diags), "10.0.0.5");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn missing_preferred_emits_w009_and_falls_back() {
+        let mut diags = Vec::new();
+        let c = candidate(
+            &[("sozune.network", "missing")],
+            vec![net("bridge", Some("172.18.0.2"))],
+        );
+        assert_eq!(resolve_ip(&c, &mut diags), "172.18.0.2");
+        assert_eq!(diags[0].code, DiagnosticCode::W009NetworkNotFound);
+    }
+
+    #[test]
+    fn first_network_used_without_preference() {
+        let mut diags = Vec::new();
+        let c = candidate(&[], vec![net("bridge", Some("172.18.0.2"))]);
+        assert_eq!(resolve_ip(&c, &mut diags), "172.18.0.2");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn empty_ip_skipped_falls_through() {
+        let mut diags = Vec::new();
+        let c = candidate(
+            &[],
+            vec![net("a", Some("")), net("b", None), net("c", Some("10.0.0.9"))],
+        );
+        assert_eq!(resolve_ip(&c, &mut diags), "10.0.0.9");
+    }
+
+    #[test]
+    fn no_networks_emits_w010_and_uses_localhost() {
+        let mut diags = Vec::new();
+        let c = candidate(&[], vec![]);
+        assert_eq!(resolve_ip(&c, &mut diags), "127.0.0.1");
+        assert_eq!(diags[0].code, DiagnosticCode::W010NoIpFellBackToLocalhost);
+    }
+}

--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -1,9 +1,382 @@
-use super::{Candidate, ParseResult};
+use std::collections::{HashMap, HashSet};
 
-/// Parse a `Candidate` into routing entrypoints and diagnostics.
-///
-/// This is a stub. Real logic lands in step 5 of the implementation plan
-/// (`.issues/validate-command.md`).
-pub fn parse(_candidate: &Candidate) -> ParseResult {
-    ParseResult::default()
+use crate::labels::candidate::Candidate;
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode, ParseResult};
+use crate::labels::fields::{auth, core, headers, host, path, ratelimit, redirect};
+use crate::labels::network;
+use crate::model::{Entrypoint, EntrypointConfig, Protocol};
+
+const SUPPORTED_PROTOCOLS: &[&str] = &["http", "tcp", "udp"];
+
+pub fn parse(candidate: &Candidate) -> ParseResult {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+    if !is_enabled(candidate) {
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticCode::E001Disabled,
+                "candidate is not enabled for sozune",
+            )
+            .with_label("sozune.enable")
+            .with_hint("set `sozune.enable=true` or set `expose_by_default: true` in the provider config"),
+        );
+        return ParseResult {
+            entrypoints: HashMap::new(),
+            diagnostics,
+        };
+    }
+
+    let services = discover_services(&candidate.labels, &mut diagnostics);
+    if services.is_empty() {
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticCode::E004NoServices,
+                "candidate is enabled but declares no sozune.<protocol>.<service>.* labels",
+            )
+            .with_hint("add labels like `sozune.http.web.host=<your-domain>`"),
+        );
+        return ParseResult {
+            entrypoints: HashMap::new(),
+            diagnostics,
+        };
+    }
+
+    let backend_ip = network::resolve_ip(candidate, &mut diagnostics);
+
+    let mut entrypoints = HashMap::new();
+    for (protocol, service_name) in services {
+        if let Some(entrypoint) = build_entrypoint(
+            &candidate.labels,
+            &protocol,
+            &service_name,
+            &backend_ip,
+            &mut diagnostics,
+        ) {
+            let key = format!("{protocol}_{service_name}");
+            entrypoints.insert(key, entrypoint);
+        }
+    }
+
+    ParseResult {
+        entrypoints,
+        diagnostics,
+    }
+}
+
+fn is_enabled(candidate: &Candidate) -> bool {
+    candidate
+        .labels
+        .get("sozune.enable")
+        .map_or(candidate.enabled_default, |v| v == "true")
+}
+
+/// Walk all labels and collect distinct (protocol, service_name) pairs.
+/// Unknown protocols (anything other than http/tcp/udp) emit `W012` and are
+/// skipped.
+fn discover_services(
+    labels: &HashMap<String, String>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Vec<(String, String)> {
+    let mut services: HashSet<(String, String)> = HashSet::new();
+    let mut unknown_protocols: HashSet<String> = HashSet::new();
+
+    for key in labels.keys() {
+        let Some(rest) = key.strip_prefix("sozune.") else {
+            continue;
+        };
+        // Skip global labels that aren't service labels.
+        if matches!(rest, "enable" | "network") {
+            continue;
+        }
+        let mut parts = rest.splitn(3, '.');
+        let Some(protocol) = parts.next() else { continue };
+        let Some(service) = parts.next() else { continue };
+        if parts.next().is_none() {
+            // No third segment means this isn't a service label.
+            continue;
+        }
+
+        if !SUPPORTED_PROTOCOLS.contains(&protocol) {
+            unknown_protocols.insert(protocol.to_string());
+            continue;
+        }
+        services.insert((protocol.to_string(), service.to_string()));
+    }
+
+    for proto in unknown_protocols {
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticCode::W012InvalidProtocol,
+                format!("unsupported protocol '{proto}', labels ignored"),
+            )
+            .with_value(&proto)
+            .with_hint(format!(
+                "supported protocols: {}",
+                SUPPORTED_PROTOCOLS.join(", ")
+            )),
+        );
+    }
+
+    let mut sorted: Vec<_> = services.into_iter().collect();
+    sorted.sort();
+    sorted
+}
+
+fn build_entrypoint(
+    labels: &HashMap<String, String>,
+    protocol: &str,
+    service_name: &str,
+    backend_ip: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Entrypoint> {
+    let prefix = format!("sozune.{protocol}.{service_name}.");
+
+    let hostnames = host::parse_hostnames(labels, &prefix, diagnostics)?;
+    let port = core::parse_port(labels, &prefix, protocol, diagnostics);
+
+    let path = if protocol == "http" {
+        Some(path::parse_path(labels, &prefix, diagnostics))
+    } else {
+        None
+    };
+
+    let tls = core::parse_bool(labels, &format!("{prefix}tls"));
+    let strip_prefix = core::parse_bool(labels, &format!("{prefix}stripPrefix"));
+    let https_redirect = core::parse_bool(labels, &format!("{prefix}httpsRedirect"));
+    let https_redirect_port = redirect::parse_https_redirect_port(labels, &prefix, diagnostics);
+    let redirect = redirect::parse_redirect_policy(labels, &prefix, diagnostics);
+    let redirect_scheme = redirect::parse_redirect_scheme(labels, &prefix, diagnostics);
+    let redirect_template = labels.get(&format!("{prefix}redirectTemplate")).cloned();
+    let www_authenticate = labels.get(&format!("{prefix}wwwAuthenticate")).cloned();
+    let priority = core::parse_priority(labels, &prefix, diagnostics);
+    let backend_timeout = core::parse_backend_timeout(labels, &prefix, diagnostics);
+    let rate_limit = ratelimit::parse_rate_limit(labels, &prefix, diagnostics);
+    let sticky_session = core::parse_bool(labels, &format!("{prefix}stickySession"));
+    let compress = core::parse_bool(labels, &format!("{prefix}compress"));
+    let auth = auth::parse_auth(labels, &prefix, diagnostics);
+    let headers = headers::parse_headers(labels, &prefix, diagnostics);
+
+    let protocol_enum = match protocol {
+        "http" => Protocol::Http,
+        "tcp" => Protocol::Tcp,
+        "udp" => Protocol::Udp,
+        _ => return None,
+    };
+
+    Some(Entrypoint {
+        id: format!("{protocol}_{service_name}"),
+        backends: vec![backend_ip.to_string()],
+        name: service_name.to_string(),
+        protocol: protocol_enum,
+        backend_weights: HashMap::new(),
+        config: EntrypointConfig {
+            hostnames,
+            port,
+            path,
+            tls,
+            strip_prefix,
+            https_redirect,
+            https_redirect_port,
+            redirect,
+            redirect_scheme,
+            redirect_template,
+            www_authenticate,
+            priority,
+            auth,
+            headers,
+            backend_timeout,
+            rate_limit,
+            sticky_session,
+            compress,
+        },
+        source: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::labels::candidate::NetworkInfo;
+
+    fn candidate(labels: &[(&str, &str)], networks: Vec<NetworkInfo>) -> Candidate {
+        Candidate {
+            provider: "test",
+            id: "container-1".into(),
+            display_name: "test-container".into(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            networks,
+            enabled_default: false,
+        }
+    }
+
+    fn net(name: &str, ip: &str) -> NetworkInfo {
+        NetworkInfo {
+            name: name.into(),
+            ip: Some(ip.into()),
+        }
+    }
+
+    fn has_code(result: &ParseResult, code: DiagnosticCode) -> bool {
+        result.diagnostics.iter().any(|d| d.code == code)
+    }
+
+    #[test]
+    fn disabled_candidate_returns_e001_and_no_entrypoints() {
+        let c = candidate(&[], vec![]);
+        let r = parse(&c);
+        assert!(r.entrypoints.is_empty());
+        assert!(has_code(&r, DiagnosticCode::E001Disabled));
+    }
+
+    #[test]
+    fn explicit_disable_overrides_enabled_default() {
+        let mut c = candidate(&[("sozune.enable", "false")], vec![]);
+        c.enabled_default = true;
+        let r = parse(&c);
+        assert!(has_code(&r, DiagnosticCode::E001Disabled));
+    }
+
+    #[test]
+    fn enabled_default_true_routes_without_label() {
+        let mut c = candidate(
+            &[("sozune.http.web.host", "example.com")],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        c.enabled_default = true;
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 1);
+        assert!(!has_code(&r, DiagnosticCode::E001Disabled));
+    }
+
+    #[test]
+    fn enabled_with_no_service_labels_emits_e004() {
+        let c = candidate(&[("sozune.enable", "true")], vec![]);
+        let r = parse(&c);
+        assert!(r.entrypoints.is_empty());
+        assert!(has_code(&r, DiagnosticCode::E004NoServices));
+    }
+
+    #[test]
+    fn missing_host_emits_e002_and_drops_service() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.port", "8080"),
+            ],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        let r = parse(&c);
+        assert!(r.entrypoints.is_empty());
+        assert!(has_code(&r, DiagnosticCode::E002MissingHost));
+    }
+
+    #[test]
+    fn happy_path_routes_with_no_diagnostics_above_info() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+                ("sozune.http.web.port", "8080"),
+                ("sozune.http.web.path", "/api"),
+            ],
+            vec![net("bridge", "172.18.0.4")],
+        );
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 1);
+        assert!(!r.has_errors());
+        let ep = r.entrypoints.get("http_web").unwrap();
+        assert_eq!(ep.config.port, 8080);
+        assert_eq!(ep.config.hostnames, vec!["example.com"]);
+        assert_eq!(ep.backends, vec!["172.18.0.4"]);
+    }
+
+    #[test]
+    fn invalid_port_falls_back_and_still_routes_with_w001() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+                ("sozune.http.web.port", "abc"),
+            ],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 1);
+        assert!(has_code(&r, DiagnosticCode::W001InvalidPort));
+        assert_eq!(r.entrypoints.get("http_web").unwrap().config.port, 80);
+    }
+
+    #[test]
+    fn unknown_protocol_emits_w012_and_is_skipped() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.ftp.legacy.host", "example.com"),
+                ("sozune.http.web.host", "example.com"),
+            ],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 1);
+        assert!(r.entrypoints.contains_key("http_web"));
+        assert!(has_code(&r, DiagnosticCode::W012InvalidProtocol));
+    }
+
+    #[test]
+    fn no_networks_falls_back_to_localhost_with_w010() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+            ],
+            vec![],
+        );
+        let r = parse(&c);
+        assert!(has_code(&r, DiagnosticCode::W010NoIpFellBackToLocalhost));
+        assert_eq!(
+            r.entrypoints.get("http_web").unwrap().backends,
+            vec!["127.0.0.1"]
+        );
+    }
+
+    #[test]
+    fn multiple_services_per_candidate_each_routed() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "web.example.com"),
+                ("sozune.http.api.host", "api.example.com"),
+                ("sozune.http.api.port", "9000"),
+                ("sozune.tcp.db.host", "db.example.com"),
+            ],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 3);
+        assert_eq!(r.entrypoints.get("http_api").unwrap().config.port, 9000);
+        assert!(matches!(
+            r.entrypoints.get("tcp_db").unwrap().protocol,
+            Protocol::Tcp
+        ));
+    }
+
+    #[test]
+    fn preferred_network_used_when_attached() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.network", "internal"),
+                ("sozune.http.web.host", "example.com"),
+            ],
+            vec![net("bridge", "172.18.0.4"), net("internal", "10.0.0.5")],
+        );
+        let r = parse(&c);
+        assert_eq!(
+            r.entrypoints.get("http_web").unwrap().backends,
+            vec!["10.0.0.5"]
+        );
+    }
 }

--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -1,0 +1,9 @@
+use super::{Candidate, ParseResult};
+
+/// Parse a `Candidate` into routing entrypoints and diagnostics.
+///
+/// This is a stub. Real logic lands in step 5 of the implementation plan
+/// (`.issues/validate-command.md`).
+pub fn parse(_candidate: &Candidate) -> ParseResult {
+    ParseResult::default()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::config::AppConfig;
 mod acme;
 mod api;
 mod config;
+mod labels;
 mod middleware;
 mod model;
 mod provider;

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -1,20 +1,19 @@
 use crate::config::DockerConfig;
-use crate::model::{
-    AuthConfig, BasicAuthUser, Entrypoint, EntrypointConfig, PathConfig, PathRuleType, Protocol,
-    RateLimitConfig,
-};
+use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::diagnostic::{Diagnostic, Severity};
+use crate::labels::{self};
+use crate::model::Entrypoint;
 use crate::provider::Provider;
 use async_trait::async_trait;
 use bollard::{
     Docker,
-    models::EventMessage,
     query_parameters::{EventsOptions, InspectContainerOptions, ListContainersOptions},
 };
 use futures_util::StreamExt;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub struct DockerProvider {
     docker: Docker,
@@ -40,12 +39,6 @@ impl Provider for DockerProvider {
 }
 
 impl DockerProvider {
-    /// Check if container should be exposed based on sozune.enable label and expose_by_default config
-    fn should_expose_container(&self, labels: &HashMap<String, String>) -> bool {
-        labels
-            .get("sozune.enable")
-            .map_or(self.config.expose_by_default, |v| v == "true")
-    }
     pub fn new(config: DockerConfig) -> Result<Self, bollard::errors::Error> {
         let docker = if config.endpoint.starts_with("unix://") {
             Docker::connect_with_socket(&config.endpoint, 120, bollard::API_DEFAULT_VERSION)?
@@ -339,43 +332,19 @@ impl DockerProvider {
         Ok(())
     }
 
-    /// Get entrypoints for a specific container
+    /// Get entrypoints for a specific container.
     async fn get_container_entrypoints(
         &self,
         container_id: &str,
     ) -> Result<HashMap<String, Entrypoint>, bollard::errors::Error> {
-        let mut entrypoints = HashMap::new();
+        let candidate = match self.inspect_to_candidate(container_id).await? {
+            Some(c) => c,
+            None => return Ok(HashMap::new()),
+        };
 
-        let container = self
-            .docker
-            .inspect_container(container_id, None::<InspectContainerOptions>)
-            .await?;
-
-        if let Some(config) = container.config {
-            if let Some(labels) = config.labels {
-                // Check if Sozune is enabled for this container
-                if !self.should_expose_container(&labels) {
-                    return Ok(entrypoints);
-                }
-
-                // Get container IP address
-                let container_ip = self
-                    .get_container_ip(container_id)
-                    .await
-                    .unwrap_or_else(|| "127.0.0.1".to_string());
-
-                // Parse labels by protocol
-                for protocol in &["http", "tcp", "udp"] {
-                    let protocol_entrypoints =
-                        self.parse_protocol_labels(&labels, protocol, &container_ip);
-                    for (key, entrypoint) in protocol_entrypoints {
-                        entrypoints.insert(key, entrypoint);
-                    }
-                }
-            }
-        }
-
-        Ok(entrypoints)
+        let result = labels::parse(&candidate);
+        log_diagnostics(&candidate, &result.diagnostics);
+        Ok(result.entrypoints)
     }
 
     pub async fn get_entrypoints_from_containers(
@@ -392,45 +361,47 @@ impl DockerProvider {
             .await?;
 
         for container in containers {
-            if let Some(labels) = container.labels {
-                let container_id = container.id.unwrap_or_default();
+            let Some(container_labels) = container.labels else {
+                continue;
+            };
+            let container_id = container.id.unwrap_or_default();
 
-                // Check if Sozune is enabled for this container
-                if !self.should_expose_container(&labels) {
-                    info!(
-                        "Skipping container {} since Sozune is disabled",
-                        container_id
-                    );
-                    continue;
-                }
+            // Network info is only available via inspect, not list — fetch it.
+            let networks = self.extract_networks(&container_id).await;
+            let candidate = self.build_candidate(
+                container_id.clone(),
+                container_labels,
+                networks,
+            );
 
-                // Get container IP address
-                let container_ip = self
-                    .get_container_ip(&container_id)
-                    .await
-                    .unwrap_or_else(|| "127.0.0.1".to_string());
+            let result = labels::parse(&candidate);
+            log_diagnostics(&candidate, &result.diagnostics);
 
-                // Track container IP for cleanup on stop
-                if let Ok(mut ips) = self.container_ips.lock() {
-                    ips.insert(container_id.clone(), container_ip.clone());
-                }
+            if result.entrypoints.is_empty() {
+                continue;
+            }
 
-                // Parse labels by protocol
-                for protocol in &["http", "tcp", "udp"] {
-                    let protocol_entrypoints =
-                        self.parse_protocol_labels(&labels, protocol, &container_ip);
-                    for (key, entrypoint) in protocol_entrypoints {
-                        if let Some(existing) = entrypoints.get_mut(&key) {
-                            existing.backends.push(container_ip.clone());
-                            info!(
-                                "Added backend {} to existing entrypoint {}",
-                                container_ip, key
-                            );
-                        } else {
-                            entrypoints.insert(key.clone(), entrypoint);
-                            info!("Created new entrypoint {}", key);
-                        }
+            // Track the resolved backend IP for cleanup on stop. Every
+            // entrypoint produced by a single candidate carries the same
+            // backend list, so peek at the first.
+            if let Some(first) = result.entrypoints.values().next() {
+                if let Some(ip) = first.backends.first() {
+                    if let Ok(mut ips) = self.container_ips.lock() {
+                        ips.insert(container_id.clone(), ip.clone());
                     }
+                }
+            }
+
+            for (key, entrypoint) in result.entrypoints {
+                let backend_ip = entrypoint.backends.first().cloned().unwrap_or_default();
+                if let Some(existing) = entrypoints.get_mut(&key) {
+                    if !existing.backends.contains(&backend_ip) {
+                        existing.backends.push(backend_ip.clone());
+                        info!("Added backend {} to existing entrypoint {}", backend_ip, key);
+                    }
+                } else {
+                    entrypoints.insert(key.clone(), entrypoint);
+                    info!("Created new entrypoint {}", key);
                 }
             }
         }
@@ -438,551 +409,140 @@ impl DockerProvider {
         Ok(entrypoints)
     }
 
-    fn parse_protocol_labels(
+    /// Inspect a container and turn it into a `Candidate`. Returns `None` when
+    /// the container has no labels at all (sozune cannot route it either way).
+    async fn inspect_to_candidate(
         &self,
-        labels: &HashMap<String, String>,
-        protocol: &str,
-        container_ip: &str,
-    ) -> HashMap<String, Entrypoint> {
-        let mut entrypoints = HashMap::new();
-        let prefix = format!("sozune.{}.", protocol);
-
-        // Find all service names for this protocol
-        let mut service_names = std::collections::HashSet::new();
-        for key in labels.keys() {
-            if key.starts_with(&prefix) {
-                if let Some(rest) = key.strip_prefix(&prefix) {
-                    if let Some(service_name) = rest.split('.').next() {
-                        service_names.insert(service_name.to_string());
-                    }
-                }
-            }
-        }
-
-        // Create an entrypoint for each service
-        for service_name in service_names {
-            if let Some(entrypoint) =
-                self.create_entrypoint_from_labels(labels, protocol, &service_name, container_ip)
-            {
-                let key = format!("{}_{}", protocol, service_name);
-                entrypoints.insert(key, entrypoint);
-            }
-        }
-
-        entrypoints
-    }
-
-    fn create_entrypoint_from_labels(
-        &self,
-        labels: &HashMap<String, String>,
-        protocol: &str,
-        service_name: &str,
-        container_ip: &str,
-    ) -> Option<Entrypoint> {
-        let prefix = format!("sozune.{}.{}.", protocol, service_name);
-
-        // Get hostnames (required)
-        let hostnames_str = labels.get(&format!("{}host", prefix))?;
-        let hostnames: Vec<String> = hostnames_str
-            .split(',')
-            .map(|h| h.trim().to_string())
-            .collect();
-
-        // Port (default based on protocol)
-        let default_port = match protocol {
-            "http" => 80,
-            "https" => 443,
-            _ => 8080,
-        };
-        let port = labels
-            .get(&format!("{}port", prefix))
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(default_port);
-
-        let path = if protocol == "http" {
-            let exact_path = labels.get(&format!("{}path", prefix));
-            let prefix_path = labels.get(&format!("{}prefix", prefix));
-            let regex_path = labels.get(&format!("{}pathRegex", prefix));
-
-            match (exact_path, prefix_path, regex_path) {
-                (Some(path), _, _) => Some(PathConfig {
-                    rule_type: PathRuleType::Prefix,
-                    value: path.clone(),
-                }),
-                (None, Some(prefix), _) => Some(PathConfig {
-                    rule_type: PathRuleType::Prefix,
-                    value: prefix.clone(),
-                }),
-                (None, None, Some(regex)) => Some(PathConfig {
-                    rule_type: PathRuleType::Regex,
-                    value: regex.clone(),
-                }),
-                _ => Some(PathConfig {
-                    rule_type: PathRuleType::Prefix,
-                    value: "/".to_string(),
-                }),
-            }
-        } else {
-            None
-        };
-
-        let tls = labels
-            .get(&format!("{}tls", prefix))
-            .map_or(false, |v| v == "true");
-
-        let strip_prefix = labels
-            .get(&format!("{}stripPrefix", prefix))
-            .map_or(false, |v| v == "true");
-
-        let https_redirect = labels
-            .get(&format!("{}httpsRedirect", prefix))
-            .map_or(false, |v| v == "true");
-
-        let https_redirect_port = labels
-            .get(&format!("{}httpsRedirectPort", prefix))
-            .and_then(|p| p.parse().ok());
-
-        let redirect = labels
-            .get(&format!("{}redirect", prefix))
-            .and_then(|v| match v.as_str() {
-                "forward" => Some(crate::model::RedirectPolicy::Forward),
-                "permanent" => Some(crate::model::RedirectPolicy::Permanent),
-                "unauthorized" => Some(crate::model::RedirectPolicy::Unauthorized),
-                _ => {
-                    warn!("Invalid redirect policy '{}', expected forward|permanent|unauthorized", v);
-                    None
-                }
-            });
-
-        let redirect_scheme = labels
-            .get(&format!("{}redirectScheme", prefix))
-            .and_then(|v| match v.as_str() {
-                "use_same" => Some(crate::model::RedirectScheme::UseSame),
-                "use_http" => Some(crate::model::RedirectScheme::UseHttp),
-                "use_https" => Some(crate::model::RedirectScheme::UseHttps),
-                _ => {
-                    warn!("Invalid redirect scheme '{}', expected use_same|use_http|use_https", v);
-                    None
-                }
-            });
-
-        let redirect_template = labels
-            .get(&format!("{}redirectTemplate", prefix))
-            .cloned();
-
-        let www_authenticate = labels
-            .get(&format!("{}wwwAuthenticate", prefix))
-            .cloned();
-
-        let priority = labels
-            .get(&format!("{}priority", prefix))
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(0);
-
-        let backend_timeout = labels
-            .get(&format!("{}backendTimeout", prefix))
-            .and_then(|p| p.parse().ok());
-
-        let rate_limit = {
-            let average = labels
-                .get(&format!("{}ratelimit.average", prefix))
-                .and_then(|p| p.parse().ok());
-            let burst = labels
-                .get(&format!("{}ratelimit.burst", prefix))
-                .and_then(|p| p.parse().ok());
-            match (average, burst) {
-                (Some(avg), Some(b)) => Some(RateLimitConfig { average: avg, burst: b }),
-                (Some(avg), None) => Some(RateLimitConfig { average: avg, burst: avg }),
-                _ => None,
-            }
-        };
-
-        let sticky_session = labels
-            .get(&format!("{}stickySession", prefix))
-            .map_or(false, |v| v == "true");
-
-        let compress = labels
-            .get(&format!("{}compress", prefix))
-            .map_or(false, |v| v == "true");
-
-        let auth = self.parse_auth_labels(labels, &prefix);
-
-        let headers = self.parse_header_labels(labels, &prefix);
-
-        let protocol_enum = match protocol {
-            "http" => Protocol::Http,
-            "tcp" => Protocol::Tcp,
-            "udp" => Protocol::Udp,
-            _ => return None,
-        };
-
-        Some(Entrypoint {
-            id: format!("{}_{}", protocol, service_name),
-            backends: vec![container_ip.to_string()],
-            name: service_name.to_string(),
-            protocol: protocol_enum,
-            backend_weights: HashMap::new(),
-            config: EntrypointConfig {
-                hostnames,
-                port,
-                path,
-                tls,
-                strip_prefix,
-                https_redirect,
-                https_redirect_port,
-                redirect,
-                redirect_scheme,
-                redirect_template,
-                www_authenticate,
-                priority,
-                auth,
-                headers,
-                backend_timeout,
-                rate_limit,
-                sticky_session,
-                compress,
-            },
-            source: None, // Will be set by the caller
-        })
-    }
-
-    fn parse_auth_labels(
-        &self,
-        labels: &HashMap<String, String>,
-        prefix: &str,
-    ) -> Option<AuthConfig> {
-        let basic_auth_str = labels.get(&format!("{}auth.basic", prefix))?;
-        let users: Vec<BasicAuthUser> = basic_auth_str
-            .split(',')
-            .filter_map(|entry| {
-                let parts: Vec<&str> = entry.trim().splitn(2, ':').collect();
-                if parts.len() == 2 {
-                    Some(BasicAuthUser {
-                        username: parts[0].to_string(),
-                        password_hash: parts[1].to_string(),
-                    })
-                } else {
-                    warn!("Invalid basic auth format: {}", entry);
-                    None
-                }
-            })
-            .collect();
-
-        if users.is_empty() {
-            None
-        } else {
-            Some(AuthConfig { basic: Some(users) })
-        }
-    }
-
-    /// Headers that must not be injected from Docker labels to prevent
-    /// request smuggling, SSRF, and host header attacks.
-    const BLOCKED_HEADERS: &[&str] = &[
-        "host",
-        "transfer-encoding",
-        "content-length",
-        "connection",
-        "upgrade",
-        "x-forwarded-for",
-        "x-forwarded-host",
-        "x-forwarded-proto",
-        "x-real-ip",
-        "forwarded",
-        "cookie",
-        "authorization",
-        "proxy-authorization",
-        "proxy-connection",
-        "te",
-        "trailer",
-    ];
-
-    fn parse_header_labels(
-        &self,
-        labels: &HashMap<String, String>,
-        prefix: &str,
-    ) -> Vec<crate::model::HeaderConfig> {
-        let header_prefix = format!("{}headers.", prefix);
-        let mut headers = Vec::new();
-
-        for (key, value) in labels {
-            let Some(remainder) = key.strip_prefix(&header_prefix) else {
-                continue;
-            };
-
-            let (direction, header_name) = if let Some(name) = remainder.strip_prefix("response.") {
-                (crate::model::HeaderDirection::Response, name)
-            } else if let Some(name) = remainder.strip_prefix("both.") {
-                (crate::model::HeaderDirection::Both, name)
-            } else {
-                (crate::model::HeaderDirection::Request, remainder)
-            };
-
-            if Self::BLOCKED_HEADERS
-                .iter()
-                .any(|blocked| blocked.eq_ignore_ascii_case(header_name))
-            {
-                warn!(
-                    "Ignoring blocked header '{}' from Docker label",
-                    header_name
-                );
-                continue;
-            }
-
-            headers.push(crate::model::HeaderConfig {
-                name: header_name.to_string(),
-                value: value.clone(),
-                direction,
-            });
-        }
-
-        headers
-    }
-
-    async fn get_container_ip(&self, container_id: &str) -> Option<String> {
+        container_id: &str,
+    ) -> Result<Option<Candidate>, bollard::errors::Error> {
         let container = self
             .docker
             .inspect_container(container_id, None::<InspectContainerOptions>)
-            .await
-            .ok()?;
+            .await?;
 
-        let preferred_network = container
-            .config
-            .as_ref()
-            .and_then(|config| config.labels.as_ref())
-            .and_then(|labels| labels.get("sozune.network"))
-            .map(|network| network.clone());
+        let display_name = container
+            .name
+            .clone()
+            .map(|n| n.trim_start_matches('/').to_string())
+            .unwrap_or_else(|| container_id.to_string());
 
-        if let Some(network_settings) = container.network_settings {
-            if let Some(networks) = network_settings.networks {
-                // If a preferred network is specified, use it
-                if let Some(preferred) = &preferred_network {
-                    if let Some(network) = networks.get(preferred) {
-                        if let Some(ip) = &network.ip_address {
-                            if !ip.is_empty() {
-                                return Some(ip.clone());
-                            }
-                        }
-                    }
-                }
+        let Some(config) = container.config else {
+            return Ok(None);
+        };
+        let Some(labels) = config.labels else {
+            return Ok(None);
+        };
 
-                // Fallback: take the first IP found in networks
-                for (_, network) in networks {
-                    if let Some(ip) = network.ip_address {
-                        if !ip.is_empty() {
-                            return Some(ip);
-                        }
-                    }
-                }
-            }
+        let networks = container
+            .network_settings
+            .and_then(|s| s.networks)
+            .map(|nets| {
+                nets.into_iter()
+                    .map(|(name, n)| NetworkInfo {
+                        name,
+                        ip: n.ip_address.filter(|ip| !ip.is_empty()),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(Some(Candidate {
+            provider: "docker",
+            id: container_id.to_string(),
+            display_name,
+            labels,
+            networks,
+            enabled_default: self.config.expose_by_default,
+        }))
+    }
+
+    /// Build a `Candidate` from labels already obtained via list_containers
+    /// (which omits network_settings). Caller supplies `networks` separately.
+    fn build_candidate(
+        &self,
+        container_id: String,
+        labels: HashMap<String, String>,
+        networks: Vec<NetworkInfo>,
+    ) -> Candidate {
+        Candidate {
+            provider: "docker",
+            display_name: container_id.clone(),
+            id: container_id,
+            labels,
+            networks,
+            enabled_default: self.config.expose_by_default,
         }
+    }
 
-        None
+    /// Fetch network information for a container via inspect.
+    async fn extract_networks(&self, container_id: &str) -> Vec<NetworkInfo> {
+        let container = match self
+            .docker
+            .inspect_container(container_id, None::<InspectContainerOptions>)
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                debug!(
+                    "Could not inspect container {} for networks: {}",
+                    container_id, e
+                );
+                return Vec::new();
+            }
+        };
+
+        container
+            .network_settings
+            .and_then(|s| s.networks)
+            .map(|nets| {
+                nets.into_iter()
+                    .map(|(name, n)| NetworkInfo {
+                        name,
+                        ip: n.ip_address.filter(|ip| !ip.is_empty()),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Resolve a container's backend IP using the shared label parser.
+    /// Used by the event listener to track backends for cleanup on stop.
+    async fn get_container_ip(&self, container_id: &str) -> Option<String> {
+        let candidate = self.inspect_to_candidate(container_id).await.ok().flatten()?;
+        let mut throwaway = Vec::new();
+        let ip = labels::network::resolve_ip(&candidate, &mut throwaway);
+        if ip == "127.0.0.1" { None } else { Some(ip) }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashMap;
-
-    fn create_test_labels() -> HashMap<String, String> {
-        let mut labels = HashMap::new();
-        labels.insert("sozune.enable".to_string(), "true".to_string());
-
-        // Web service HTTP
-        labels.insert(
-            "sozune.http.web.host".to_string(),
-            "example.com,www.example.com".to_string(),
-        );
-        labels.insert("sozune.http.web.port".to_string(), "8080".to_string());
-        labels.insert("sozune.http.web.prefix".to_string(), "/api".to_string());
-        labels.insert("sozune.http.web.tls".to_string(), "true".to_string());
-        labels.insert(
-            "sozune.http.web.stripPrefix".to_string(),
-            "false".to_string(),
-        );
-        labels.insert("sozune.http.web.priority".to_string(), "10".to_string());
-        labels.insert(
-            "sozune.http.web.auth.basic".to_string(),
-            "admin:$2b$10$hash1,user:$2b$10$hash2".to_string(),
-        );
-        labels.insert(
-            "sozune.http.web.headers.X-Custom-Header".to_string(),
-            "custom-value".to_string(),
-        );
-
-        // API service HTTP
-        labels.insert(
-            "sozune.http.api.host".to_string(),
-            "api.example.com".to_string(),
-        );
-        labels.insert("sozune.http.api.port".to_string(), "3000".to_string());
-        labels.insert("sozune.http.api.path".to_string(), "/exact".to_string());
-
-        // TCP service
-        labels.insert(
-            "sozune.tcp.db.host".to_string(),
-            "db.example.com".to_string(),
-        );
-        labels.insert("sozune.tcp.db.port".to_string(), "5432".to_string());
-
-        labels
-    }
-
-    #[test]
-    fn test_parse_protocol_labels() {
-        let provider = DockerProvider {
-            docker: Docker::connect_with_local_defaults().unwrap(),
-            config: Default::default(),
-            container_ips: std::sync::Mutex::new(HashMap::new()),
-        };
-        let labels = create_test_labels();
-        let container_ip = "192.168.1.100";
-
-        // Test parsing HTTP labels
-        let http_entrypoints = provider.parse_protocol_labels(&labels, "http", container_ip);
-
-        // Should have 2 HTTP services: web and api
-        assert_eq!(http_entrypoints.len(), 2);
-
-        // Test web service
-        let web_entrypoint = http_entrypoints.get("http_web").unwrap();
-        assert_eq!(web_entrypoint.name, "web");
-        assert!(matches!(web_entrypoint.protocol, Protocol::Http));
-        assert_eq!(
-            web_entrypoint.config.hostnames,
-            vec!["example.com", "www.example.com"]
-        );
-        assert_eq!(web_entrypoint.config.port, 8080);
-        assert_eq!(web_entrypoint.config.tls, true);
-        assert_eq!(web_entrypoint.config.strip_prefix, false);
-        assert_eq!(web_entrypoint.config.priority, 10);
-
-        let path_config = web_entrypoint.config.path.as_ref().unwrap();
-        assert_eq!(path_config.value, "/api");
-        assert!(matches!(path_config.rule_type, PathRuleType::Prefix));
-
-        let auth = web_entrypoint.config.auth.as_ref().unwrap();
-        let basic_users = auth.basic.as_ref().unwrap();
-        assert_eq!(basic_users.len(), 2);
-        assert_eq!(basic_users[0].username, "admin");
-        assert_eq!(basic_users[0].password_hash, "$2b$10$hash1");
-
-        let custom_header = web_entrypoint
-            .config
-            .headers
-            .iter()
-            .find(|h| h.name == "X-Custom-Header")
-            .expect("X-Custom-Header should be parsed");
-        assert_eq!(custom_header.value, "custom-value");
-        assert_eq!(custom_header.direction, crate::model::HeaderDirection::Request);
-
-        // Test api service
-        let api_entrypoint = http_entrypoints.get("http_api").unwrap();
-        assert_eq!(api_entrypoint.name, "api");
-        assert_eq!(api_entrypoint.config.hostnames, vec!["api.example.com"]);
-        assert_eq!(api_entrypoint.config.port, 3000);
-
-        let path_config = api_entrypoint.config.path.as_ref().unwrap();
-        assert_eq!(path_config.value, "/exact");
-        assert!(matches!(path_config.rule_type, PathRuleType::Prefix));
-    }
-
-    #[test]
-    fn test_parse_tcp_labels() {
-        let provider = DockerProvider {
-            docker: Docker::connect_with_local_defaults().unwrap(),
-            config: Default::default(),
-            container_ips: std::sync::Mutex::new(HashMap::new()),
-        };
-        let labels = create_test_labels();
-        let container_ip = "192.168.1.100";
-
-        // Test parsing TCP labels
-        let tcp_entrypoints = provider.parse_protocol_labels(&labels, "tcp", container_ip);
-
-        // Should have 1 TCP service: db
-        assert_eq!(tcp_entrypoints.len(), 1);
-
-        let db_entrypoint = tcp_entrypoints.get("tcp_db").unwrap();
-        assert_eq!(db_entrypoint.name, "db");
-        assert!(matches!(db_entrypoint.protocol, Protocol::Tcp));
-        assert_eq!(db_entrypoint.config.hostnames, vec!["db.example.com"]);
-        assert_eq!(db_entrypoint.config.port, 5432);
-        assert_eq!(db_entrypoint.config.path, None);
-    }
-
-    #[test]
-    fn test_parse_auth_labels() {
-        let provider = DockerProvider {
-            docker: Docker::connect_with_local_defaults().unwrap(),
-            config: Default::default(),
-            container_ips: std::sync::Mutex::new(HashMap::new()),
-        };
-        let labels = create_test_labels();
-
-        let auth = provider.parse_auth_labels(&labels, "sozune.http.web.");
-        assert!(auth.is_some());
-
-        let auth = auth.unwrap();
-        let basic_users = auth.basic.unwrap();
-        assert_eq!(basic_users.len(), 2);
-        assert_eq!(basic_users[0].username, "admin");
-        assert_eq!(basic_users[1].username, "user");
-    }
-
-    #[test]
-    fn test_parse_header_labels() {
-        let provider = DockerProvider {
-            docker: Docker::connect_with_local_defaults().unwrap(),
-            config: Default::default(),
-            container_ips: std::sync::Mutex::new(HashMap::new()),
-        };
-        let labels = create_test_labels();
-
-        let headers = provider.parse_header_labels(&labels, "sozune.http.web.");
-        assert_eq!(headers.len(), 1);
-        assert_eq!(headers[0].name, "X-Custom-Header");
-        assert_eq!(headers[0].value, "custom-value");
-        assert_eq!(headers[0].direction, crate::model::HeaderDirection::Request);
-    }
-
-    #[test]
-    fn test_disabled_container() {
-        let provider = DockerProvider {
-            docker: Docker::connect_with_local_defaults().unwrap(),
-            config: Default::default(),
-            container_ips: std::sync::Mutex::new(HashMap::new()),
-        };
-        let mut labels = HashMap::new();
-        labels.insert("sozune.enable".to_string(), "false".to_string());
-        labels.insert(
-            "sozune.http.web.host".to_string(),
-            "example.com".to_string(),
-        );
-
-        let entrypoints = provider.parse_protocol_labels(&labels, "http", "192.168.1.100");
-        assert_eq!(entrypoints.len(), 1);
-
-        // Enable check is done upstream in get_entrypoints_from_containers
-        assert_eq!(
-            labels.get("sozune.enable").map_or(false, |v| v == "true"),
-            false
-        );
-    }
-
-    #[test]
-    fn test_missing_host_label() {
-        let provider = DockerProvider {
-            docker: Docker::connect_with_local_defaults().unwrap(),
-            config: Default::default(),
-            container_ips: std::sync::Mutex::new(HashMap::new()),
-        };
-        let mut labels = HashMap::new();
-        labels.insert("sozune.enable".to_string(), "true".to_string());
-        labels.insert("sozune.http.web.port".to_string(), "8080".to_string());
-
-        let entrypoints = provider.parse_protocol_labels(&labels, "http", "192.168.1.100");
-        assert_eq!(entrypoints.len(), 0);
+/// Emit each diagnostic at the appropriate tracing level so the runtime logs
+/// match what `sozune validate` would report.
+fn log_diagnostics(candidate: &Candidate, diagnostics: &[Diagnostic]) {
+    for d in diagnostics {
+        let target = format!("{}/{}", candidate.provider, candidate.display_name);
+        match d.severity() {
+            Severity::Error => error!(
+                "[{}] {}: {} (label={})",
+                target,
+                d.code.as_str(),
+                d.message,
+                d.label.as_deref().unwrap_or("-")
+            ),
+            Severity::Warn => warn!(
+                "[{}] {}: {} (label={}, value={:?})",
+                target,
+                d.code.as_str(),
+                d.message,
+                d.label.as_deref().unwrap_or("-"),
+                d.value.as_deref().unwrap_or("")
+            ),
+            Severity::Info => debug!(
+                "[{}] {}: {}",
+                target,
+                d.code.as_str(),
+                d.message
+            ),
+        }
     }
 }
+


### PR DESCRIPTION
Today, all the logic that turns Docker labels into routes lives in
`provider/docker.rs`. When a container isn't routed, there's no clean
way to know why: half the cases fall through a silent `unwrap_or`,
the other half log a `warn!` with no actionable context.

This PR moves that logic into a dedicated `src/labels/` module that
takes labels in and returns two things: the routes sozune is going to
create, and the list of issues hit along the way (missing required
label, invalid port, network not found, blocked header, and so on).

## What changes for the user

No new command. No change in routing behavior. The only visible
difference is that runtime logs become significantly more useful:
every silent fallback now carries a stable code, the offending
label name, its value, and where relevant a hint on how to fix it.
If a container isn't routed tomorrow, the logs will say why — instead
of leaving you to guess.

## What changes in the code

`docker.rs` loses ~440 lines: all the parsing moves into `labels/`,
and the Docker provider just extracts containers and hands them to
the shared parser. Nine dead-code warnings disappear in the process.

The `labels/` module is designed to be reusable. Whenever a Nomad
or Kubernetes provider gets added later, they'll only need to extract
their annotations in the same shape; parsing, diagnostics, and error
codes are shared. No duplication, no drift between providers.

## How it's tested

99 tests pass. 62 are new and cover every place the parser can fail
or silently fall back: one test per diagnostic code, plus a dozen
end-to-end scenarios on the full parser (disabled container, missing
host, multiple services per container, preferred network, and so on).

On the runtime side, the Docker provider's public API
(`get_entrypoints_from_containers`, `get_container_entrypoints`) is
unchanged, so the rest of the codebase wasn't touched.

## What's next

The parser is the foundation for a `sozune validate` command that
will list every container and explain precisely which ones would be
routed and why the others wouldn't. That command lands in a separate,
smaller PR that just plugs a renderer on top of this parser.

## Test plan

- [x] `cargo test --bin sozune` (99/99)
- [ ] `tests/e2e/run-all.sh` to confirm live routing hasn't changed