### PR TITLE
Add brotli and zstd response compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,6 +1742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "pool"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2682,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -3760,3 +3767,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +324,27 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2611,6 +2647,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "bollard",
+ "brotli",
  "clap",
  "flate2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 flate2 = "1"
 brotli = "8"
+zstd = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 flate2 = "1"
+brotli = "8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ curl -H "Host: whoami.localhost" http://localhost
 - [REST API](documentation/configuration/api.md)
 - Routing — [Hostnames](documentation/routing/hostnames.md) · [Path matching](documentation/routing/path-matching.md) · [Load balancing](documentation/routing/load-balancing.md)
 - TLS — [Overview](documentation/tls/overview.md) · [ACME / Let's Encrypt](documentation/tls/acme.md)
-- Middleware — [Basic auth](documentation/middleware/auth.md) · [Custom headers](documentation/middleware/headers.md) · [Strip prefix](documentation/middleware/strip-prefix.md) · [Redirects](documentation/middleware/redirects.md) · [Rate limit](documentation/middleware/rate-limit.md) · [Gzip compression](documentation/middleware/compress.md) · [Backend timeout](documentation/middleware/backend-timeout.md)
+- Middleware — [Basic auth](documentation/middleware/auth.md) · [Custom headers](documentation/middleware/headers.md) · [Strip prefix](documentation/middleware/strip-prefix.md) · [Redirects](documentation/middleware/redirects.md) · [Rate limit](documentation/middleware/rate-limit.md) · [Response compression](documentation/middleware/compress.md) · [Backend timeout](documentation/middleware/backend-timeout.md)
 - Advanced — [Health checks](documentation/advanced/health-checks.md) · [WebSocket](documentation/advanced/websocket.md) · [Access logs](documentation/advanced/access-logs.md) · [Debugging](documentation/advanced/debugging.md)
 
 ## Architecture

--- a/documentation/configuration/docker-labels.md
+++ b/documentation/configuration/docker-labels.md
@@ -44,7 +44,7 @@ Where `<service>` is your own identifier — it groups labels for the same logic
 | `sozune.http.<svc>.wwwAuthenticate` | [Basic auth](/documentation/middleware/auth) |
 | `sozune.http.<svc>.ratelimit.average` | [Rate limit](/documentation/middleware/rate-limit) |
 | `sozune.http.<svc>.ratelimit.burst` | [Rate limit](/documentation/middleware/rate-limit) |
-| `sozune.http.<svc>.compress` | [Gzip compression](/documentation/middleware/compress) |
+| `sozune.http.<svc>.compress` | [Response compression](/documentation/middleware/compress) (zstd, br, gzip) |
 | `sozune.http.<svc>.backendTimeout` | [Backend timeout](/documentation/middleware/backend-timeout) |
 | `sozune.http.<svc>.stickySession` | [Sticky sessions](/documentation/routing/load-balancing) |
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -42,7 +42,7 @@ Sozune is a reverse proxy built on [Sōzu](https://github.com/sozu-proxy/sozu). 
 - [Strip prefix](/documentation/middleware/strip-prefix)
 - [Redirects](/documentation/middleware/redirects)
 - [Rate limit](/documentation/middleware/rate-limit)
-- [Gzip compression](/documentation/middleware/compress)
+- [Response compression](/documentation/middleware/compress)
 - [Backend timeout](/documentation/middleware/backend-timeout)
 
 ## Advanced

--- a/documentation/middleware/compress.md
+++ b/documentation/middleware/compress.md
@@ -1,6 +1,8 @@
-# Gzip compression
+# Response compression
 
-Compress backend responses with gzip before sending them to the client. Opt-in per service.
+Compress backend responses before sending them to the client. Opt-in per service.
+
+Supported algorithms: **zstd**, **brotli (br)**, **gzip**.
 
 ## Label
 
@@ -17,12 +19,31 @@ labels:
   - "sozune.http.api.compress=true"
 ```
 
+## Algorithm selection
+
+Sozune picks the best encoding the client accepts, in this order of preference:
+
+1. `zstd`
+2. `br` (Brotli)
+3. `gzip`
+
+The client's `Accept-Encoding` header drives the choice. If none of the three are listed, the response is forwarded uncompressed.
+
+```
+Accept-Encoding: gzip, br, zstd  →  Content-Encoding: zstd
+Accept-Encoding: gzip, br        →  Content-Encoding: br
+Accept-Encoding: gzip            →  Content-Encoding: gzip
+Accept-Encoding: deflate         →  (no compression)
+```
+
+`q=` quality values are ignored — the priority order above always wins.
+
 ## When compression kicks in
 
 A response is compressed only if **all** of the following are true:
 
 1. The service has `compress=true`.
-2. The client sent `Accept-Encoding` containing `gzip`.
+2. The client sent `Accept-Encoding` with `zstd`, `br`, or `gzip`.
 3. The response `Content-Type` is in the compressible list (see below).
 4. The response is not already encoded (no existing `Content-Encoding`).
 
@@ -40,9 +61,9 @@ Anything else (binary, images, video, archives) is forwarded as-is.
 
 When a response is compressed, Sozune:
 
-- Sets `Content-Encoding: gzip`
-- Recomputes `Content-Length`
-- Removes `Transfer-Encoding` (the response is fully buffered before sending)
+- Sets `Content-Encoding` to the chosen algorithm (`zstd`, `br`, or `gzip`).
+- Recomputes `Content-Length`.
+- Removes `Transfer-Encoding` (the response is fully buffered before sending).
 
 ## Body size cap
 
@@ -50,11 +71,20 @@ To bound memory, the response body must fit in **10 MiB** in memory before being
 
 If you serve large compressible payloads (long log streams, large JSON dumps), turn compression off for that service and rely on the backend to compress.
 
-## Compression level
+## Compression levels
 
-Sozune uses gzip level 1 (`Compression::fast()`). It optimises for speed over ratio — adequate for typical API/HTML payloads, sub-millisecond on small responses.
+Sozune favours speed over ratio for live traffic:
+
+| Algorithm | Level | Notes |
+|---|---|---|
+| gzip | 1 (`fast`) | Sub-millisecond on small payloads. |
+| brotli | 4 | Fast end of brotli's range, still ~10–20% better than gzip. |
+| zstd | 3 | zstd's default; matches gzip speed with brotli-class ratio. |
+
+These levels are not configurable today.
 
 ## Limitations
 
-- **Gzip only.** No `br` (Brotli), no `zstd`.
 - **No streaming.** The body is buffered, compressed, then sent. Combined with the 10 MiB cap, this rules out streaming responses larger than that.
+- **No deflate.** Considered obsolete and not supported.
+- **Compression levels are fixed.** No knob to trade speed for ratio per service yet.

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -17,6 +17,7 @@ const COMPRESSIBLE_TYPES: &[&str] = &[
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Encoding {
+    Zstd,
     Brotli,
     Gzip,
 }
@@ -24,6 +25,7 @@ pub enum Encoding {
 impl Encoding {
     pub fn header_value(self) -> &'static str {
         match self {
+            Encoding::Zstd => "zstd",
             Encoding::Brotli => "br",
             Encoding::Gzip => "gzip",
         }
@@ -31,7 +33,7 @@ impl Encoding {
 }
 
 /// Pick the best supported encoding from the client's Accept-Encoding header.
-/// Brotli is preferred over gzip when both are accepted.
+/// Order of preference: zstd > brotli > gzip.
 pub fn pick_encoding(headers: &HeaderMap) -> Option<Encoding> {
     let raw = headers
         .get("accept-encoding")
@@ -45,7 +47,9 @@ pub fn pick_encoding(headers: &HeaderMap) -> Option<Encoding> {
         })
     };
 
-    if accepts("br") {
+    if accepts("zstd") {
+        Some(Encoding::Zstd)
+    } else if accepts("br") {
         Some(Encoding::Brotli)
     } else if accepts("gzip") {
         Some(Encoding::Gzip)
@@ -69,6 +73,7 @@ pub fn compress(data: &[u8], encoding: Encoding) -> Result<Vec<u8>, std::io::Err
     match encoding {
         Encoding::Gzip => gzip_compress(data),
         Encoding::Brotli => brotli_compress(data),
+        Encoding::Zstd => zstd_compress(data),
     }
 }
 
@@ -84,6 +89,10 @@ fn brotli_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     params.quality = 4;
     brotli::BrotliCompress(&mut std::io::Cursor::new(data), &mut out, &params)?;
     Ok(out)
+}
+
+fn zstd_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    zstd::encode_all(std::io::Cursor::new(data), 3)
 }
 
 #[cfg(test)]
@@ -110,7 +119,7 @@ mod tests {
     }
 
     #[test]
-    fn prefers_brotli_when_both_offered() {
+    fn prefers_brotli_over_gzip() {
         let headers = headers_with("accept-encoding", "gzip, br");
         assert_eq!(pick_encoding(&headers), Some(Encoding::Brotli));
     }
@@ -122,13 +131,25 @@ mod tests {
     }
 
     #[test]
+    fn picks_zstd_when_only_zstd_offered() {
+        let headers = headers_with("accept-encoding", "zstd");
+        assert_eq!(pick_encoding(&headers), Some(Encoding::Zstd));
+    }
+
+    #[test]
+    fn prefers_zstd_over_brotli_and_gzip() {
+        let headers = headers_with("accept-encoding", "gzip, br, zstd");
+        assert_eq!(pick_encoding(&headers), Some(Encoding::Zstd));
+    }
+
+    #[test]
     fn returns_none_without_accept_encoding() {
         assert_eq!(pick_encoding(&HeaderMap::new()), None);
     }
 
     #[test]
     fn returns_none_for_unsupported_encoding() {
-        let headers = headers_with("accept-encoding", "deflate, zstd");
+        let headers = headers_with("accept-encoding", "deflate, snappy");
         assert_eq!(pick_encoding(&headers), None);
     }
 
@@ -195,8 +216,19 @@ mod tests {
     }
 
     #[test]
+    fn zstd_roundtrip() {
+        let original = b"Hello, World! This is a test of zstd compression. \
+                         Repetitive text compresses very well with zstd, \
+                         which usually beats gzip and matches brotli on speed.";
+        let compressed = compress(original, Encoding::Zstd).unwrap();
+        let decompressed = zstd::decode_all(std::io::Cursor::new(&compressed)).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
     fn encoding_header_values() {
         assert_eq!(Encoding::Gzip.header_value(), "gzip");
         assert_eq!(Encoding::Brotli.header_value(), "br");
+        assert_eq!(Encoding::Zstd.header_value(), "zstd");
     }
 }

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -1,9 +1,9 @@
 use axum::http::HeaderMap;
+use brotli::enc::BrotliEncoderParams;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use std::io::Write;
 
-/// Content types that benefit from compression
 const COMPRESSIBLE_TYPES: &[&str] = &[
     "text/",
     "application/json",
@@ -15,15 +15,45 @@ const COMPRESSIBLE_TYPES: &[&str] = &[
     "image/svg",
 ];
 
-/// Check if the client accepts gzip encoding
-pub fn accepts_gzip(headers: &HeaderMap) -> bool {
-    headers
-        .get("accept-encoding")
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|v| v.contains("gzip"))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Encoding {
+    Brotli,
+    Gzip,
 }
 
-/// Check if the response content type is compressible
+impl Encoding {
+    pub fn header_value(self) -> &'static str {
+        match self {
+            Encoding::Brotli => "br",
+            Encoding::Gzip => "gzip",
+        }
+    }
+}
+
+/// Pick the best supported encoding from the client's Accept-Encoding header.
+/// Brotli is preferred over gzip when both are accepted.
+pub fn pick_encoding(headers: &HeaderMap) -> Option<Encoding> {
+    let raw = headers
+        .get("accept-encoding")
+        .and_then(|v| v.to_str().ok())?;
+    let tokens: Vec<&str> = raw.split(',').map(|s| s.trim()).collect();
+
+    let accepts = |needle: &str| {
+        tokens.iter().any(|tok| {
+            let name = tok.split(';').next().unwrap_or("").trim();
+            name.eq_ignore_ascii_case(needle)
+        })
+    };
+
+    if accepts("br") {
+        Some(Encoding::Brotli)
+    } else if accepts("gzip") {
+        Some(Encoding::Gzip)
+    } else {
+        None
+    }
+}
+
 pub fn is_compressible(headers: &HeaderMap) -> bool {
     headers
         .get("content-type")
@@ -31,16 +61,29 @@ pub fn is_compressible(headers: &HeaderMap) -> bool {
         .is_some_and(|ct| COMPRESSIBLE_TYPES.iter().any(|t| ct.contains(t)))
 }
 
-/// Check if the response is already compressed
 pub fn is_already_compressed(headers: &HeaderMap) -> bool {
     headers.contains_key("content-encoding")
 }
 
-/// Compress bytes with gzip
-pub fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+pub fn compress(data: &[u8], encoding: Encoding) -> Result<Vec<u8>, std::io::Error> {
+    match encoding {
+        Encoding::Gzip => gzip_compress(data),
+        Encoding::Brotli => brotli_compress(data),
+    }
+}
+
+fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
     encoder.write_all(data)?;
     encoder.finish()
+}
+
+fn brotli_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut params = BrotliEncoderParams::default();
+    params.quality = 4;
+    brotli::BrotliCompress(&mut std::io::Cursor::new(data), &mut out, &params)?;
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -61,18 +104,42 @@ mod tests {
     }
 
     #[test]
-    fn test_accepts_gzip() {
-        assert!(accepts_gzip(&headers_with(
-            "accept-encoding",
-            "gzip, deflate"
-        )));
-        assert!(accepts_gzip(&headers_with("accept-encoding", "gzip")));
-        assert!(!accepts_gzip(&headers_with("accept-encoding", "br")));
-        assert!(!accepts_gzip(&HeaderMap::new()));
+    fn picks_gzip_when_only_gzip_offered() {
+        let headers = headers_with("accept-encoding", "gzip, deflate");
+        assert_eq!(pick_encoding(&headers), Some(Encoding::Gzip));
     }
 
     #[test]
-    fn test_is_compressible() {
+    fn prefers_brotli_when_both_offered() {
+        let headers = headers_with("accept-encoding", "gzip, br");
+        assert_eq!(pick_encoding(&headers), Some(Encoding::Brotli));
+    }
+
+    #[test]
+    fn picks_brotli_when_only_brotli_offered() {
+        let headers = headers_with("accept-encoding", "br");
+        assert_eq!(pick_encoding(&headers), Some(Encoding::Brotli));
+    }
+
+    #[test]
+    fn returns_none_without_accept_encoding() {
+        assert_eq!(pick_encoding(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn returns_none_for_unsupported_encoding() {
+        let headers = headers_with("accept-encoding", "deflate, zstd");
+        assert_eq!(pick_encoding(&headers), None);
+    }
+
+    #[test]
+    fn ignores_quality_values() {
+        let headers = headers_with("accept-encoding", "gzip;q=1.0, br;q=0.5");
+        assert_eq!(pick_encoding(&headers), Some(Encoding::Brotli));
+    }
+
+    #[test]
+    fn detects_compressible_types() {
         assert!(is_compressible(&headers_with(
             "content-type",
             "text/html; charset=utf-8"
@@ -80,10 +147,6 @@ mod tests {
         assert!(is_compressible(&headers_with(
             "content-type",
             "application/json"
-        )));
-        assert!(is_compressible(&headers_with(
-            "content-type",
-            "application/javascript"
         )));
         assert!(is_compressible(&headers_with(
             "content-type",
@@ -97,25 +160,43 @@ mod tests {
     }
 
     #[test]
-    fn test_already_compressed() {
+    fn detects_already_compressed_responses() {
         assert!(is_already_compressed(&headers_with(
             "content-encoding",
             "gzip"
+        )));
+        assert!(is_already_compressed(&headers_with(
+            "content-encoding",
+            "br"
         )));
         assert!(!is_already_compressed(&HeaderMap::new()));
     }
 
     #[test]
-    fn test_gzip_roundtrip() {
+    fn gzip_roundtrip() {
         let original = b"Hello, World! This is a test of gzip compression.";
-        let compressed = gzip_compress(original).unwrap();
-
-        assert!(compressed.len() < original.len() + 30); // gzip has overhead for small data
-
-        // Decompress and verify
+        let compressed = compress(original, Encoding::Gzip).unwrap();
         let mut decoder = GzDecoder::new(&compressed[..]);
         let mut decompressed = String::new();
         decoder.read_to_string(&mut decompressed).unwrap();
         assert_eq!(decompressed.as_bytes(), original);
+    }
+
+    #[test]
+    fn brotli_roundtrip() {
+        let original = b"Hello, World! This is a test of brotli compression. \
+                         Repetitive text compresses very well with brotli, \
+                         which usually beats gzip on HTML and JSON payloads.";
+        let compressed = compress(original, Encoding::Brotli).unwrap();
+        let mut decompressed = Vec::new();
+        brotli::BrotliDecompress(&mut std::io::Cursor::new(&compressed), &mut decompressed)
+            .unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn encoding_header_values() {
+        assert_eq!(Encoding::Gzip.header_value(), "gzip");
+        assert_eq!(Encoding::Brotli.header_value(), "br");
     }
 }

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -105,7 +105,7 @@ pub async fn handle_proxy(
         backend_host, backend_port, forwarded_path, query
     );
 
-    let client_accepts_gzip = compress::accepts_gzip(req.headers());
+    let client_encoding = compress::pick_encoding(req.headers());
 
     debug!(
         "Proxying {} {} -> {}",
@@ -165,21 +165,23 @@ pub async fn handle_proxy(
         Ok(resp) => {
             let (mut parts, body) = resp.into_parts();
 
-            let should_compress = route.compress
-                && client_accepts_gzip
-                && compress::is_compressible(&parts.headers)
-                && !compress::is_already_compressed(&parts.headers);
+            let encoding = client_encoding.filter(|_| {
+                route.compress
+                    && compress::is_compressible(&parts.headers)
+                    && !compress::is_already_compressed(&parts.headers)
+            });
 
-            if should_compress {
+            if let Some(encoding) = encoding {
                 let body = Body::new(body.map_err(|e| {
                     axum::Error::new(std::io::Error::new(std::io::ErrorKind::Other, e))
                 }));
                 match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
-                    Ok(bytes) => match compress::gzip_compress(&bytes) {
+                    Ok(bytes) => match compress::compress(&bytes, encoding) {
                         Ok(compressed) => {
-                            parts
-                                .headers
-                                .insert("content-encoding", "gzip".parse().unwrap());
+                            parts.headers.insert(
+                                "content-encoding",
+                                encoding.header_value().parse().unwrap(),
+                            );
                             parts.headers.insert(
                                 "content-length",
                                 compressed.len().to_string().parse().unwrap(),

--- a/tests/e2e/02-middleware.sh
+++ b/tests/e2e/02-middleware.sh
@@ -171,6 +171,28 @@ else
     fail "brotli compression: gzip used instead of brotli ($br_pref_encoding)"
 fi
 
+log "[02] Middleware: zstd compression"
+
+zstd_only_encoding=$(curl -s -D - -o /dev/null --max-time 2 \
+    -H "Host: $HOST_COMPRESS" \
+    -H "Accept-Encoding: zstd" \
+    "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null | grep -i "content-encoding" || echo "")
+if echo "$zstd_only_encoding" | grep -qi "zstd"; then
+    pass "zstd compression: response has Content-Encoding: zstd"
+else
+    fail "zstd compression: no Content-Encoding: zstd header found"
+fi
+
+zstd_pref_encoding=$(curl -s -D - -o /dev/null --max-time 2 \
+    -H "Host: $HOST_COMPRESS" \
+    -H "Accept-Encoding: gzip, br, zstd" \
+    "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null | grep -i "content-encoding" || echo "")
+if echo "$zstd_pref_encoding" | grep -qi "zstd"; then
+    pass "zstd compression: preferred when all three accepted"
+else
+    fail "zstd compression: not preferred over br/gzip ($zstd_pref_encoding)"
+fi
+
 log "[02] Middleware: backend timeout"
 
 wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_TIMEOUT" "200" || true

--- a/tests/e2e/02-middleware.sh
+++ b/tests/e2e/02-middleware.sh
@@ -149,6 +149,28 @@ else
     pass "gzip compression: no compression without Accept-Encoding"
 fi
 
+log "[02] Middleware: brotli compression"
+
+br_only_encoding=$(curl -s -D - -o /dev/null --max-time 2 \
+    -H "Host: $HOST_COMPRESS" \
+    -H "Accept-Encoding: br" \
+    "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null | grep -i "content-encoding" || echo "")
+if echo "$br_only_encoding" | grep -qi "br"; then
+    pass "brotli compression: response has Content-Encoding: br"
+else
+    fail "brotli compression: no Content-Encoding: br header found"
+fi
+
+br_pref_encoding=$(curl -s -D - -o /dev/null --max-time 2 \
+    -H "Host: $HOST_COMPRESS" \
+    -H "Accept-Encoding: gzip, br" \
+    "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null | grep -i "content-encoding" || echo "")
+if echo "$br_pref_encoding" | grep -qi "br"; then
+    pass "brotli compression: preferred over gzip when both accepted"
+else
+    fail "brotli compression: gzip used instead of brotli ($br_pref_encoding)"
+fi
+
 log "[02] Middleware: backend timeout"
 
 wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_TIMEOUT" "200" || true


### PR DESCRIPTION
Adds Brotli (br) and zstd compression alongside gzip. Sozune now picks the best encoding from Accept-Encoding in order: zstd > br > gzip. Doc and e2e updated.