### PR TITLE
Release 0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  CARGO_TERM_COLOR: always
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  binary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build dashboard
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/release/sozune dist/sozune
+          cd dist && tar -czf sozune-${{ github.ref_name }}-linux-amd64.tar.gz sozune
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sozune-linux-amd64
+          path: dist/sozune-${{ github.ref_name }}-linux-amd64.tar.gz
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [docker, binary]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sozune-linux-amd64
+          path: dist
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          version="${{ github.ref_name }}"
+          awk -v v="$version" '
+            $0 ~ "^## \\[" v "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes-file release-notes.md \
+            dist/sozune-${{ github.ref_name }}-linux-amd64.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - 2026-04-28
+## [0.11.0] - 2026-04-29
+
+### CLI
+
+- New `sozune` CLI based on `clap` with `serve` and `validate` subcommands.
+- `sozune validate` parses the configuration and renders a tree of entrypoints, routes, backends, and middlewares — without starting the proxy.
+
+### Dashboard
+
+- Read-only SvelteKit dashboard embedded via `rust-embed`, served on its own port.
+- Login page with Basic auth flow against the API.
+- Sidebar with a Documentation link.
+- Configuration documentation page.
+- Biome lint/format, mobile responsive layout.
+
+### API
+
+- Bearer token replaced by **Basic auth + named users + roles**.
+- CORS support via `cors_origins` config; default policy allows any origin.
+- `GET /entrypoints` now returns an array instead of a map.
 
 ### Native middleware migration
 
@@ -32,16 +51,45 @@ New `EntrypointConfig` fields, parsed from Docker labels and passed through to S
 - `redirectTemplate` → `RequestHttpFrontend.redirect_template` (template with `%REDIRECT_LOCATION` / `%STATUS_CODE`)
 - `wwwAuthenticate` → `Cluster.www_authenticate` (realm in the 401 `WWW-Authenticate` header)
 
+### Routing & providers
+
+- Regex-based path matching (`PathRuleKind` aligned with Sōzu proto).
+- New HTTP provider: poll entrypoints from a remote URL (JSON only).
+
+### Middleware
+
+- Gzip response compression for compressible content types, opt-in via `compress` label.
+
+### Labels module
+
+- New `labels` module with a shared parser orchestrating per-field helpers (port, priority, backend timeout, redirect, scheme, ratelimit, auth, headers, host, network, path).
+- `LabelSource` trait wired through the Docker provider.
+
+### Documentation & website
+
+- Public website with prerendered home, mobile-responsive layout, deployed via Pages.
+- README slimmed down to vitrine + quickstart, with details moved under `documentation/`.
+
+### Container & CI
+
+- Container runs as root by default; non-root override documented.
+- CI installs `protoc` to build `sozu-command-lib` and builds the dashboard before cargo.
+- Bumped patched Sōzu fork (wildcard overflow fix) and added `Cluster.http2`.
+
 ### Breaking changes
 
 - **Basic auth password format**: `password_hash` (in `auth.basic` config and `sozune.http.<name>.auth.basic` Docker labels) must now be lowercase **hex(SHA-256)** of the password instead of bcrypt. Bcrypt is rejected by Sozu's native auth path. Generate hashes with `echo -n 'password' | sha256sum`. The `bcrypt` dependency has been removed.
 - `strip_prefix` no longer rejects partial-segment matches (e.g. `/apiv2` against prefix `/api`). The behavior now follows Sozu's `PathRule::Prefix` `starts_with` semantics. Use a trailing slash (`/api/`) or a regex path to enforce segment boundaries.
 - **`headers` field schema**: `EntrypointConfig.headers` changed from `HashMap<String, String>` to `Vec<HeaderConfig>` where `HeaderConfig = { name, value, direction }`. The HTTP provider JSON and REST API payloads must use an array (`"headers": []`) instead of an object (`"headers": {}`).
