### PR TITLE
Replace API bearer token with Basic auth, named users, and roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,15 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -351,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -453,6 +462,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -483,6 +501,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -524,13 +552,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -759,6 +797,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2337,13 +2385,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2458,7 +2517,7 @@ dependencies = [
  "rusty_ulid",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "time",
  "toml",
@@ -2489,7 +2548,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rusty_ulid",
- "sha2",
+ "sha2 0.11.0",
  "slab",
  "socket2",
  "sozu-command-lib",
@@ -2522,10 +2581,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "signal-hook",
  "signal-hook-tokio",
  "sozu-command-lib",
  "sozu-lib",
+ "subtle",
  "tokio",
  "tower",
  "tower-http",
@@ -2998,6 +3059,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ flate2 = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"] }
+sha2 = "0.10"
+subtle = "2"

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,9 @@ providers:
 
 api:
   enabled: true
+  # WARNING: HTTP Basic sends the password in the clear on every request.
+  # Bind to 127.0.0.1 (default) or front the API with TLS before exposing it.
+  # See documentation/configuration/api.md for the full notes.
   listen_address: 0.0.0.0:3035
   # API users authenticate via HTTP Basic. Hash format is hex(sha256(password)).
   # Generate with: echo -n "<password>" | sha256sum

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,13 @@ providers:
 api:
   enabled: true
   listen_address: 0.0.0.0:3035
+  # API users authenticate via HTTP Basic. Hash format is hex(sha256(password)).
+  # Generate with: echo -n "<password>" | sha256sum
+  # Roles: admin (default, full access) or read-only (GET only).
+  users:
+    - name: admin
+      hash: "b630f5d579dfef28c45ddf5e3c7a65f09ebca4d5b064a70c4203578c8667fdeb"  # sha256("admin-pass") — change me
+      role: admin
 
 proxy:
   http:

--- a/documentation/configuration/api.md
+++ b/documentation/configuration/api.md
@@ -10,21 +10,56 @@ Sozune exposes a REST API to manage entrypoints on the fly, without restarting.
 api:
   enabled: true
   listen_address: "127.0.0.1:3035"
-  token: "your-secret-token"
+  users:
+    - name: admin
+      hash: "b630f5d579dfef28c45ddf5e3c7a65f09ebca4d5b064a70c4203578c8667fdeb"
+      role: admin
+    - name: dashboard
+      hash: "7d4cab0d7c8a5e9eef83b7d306b4cb6dad27b3aaf7df9e0db18f78f9efb1ee43"
+      role: read-only
   cors_origins:
     - "https://dashboard.example.com"
 ```
 
+The API refuses to start when `users` is empty. There is no anonymous mode.
+
 ## Authentication
 
-When a `token` is configured, every route (except `/health`) requires a matching bearer token:
+The API uses HTTP Basic. Each user has a `name`, a `hash` (hex of `sha256(password)`), and a `role`.
+
+Generate a hash with:
 
 ```bash
-curl -H "Authorization: Bearer your-secret-token" \
-     http://localhost:3035/entrypoints
+echo -n "your-password" | sha256sum
 ```
 
-**If `token` is not set, the API runs without any authentication.** Every route is publicly reachable on `listen_address`. Always either bind the API to `127.0.0.1` (default) or set a token before exposing it.
+Then call the API with the password — sozune hashes it on receive and compares in constant time:
+
+```bash
+curl -u admin:your-password http://localhost:3035/entrypoints
+```
+
+The hash format matches what sozune accepts in route-level basic auth (`sozune.http.<svc>.auth.basic`), so the same generation step works on both sides.
+
+## Roles
+
+| Role | GET | POST / PUT / DELETE |
+|---|---|---|
+| `admin` (default) | yes | yes |
+| `read-only` | yes | 403 |
+
+`role` can be omitted; it defaults to `admin`.
+
+## Securing the API on a network
+
+> **HTTP Basic over plaintext HTTP sends the password in the clear on every request.** It is only safe when the connection is encrypted.
+
+Sozune's API listens in HTTP. If you bind it to anything other than `127.0.0.1`, put it behind TLS yourself. Two common patterns:
+
+- **Behind sozune itself** — declare an entrypoint that points at `127.0.0.1:3035` with `tls: true` and an ACME-issued certificate, and only the TLS-fronted hostname is reachable from outside.
+- **Behind another reverse proxy** that already terminates TLS (nginx, Caddy, an ingress controller).
+
+The default `listen_address: "127.0.0.1:3035"` keeps the API local-only — fine for CLI use from the same host, never expose it on `0.0.0.0` without TLS in front.
 
 ## Endpoints
 
@@ -39,15 +74,15 @@ curl http://localhost:3035/health
 
 ### `GET /entrypoints`
 
-Lists every entrypoint (Docker + API).
+Lists every entrypoint (Docker + API). Available to both roles.
 
 ### `POST /entrypoints`
 
-Creates an entrypoint through the API.
+Creates an entrypoint through the API. Admin only.
 
 ```bash
 curl -X POST http://localhost:3035/entrypoints \
-  -H "Authorization: Bearer your-secret-token" \
+  -u admin:your-password \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-api",
@@ -70,11 +105,11 @@ Fetches a single entrypoint.
 
 ### `PUT /entrypoints/:id`
 
-Updates an entrypoint (only those created through the API, not Docker).
+Updates an entrypoint (only those created through the API, not Docker). Admin only.
 
 ### `DELETE /entrypoints/:id`
 
-Deletes an entrypoint.
+Deletes an entrypoint. Admin only.
 
 ## Note
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,0 +1,236 @@
+//! HTTP Basic auth for the management API.
+//!
+//! Mirrors the storage format Sozu uses for route-level basic auth so users
+//! generate hashes the same way on both sides: `username:hex(sha256(password))`.
+//! Comparison is constant-time over a fixed envelope so the time spent
+//! validating a credential leaks neither the matching slot nor the matching
+//! username length.
+
+use crate::config::{ApiUser, Role};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+/// Maximum size, in bytes, of a base64-decoded `Authorization: Basic`
+/// payload. RFC 7617 imposes no limit but anything beyond this for a
+/// management API is pathological.
+const MAX_DECODED_CREDENTIAL_BYTES: usize = 4096;
+
+/// Pad length used by [`constant_time_match`]. Must be at least as large as
+/// the longest realistic `username:hex(sha256)` we ever compare. SHA-256 hex
+/// is 64 chars; usernames are bounded in practice but we leave generous
+/// headroom so a longer username does not bypass the constant-time guard.
+const PAD_LEN: usize = 256;
+
+/// Resolved identity attached to authenticated requests. Stored in
+/// `request.extensions()` so handlers and logs can read it back.
+#[derive(Debug, Clone)]
+pub struct Identity {
+    pub name: String,
+    pub role: Role,
+}
+
+/// Outcome of validating an `Authorization` header against the user list.
+pub enum AuthOutcome {
+    /// No credential was present (no header, wrong scheme, malformed).
+    Missing,
+    /// Credential was well-formed but did not match any configured user.
+    Invalid,
+    /// Credential matched. The resolved identity is returned.
+    Authenticated(Identity),
+}
+
+/// Verify a raw `Authorization` header value against the configured users.
+pub fn check(header_value: Option<&str>, users: &[ApiUser]) -> AuthOutcome {
+    let Some(value) = header_value else {
+        return AuthOutcome::Missing;
+    };
+
+    let Some(decoded) = decode_basic(value) else {
+        return AuthOutcome::Missing;
+    };
+
+    let Some((submitted_user, password)) = decoded.split_once(':') else {
+        return AuthOutcome::Missing;
+    };
+
+    let submitted_hash = hex_sha256(password.as_bytes());
+    let candidate = format!("{submitted_user}:{submitted_hash}");
+
+    // Build the canonical entry list once so the comparison loop iterates
+    // every user even on a hit.
+    let entries: Vec<String> = users
+        .iter()
+        .map(|u| format!("{}:{}", u.name, u.hash))
+        .collect();
+
+    if !constant_time_match(&candidate, &entries) {
+        return AuthOutcome::Invalid;
+    }
+
+    // Match found — locate the user (this lookup is fine to short-circuit;
+    // the sensitive part is the credential check above).
+    if let Some(user) = users.iter().find(|u| {
+        let entry = format!("{}:{}", u.name, u.hash);
+        entry == candidate
+    }) {
+        AuthOutcome::Authenticated(Identity {
+            name: user.name.clone(),
+            role: user.role,
+        })
+    } else {
+        AuthOutcome::Invalid
+    }
+}
+
+/// Decode a `Basic <token>` header value into the raw `user:password` UTF-8
+/// string. Returns `None` for any malformed input.
+fn decode_basic(value: &str) -> Option<String> {
+    let trimmed = value.trim_start();
+    let token = trimmed
+        .strip_prefix("Basic ")
+        .or_else(|| trimmed.strip_prefix("basic "))?;
+    let decoded = STANDARD.decode(token.trim()).ok()?;
+    if decoded.len() > MAX_DECODED_CREDENTIAL_BYTES {
+        return None;
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+/// Compare `candidate` against every entry using constant-time equality
+/// over a fixed envelope. Both sides are padded to `PAD_LEN` plus a length
+/// suffix before `subtle::ConstantTimeEq` runs, which:
+///   * makes the per-entry compare iterate the full padded length even
+///     when candidate and entry differ in length (subtle's slice `ct_eq`
+///     short-circuits on length mismatch — padding defeats that leak);
+///   * makes the outer loop iterate the full slice on every call, so the
+///     time spent does not vary with the position of the matching entry.
+fn constant_time_match(candidate: &str, entries: &[String]) -> bool {
+    let candidate_padded = pad(candidate.as_bytes());
+    let mut matched = subtle::Choice::from(0u8);
+    for entry in entries {
+        let entry_padded = pad(entry.as_bytes());
+        matched |= candidate_padded.as_slice().ct_eq(entry_padded.as_slice());
+    }
+    bool::from(matched)
+}
+
+fn pad(input: &[u8]) -> [u8; PAD_LEN + 8] {
+    let mut buf = [0u8; PAD_LEN + 8];
+    let n = input.len().min(PAD_LEN);
+    buf[..n].copy_from_slice(&input[..n]);
+    buf[PAD_LEN..].copy_from_slice(&(input.len() as u64).to_le_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(name: &str, password: &str, role: Role) -> ApiUser {
+        ApiUser {
+            name: name.into(),
+            hash: hex_sha256(password.as_bytes()),
+            role,
+        }
+    }
+
+    fn basic_header(user: &str, password: &str) -> String {
+        let raw = format!("{user}:{password}");
+        format!("Basic {}", STANDARD.encode(raw))
+    }
+
+    #[test]
+    fn missing_header_returns_missing() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        assert!(matches!(check(None, &users), AuthOutcome::Missing));
+    }
+
+    #[test]
+    fn wrong_scheme_returns_missing() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        let h = format!("Bearer {}", STANDARD.encode("alice:secret"));
+        assert!(matches!(check(Some(&h), &users), AuthOutcome::Missing));
+    }
+
+    #[test]
+    fn malformed_base64_returns_missing() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        assert!(matches!(
+            check(Some("Basic !!!not base64!!!"), &users),
+            AuthOutcome::Missing
+        ));
+    }
+
+    #[test]
+    fn missing_colon_returns_missing() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        let h = format!("Basic {}", STANDARD.encode("nocolon"));
+        assert!(matches!(check(Some(&h), &users), AuthOutcome::Missing));
+    }
+
+    #[test]
+    fn correct_credential_authenticates_with_role() {
+        let users = vec![
+            user("alice", "secret", Role::Admin),
+            user("bob", "hunter2", Role::ReadOnly),
+        ];
+        let h = basic_header("bob", "hunter2");
+        match check(Some(&h), &users) {
+            AuthOutcome::Authenticated(id) => {
+                assert_eq!(id.name, "bob");
+                assert_eq!(id.role, Role::ReadOnly);
+            }
+            _ => panic!("expected Authenticated"),
+        }
+    }
+
+    #[test]
+    fn wrong_password_returns_invalid() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        let h = basic_header("alice", "wrong");
+        assert!(matches!(check(Some(&h), &users), AuthOutcome::Invalid));
+    }
+
+    #[test]
+    fn unknown_user_returns_invalid() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        let h = basic_header("mallory", "secret");
+        assert!(matches!(check(Some(&h), &users), AuthOutcome::Invalid));
+    }
+
+    #[test]
+    fn empty_user_list_rejects_everything() {
+        let h = basic_header("alice", "secret");
+        assert!(matches!(check(Some(&h), &[]), AuthOutcome::Invalid));
+    }
+
+    #[test]
+    fn case_insensitive_basic_scheme() {
+        let users = vec![user("alice", "secret", Role::Admin)];
+        let raw = format!("alice:{}", "secret");
+        let h = format!("basic {}", STANDARD.encode(raw));
+        assert!(matches!(
+            check(Some(&h), &users),
+            AuthOutcome::Authenticated(_)
+        ));
+    }
+
+    #[test]
+    fn oversized_payload_returns_missing() {
+        let big = "a".repeat(MAX_DECODED_CREDENTIAL_BYTES + 1);
+        let h = format!("Basic {}", STANDARD.encode(big));
+        let users = vec![user("alice", "secret", Role::Admin)];
+        assert!(matches!(check(Some(&h), &users), AuthOutcome::Missing));
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod auth;
 pub(crate) mod server;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,4 +1,5 @@
-use crate::config::ApiConfig;
+use crate::api::auth::{AuthOutcome, Identity, check};
+use crate::config::{ApiConfig, ApiUser, Role};
 use crate::model::{Entrypoint, EntrypointConfig, Protocol};
 use axum::extract::{Path, Request, State};
 use axum::http::StatusCode;
@@ -20,7 +21,7 @@ use tracing::{error, info, warn};
 pub struct AppState {
     pub storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     pub reload_tx: mpsc::Sender<()>,
-    pub token: Option<String>,
+    pub users: Vec<ApiUser>,
 }
 
 #[derive(Deserialize)]
@@ -32,41 +33,82 @@ pub struct CreateEntrypointRequest {
     pub backend_weights: Option<std::collections::HashMap<String, u32>>,
 }
 
-async fn auth_middleware(State(state): State<AppState>, req: Request, next: Next) -> Response {
-    let token = match &state.token {
-        Some(t) => t,
-        None => return next.run(req).await,
-    };
+/// Authenticate the request with HTTP Basic, then attach the resolved
+/// `Identity` to request extensions so downstream handlers and the role
+/// guard can read it back.
+async fn auth_middleware(State(state): State<AppState>, mut req: Request, next: Next) -> Response {
+    if state.users.is_empty() {
+        return unauthorized("API has no users configured, refusing all requests");
+    }
 
-    let auth_header = req
+    let header = req
         .headers()
-        .get("authorization")
+        .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok());
 
-    match auth_header {
-        Some(header) if header.starts_with("Bearer ") => {
-            let provided = &header[7..];
-            if provided == token {
-                next.run(req).await
-            } else {
-                warn!("Invalid bearer token from {:?}", req.headers().get("host"));
-                Json(serde_json::json!({"error": "invalid token"}))
-                    .into_response_with_status(StatusCode::UNAUTHORIZED)
-            }
+    match check(header, &state.users) {
+        AuthOutcome::Authenticated(identity) => {
+            req.extensions_mut().insert(identity);
+            next.run(req).await
         }
-        _ => Json(serde_json::json!({"error": "missing or invalid authorization header"}))
-            .into_response_with_status(StatusCode::UNAUTHORIZED),
+        AuthOutcome::Invalid => {
+            warn!(
+                "Rejected API request with invalid credentials from {:?}",
+                req.headers().get("host")
+            );
+            unauthorized("invalid credentials")
+        }
+        AuthOutcome::Missing => unauthorized("missing or invalid authorization header"),
     }
 }
 
-trait IntoResponseWithStatus {
-    fn into_response_with_status(self, status: StatusCode) -> Response;
+/// Block write methods (POST/PUT/DELETE) when the authenticated user is
+/// `read-only`. Runs after `auth_middleware` so the `Identity` is always
+/// present in extensions.
+async fn require_admin(req: Request, next: Next) -> Response {
+    let is_write = !matches!(
+        req.method(),
+        &Method::GET | &Method::HEAD | &Method::OPTIONS
+    );
+    if !is_write {
+        return next.run(req).await;
+    }
+
+    let identity = req.extensions().get::<Identity>().cloned();
+    match identity {
+        Some(id) if id.role == Role::Admin => next.run(req).await,
+        Some(id) => {
+            warn!(
+                "User '{}' (read-only) attempted {} {}",
+                id.name,
+                req.method(),
+                req.uri().path()
+            );
+            forbidden("read-only role cannot perform this operation")
+        }
+        None => unauthorized("missing identity"),
+    }
 }
 
-impl IntoResponseWithStatus for Json<serde_json::Value> {
-    fn into_response_with_status(self, status: StatusCode) -> Response {
-        (status, self).into_response()
-    }
+fn unauthorized(message: &str) -> Response {
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({"error": message})),
+    )
+        .into_response();
+    response.headers_mut().insert(
+        header::WWW_AUTHENTICATE,
+        HeaderValue::from_static("Basic realm=\"sozune\""),
+    );
+    response
+}
+
+fn forbidden(message: &str) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({"error": message})),
+    )
+        .into_response()
 }
 
 pub async fn serve(
@@ -74,10 +116,16 @@ pub async fn serve(
     storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     reload_tx: mpsc::Sender<()>,
 ) -> anyhow::Result<()> {
+    if config.users.is_empty() {
+        anyhow::bail!(
+            "API enabled but no users configured. Add at least one entry under `api.users`."
+        );
+    }
+
     let state = AppState {
         storage,
         reload_tx,
-        token: config.token.clone(),
+        users: config.users.clone(),
     };
 
     let protected = Router::new()
@@ -91,6 +139,7 @@ pub async fn serve(
                 .put(update_entrypoint)
                 .delete(delete_entrypoint),
         )
+        .route_layer(axum_middleware::from_fn(require_admin))
         .route_layer(axum_middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -337,21 +386,42 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::util::ServiceExt;
 
-    fn test_state() -> AppState {
-        let (reload_tx, _reload_rx) = mpsc::channel(64);
-        AppState {
-            storage: Arc::new(RwLock::new(BTreeMap::new())),
-            reload_tx,
-            token: None,
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD;
+    use sha2::Digest;
+
+    fn hash_password(password: &str) -> String {
+        let digest = sha2::Sha256::digest(password.as_bytes());
+        let mut out = String::with_capacity(64);
+        for byte in digest {
+            use std::fmt::Write;
+            let _ = write!(&mut out, "{byte:02x}");
+        }
+        out
+    }
+
+    fn user(name: &str, password: &str, role: Role) -> ApiUser {
+        ApiUser {
+            name: name.into(),
+            hash: hash_password(password),
+            role,
         }
     }
 
-    fn test_state_with_token(token: &str) -> AppState {
+    fn basic(user: &str, password: &str) -> String {
+        format!("Basic {}", STANDARD.encode(format!("{user}:{password}")))
+    }
+
+    fn test_state() -> AppState {
+        test_state_with_users(vec![user("admin", "admin-pass", Role::Admin)])
+    }
+
+    fn test_state_with_users(users: Vec<ApiUser>) -> AppState {
         let (reload_tx, _reload_rx) = mpsc::channel(64);
         AppState {
             storage: Arc::new(RwLock::new(BTreeMap::new())),
             reload_tx,
-            token: Some(token.to_string()),
+            users,
         }
     }
 
@@ -367,6 +437,7 @@ mod tests {
                     .put(update_entrypoint)
                     .delete(delete_entrypoint),
             )
+            .route_layer(axum_middleware::from_fn(require_admin))
             .route_layer(axum_middleware::from_fn_with_state(
                 state.clone(),
                 auth_middleware,
@@ -376,6 +447,11 @@ mod tests {
             .route("/health", get(health))
             .merge(protected)
             .with_state(state)
+    }
+
+    /// Default credential matching `test_state()`'s default admin user.
+    fn admin_auth() -> String {
+        basic("admin", "admin-pass")
     }
 
     fn sample_entrypoint_json() -> serde_json::Value {
@@ -421,7 +497,12 @@ mod tests {
         let app = test_app(test_state());
 
         let response = app
-            .oneshot(Request::get("/entrypoints").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/entrypoints")
+                    .header("authorization", admin_auth())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -436,6 +517,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::post("/entrypoints")
+                    .header("authorization", admin_auth())
                     .header("content-type", "application/json")
                     .body(Body::from(sample_entrypoint_json().to_string()))
                     .unwrap(),
@@ -463,6 +545,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::post("/entrypoints")
+                    .header("authorization", admin_auth())
                     .header("content-type", "application/json")
                     .body(Body::from(sample_entrypoint_json().to_string()))
                     .unwrap(),
@@ -476,6 +559,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::get(&format!("/entrypoints/{}", id))
+                    .header("authorization", admin_auth())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -494,6 +578,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::get("/entrypoints/00000000-0000-0000-0000-000000000000")
+                    .header("authorization", admin_auth())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -513,6 +598,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::post("/entrypoints")
+                    .header("authorization", admin_auth())
                     .header("content-type", "application/json")
                     .body(Body::from(sample_entrypoint_json().to_string()))
                     .unwrap(),
@@ -529,6 +615,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::put(&format!("/entrypoints/{}", id))
+                    .header("authorization", admin_auth())
                     .header("content-type", "application/json")
                     .body(Body::from(updated_json.to_string()))
                     .unwrap(),
@@ -551,6 +638,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::post("/entrypoints")
+                    .header("authorization", admin_auth())
                     .header("content-type", "application/json")
                     .body(Body::from(sample_entrypoint_json().to_string()))
                     .unwrap(),
@@ -564,6 +652,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::delete(&format!("/entrypoints/{}", id))
+                    .header("authorization", admin_auth())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -623,6 +712,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::put("/entrypoints/550e8400-e29b-41d4-a716-446655440000")
+                    .header("authorization", admin_auth())
                     .header("content-type", "application/json")
                     .body(Body::from(sample_entrypoint_json().to_string()))
                     .unwrap(),
@@ -637,6 +727,7 @@ mod tests {
                 Request::builder()
                     .method("DELETE")
                     .uri("/entrypoints/550e8400-e29b-41d4-a716-446655440000")
+                    .header("authorization", admin_auth())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -646,9 +737,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_auth_required_when_token_configured() {
-        let state = test_state_with_token("secret-token");
-        let app = test_app(state);
+    async fn missing_credentials_rejected() {
+        let app = test_app(test_state());
 
         let response = app
             .oneshot(Request::get("/entrypoints").body(Body::empty()).unwrap())
@@ -656,17 +746,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            response
+                .headers()
+                .get("www-authenticate")
+                .is_some_and(|v| v.to_str().unwrap_or("").starts_with("Basic"))
+        );
     }
 
     #[tokio::test]
-    async fn test_auth_valid_token() {
-        let state = test_state_with_token("secret-token");
-        let app = test_app(state);
+    async fn valid_credentials_accepted() {
+        let app = test_app(test_state());
 
         let response = app
             .oneshot(
                 Request::get("/entrypoints")
-                    .header("authorization", "Bearer secret-token")
+                    .header("authorization", admin_auth())
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -677,14 +772,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_auth_invalid_token() {
-        let state = test_state_with_token("secret-token");
-        let app = test_app(state);
+    async fn invalid_password_rejected() {
+        let app = test_app(test_state());
 
         let response = app
             .oneshot(
                 Request::get("/entrypoints")
-                    .header("authorization", "Bearer wrong-token")
+                    .header("authorization", basic("admin", "wrong"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -695,9 +789,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_health_not_protected() {
-        let state = test_state_with_token("secret-token");
+    async fn read_only_user_can_read() {
+        let state = test_state_with_users(vec![
+            user("admin", "admin-pass", Role::Admin),
+            user("readonly", "ro-pass", Role::ReadOnly),
+        ]);
         let app = test_app(state);
+
+        let response = app
+            .oneshot(
+                Request::get("/entrypoints")
+                    .header("authorization", basic("readonly", "ro-pass"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn read_only_user_cannot_write() {
+        let state = test_state_with_users(vec![user("readonly", "ro-pass", Role::ReadOnly)]);
+        let app = test_app(state);
+
+        let response = app
+            .oneshot(
+                Request::post("/entrypoints")
+                    .header("authorization", basic("readonly", "ro-pass"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(sample_entrypoint_json().to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn health_not_protected() {
+        let app = test_app(test_state());
 
         let response = app
             .oneshot(Request::get("/health").body(Body::empty()).unwrap())

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,10 +60,26 @@ pub struct ApiConfig {
     pub enabled: bool,
     #[serde(default, deserialize_with = "deserialize_api_listen_address_with_env")]
     pub listen_address: String,
-    #[serde(default, deserialize_with = "deserialize_api_token_with_env")]
-    pub token: Option<String>,
+    #[serde(default)]
+    pub users: Vec<ApiUser>,
     #[serde(default)]
     pub cors_origins: Vec<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ApiUser {
+    pub name: String,
+    pub hash: String,
+    #[serde(default)]
+    pub role: Role,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum Role {
+    #[default]
+    Admin,
+    ReadOnly,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -168,7 +184,7 @@ impl Default for ApiConfig {
         Self {
             enabled: false,
             listen_address: default_api_listen_address(),
-            token: None,
+            users: Vec::new(),
             cors_origins: Vec::new(),
         }
     }
@@ -403,18 +419,6 @@ deserialize_string_with_env!(
     "SOZUNE_API_LISTEN_ADDRESS",
     default_api_listen_address
 );
-
-fn deserialize_api_token_with_env<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Option::<String>::deserialize(deserializer).unwrap_or(None);
-    let result = match std::env::var("SOZUNE_API_TOKEN") {
-        Ok(env_val) if !env_val.is_empty() => Some(env_val),
-        _ => value,
-    };
-    Ok(result)
-}
 
 deserialize_with_env!(
     deserialize_max_buffers_with_env,


### PR DESCRIPTION
Single static `token` is gone. The API now authenticates with HTTP Basic against a list of named users in config, each with a role.

```yaml
api:
  enabled: true
  listen_address: 0.0.0.0:3035
  users:
    - name: alice
      hash: "b630f5d5..."   # echo -n password | sha256sum
      role: admin
    - name: dashboard
      hash: "7d4cab0d..."
      role: read-only
```

- Hash format mirrors what Sozu uses for route-level basic auth: `hex(sha256(password))`. Same generation command on both sides (`echo -n pass | sha256sum`).
- Constant-time comparison (sha2 + subtle, both already in the lockfile via rustls). Logic adapted from `sozu::lib::protocol::mux::auth` but decoupled from kawa.
- Two roles: `admin` (default, full access) and `read-only` (GET only, returns 403 on writes).
- Identity attached to request extensions; role-violations log the user name + method + path.
- API refuses to start when `users` is empty (no implicit unauthenticated mode).

## Breaking change

`api.token` is removed. Existing configs using `token` will fail to parse with a clear serde error. Migration is a one-liner: replace the token with a single admin user.

## Test plan

- [x] `cargo test --bin sozune` — 116 pass (11 new in `api::auth`, 4 new in `api::server` covering the role guard)
- [x] Manual hash check: `echo -n admin-pass | sha256sum` matches the hash in the example config