### PR TITLE
Install protoc in CI to build sozu-command-lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt


### PR DESCRIPTION
sozu-command-lib's build.rs needs protoc to compile protobuf definitions. Ubuntu runners don't ship it, so cargo check failed before anything else could run. Matches what Sozu does in its own CI.