+- **API authentication**: bearer token replaced by Basic auth with named users and roles. Existing API clients must migrate.
+- **`GET /entrypoints` shape**: returns an array instead of a map.
 
 ### Internals
 
 - Middleware module slimmed down: `auth.rs`, `headers.rs`, `strip_prefix.rs` deleted (~340 LOC removed).
 - `MiddlewareRoute` now only carries `backends`, `backend_counter`, `backend_timeout`, `rate_limiter`, `compress`.
+- `cargo fmt` pass over the codebase.
+- Integration tests added for rate limiting, gzip compression, API CRUD, backend timeout, HTTP provider, plus end-to-end tests.
 
 ## [0.10.0] - 2026-04-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "sozune"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sozune"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["mlanawo Mbechezi mlanawo.mbechezi@kemeter.io"]
 edition = "2024"
 
@@ -40,3 +40,8 @@ sha2 = "0.10"
 subtle = "2"
 rust-embed = "8"
 mime_guess = "2"
+
+[profile.release]
+strip = true
+lto = "thin"
+codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM oven/bun:1-debian AS dashboard
+WORKDIR /dashboard
+COPY dashboard/package.json dashboard/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY dashboard/ ./
+RUN bun run build
+
 FROM rust:1-bookworm AS chef
 RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
@@ -12,6 +19,7 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
+COPY --from=dashboard /dashboard/build ./dashboard/build
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian12:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
-FROM rust:latest as builder
-
+FROM rust:1-bookworm AS chef
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef --locked
 WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release
 
-FROM debian:sid-slim
-
+FROM gcr.io/distroless/cc-debian12:nonroot
 COPY --from=builder /app/target/release/sozune /sozune
 
-EXPOSE 80
+USER root
+
+EXPOSE 80 443
 ENTRYPOINT ["/sozune"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: all build build-dashboard run test fmt clean
+.PHONY: all build build-dashboard docker-build run test fmt clean
+
+IMAGE ?= sozune
+TAG ?= latest
 
 all: build
 
@@ -7,6 +10,9 @@ build: build-dashboard
 
 build-dashboard:
 	cd dashboard && bun install && bun run build
+
+docker-build:
+	docker build -t $(IMAGE):$(TAG) .
 
 run: build-dashboard
 	cargo run

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -75,6 +75,10 @@
           </div>
           <button class="logout" onclick={logout}>Sign out</button>
         {/if}
+        <a class="doc-link" href="https://sozune.kemeter.io/documentation" target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h4a2 2 0 0 1 2 2v9a2 2 0 0 0-2-2H2zM14 3h-4a2 2 0 0 0-2 2v9a2 2 0 0 1 2-2h4z"/></svg>
+          <span>Documentation</span>
+        </a>
         <div class="version mono">v0.10.0</div>
       </div>
     </aside>
@@ -215,6 +219,25 @@
   .logout:hover {
     background: var(--bg-hover);
     color: var(--fg-0);
+  }
+
+  .doc-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.625rem;
+    border-radius: var(--radius);
+    color: var(--fg-2);
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+  .doc-link:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .doc-link :global(svg) {
+    width: 14px;
+    height: 14px;
   }
 
   .version {

--- a/documentation/configuration/dashboard.md
+++ b/documentation/configuration/dashboard.md
@@ -1,0 +1,41 @@
+# Dashboard
+
+Sozune ships with a built-in web dashboard to inspect entrypoints, check health, and manage settings without hitting the REST API by hand.
+
+## Configuration
+
+Disabled by default. Enable it in `config.yaml`:
+
+```yaml
+dashboard:
+  enabled: true
+  listen_address: "127.0.0.1:3038"
+```
+
+Restart sozune to pick up the change.
+
+## Authentication
+
+The dashboard talks to the [REST API](/documentation/configuration/api) and uses the same credentials. Configure at least one user under `api.users` and log in from the dashboard's `/login` page.
+
+## Exposing the dashboard
+
+The dashboard listens on `127.0.0.1:3038` by default — local-only, like the API. Two patterns to expose it externally:
+
+- **Behind sozune itself** — declare an entrypoint pointing at `127.0.0.1:3038` with `tls: true`. Example with Docker labels on the sozune container:
+
+  ```yaml
+  labels:
+    - "sozune.enable=true"
+    - "sozune.http.dashboard.host=dashboard.example.com"
+    - "sozune.http.dashboard.port=3038"
+    - "sozune.http.dashboard.tls=true"
+  ```
+
+- **Behind another reverse proxy** that already terminates TLS.
+
+If you need it reachable on a LAN without going through a proxy, switch `listen_address` to `0.0.0.0:3038` — but never expose it on a public interface without TLS.
+
+## CORS
+
+The dashboard runs on its own origin (e.g. `http://dashboard.example.com`) and calls the API on another (`http://localhost:3035`). The API allows any origin by default; restrict with `api.cors_origins` if you need to.

--- a/documentation/getting-started/installation.md
+++ b/documentation/getting-started/installation.md
@@ -22,6 +22,28 @@ cargo build --release
 ./target/release/sozune
 ```
 
+## Running as non-root
+
+The image runs as `root` by default so it works out of the box: it can bind to ports `80`/`443` and read `/var/run/docker.sock` without extra configuration.
+
+If you'd rather run as the unprivileged `nonroot` user (UID `65532`) baked into the distroless base image, override `user` and grant the necessary capability + group:
+
+```yaml
+services:
+  sozune:
+    image: ghcr.io/kemeter/sozune:latest
+    user: "65532:65532"
+    cap_add:
+      - NET_BIND_SERVICE
+    group_add:
+      - "997"  # GID of the `docker` group on the host (varies — check with `getent group docker`)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./config.yaml:/config.yaml:ro
+```
+
+The `group_add` value must match your host's `docker` group GID. Without it, sozune cannot read the Docker socket.
+
 ## Verify the install
 
 `/health` is exposed by the [REST API](/documentation/configuration/api), not by the proxy itself. With the API enabled (default port `127.0.0.1:3035`):

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -22,6 +22,7 @@ Sozune is a reverse proxy built on [Sōzu](https://github.com/sozu-proxy/sozu). 
 - [Docker labels](/documentation/configuration/docker-labels)
 - [HTTP provider](/documentation/configuration/http-provider)
 - [REST API](/documentation/configuration/api)
+- [Dashboard](/documentation/configuration/dashboard)
 
 ## Routing
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -155,7 +155,9 @@ pub async fn serve(
         .merge(authed)
         .with_state(state);
 
-    if !config.cors_origins.is_empty() {
+    let allow_origin = if config.cors_origins.is_empty() {
+        AllowOrigin::any()
+    } else {
         let origins: Vec<HeaderValue> = config
             .cors_origins
             .iter()
@@ -167,20 +169,21 @@ pub async fn serve(
                 }
             })
             .collect();
+        AllowOrigin::list(origins)
+    };
 
-        let cors = CorsLayer::new()
-            .allow_origin(AllowOrigin::list(origins))
-            .allow_methods([
-                Method::GET,
-                Method::POST,
-                Method::PUT,
-                Method::DELETE,
-                Method::OPTIONS,
-            ])
-            .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE, header::ACCEPT]);
+    let cors = CorsLayer::new()
+        .allow_origin(allow_origin)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE, header::ACCEPT]);
 
-        app = app.layer(cors);
-    }
+    app = app.layer(cors);
 
     let addr = SocketAddr::from_str(&config.listen_address).map_err(|e| {
         anyhow::anyhow!(

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -26,7 +26,7 @@ export default function Hero() {
           HTTP/2 by default. Hot reload through a REST API.
         </p>
         <div className="hero-actions">
-          <Link to="/documentation/quick-start" className="btn btn-primary">
+          <Link to="/documentation/getting-started/quick-start" className="btn btn-primary">
             Quick start
           </Link>
           <a


### PR DESCRIPTION
Bump version to 0.11.0, complete the changelog and add the release workflow (Docker multi-arch + Linux amd64 binary).

The release pipeline triggers on tags matching `X.Y.Z` and:
- builds and pushes `ghcr.io/kemeter/sozune:0.11.0` + `:latest` (linux/amd64 + linux/arm64)
- builds a Linux amd64 binary tarball
- creates a GitHub release with notes extracted from CHANGELOG.md and the tarball attached