### PR TITLE
Diagnose unknown labels and unrouted requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -H "Host: whoami.localhost" http://localhost
 - Routing — [Hostnames](documentation/routing/hostnames.md) · [Path matching](documentation/routing/path-matching.md) · [Load balancing](documentation/routing/load-balancing.md)
 - TLS — [Overview](documentation/tls/overview.md) · [ACME / Let's Encrypt](documentation/tls/acme.md)
 - Middleware — [Basic auth](documentation/middleware/auth.md) · [Custom headers](documentation/middleware/headers.md) · [Strip prefix](documentation/middleware/strip-prefix.md) · [Redirects](documentation/middleware/redirects.md) · [Rate limit](documentation/middleware/rate-limit.md) · [Gzip compression](documentation/middleware/compress.md) · [Backend timeout](documentation/middleware/backend-timeout.md)
-- Advanced — [Health checks](documentation/advanced/health-checks.md) · [WebSocket](documentation/advanced/websocket.md) · [Access logs](documentation/advanced/access-logs.md)
+- Advanced — [Health checks](documentation/advanced/health-checks.md) · [WebSocket](documentation/advanced/websocket.md) · [Access logs](documentation/advanced/access-logs.md) · [Debugging](documentation/advanced/debugging.md)
 
 ## Architecture
 

--- a/documentation/advanced/debugging.md
+++ b/documentation/advanced/debugging.md
@@ -1,0 +1,56 @@
+# Debugging
+
+When a request can't be routed, sozune returns `502 Bad Gateway`. By default the response body is empty so configured hostnames and backend addresses don't leak to the public. Setting `SOZUNE_DEBUG=true` adds a plain-text body explaining what went wrong, including a did-you-mean suggestion when the request `Host` looks like a typo of a configured host.
+
+## The `X-Sozune-Diagnostic` header
+
+The header is **always** set on routing failures, regardless of `SOZUNE_DEBUG`. It carries one of the following reasons:
+
+| Value | Meaning |
+|---|---|
+| `no-route-for-host` | No entrypoint matches the request's `Host` header |
+| `no-healthy-backend` | A route matched but no backend is currently available |
+
+The header is opaque on purpose — it tells operators *why* without exposing topology. Grep for it in CDN/proxy access logs to spot misrouted traffic without turning on debug mode.
+
+## `SOZUNE_DEBUG=true`
+
+When set to `true` (or `1`), sozune adds a plain-text body to the failure response:
+
+```
+$ SOZUNE_DEBUG=true sozune
+$ curl -i -H "Host: exmple.com" http://localhost
+HTTP/1.1 502 Bad Gateway
+x-sozune-diagnostic: no-route-for-host
+content-type: text/plain; charset=utf-8
+
+sozune: no route configured for host 'exmple.com'.
+
+Configured hosts:
+  - api.example.com
+  - example.com
+
+Did you mean 'example.com'?
+
+Set SOZUNE_DEBUG=false to hide this body in production.
+```
+
+For `no-healthy-backend`, the body lists the configured backends instead:
+
+```
+sozune: no backend available for host 'example.com'.
+
+Configured backends:
+  - 10.0.0.1:8080
+  - 10.0.0.2:8080
+```
+
+## When to use it
+
+- **Local development** — instantly see why a `Host`/route doesn't match, without tailing logs.
+- **Staging** — leave it on so QA gets immediate feedback on misconfigured services.
+- **Production** — leave it **off**. The `X-Sozune-Diagnostic` header is enough to diagnose from the operator side, and the server-side log line (`info` level) records the same information without exposing it to clients.
+
+## Configuration validation at boot
+
+`SOZUNE_DEBUG` only affects runtime responses. For diagnostics that surface at config-load time (typos in Docker labels, missing required fields, unknown protocols), use [`sozune validate`](../configuration/docker-labels.md). Both paths share the same diagnostic codes (`E001` … `W013`, `I001` …), so what `validate` reports cannot drift from what the proxy actually does.

--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -141,3 +141,12 @@ Every field above can be overridden through an environment variable. The env var
 | `middleware.port` | `SOZUNE_MIDDLEWARE_PORT` |
 
 Booleans accept `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`.
+
+### Standalone variables
+
+These have no YAML counterpart:
+
+| Env var | Effect |
+|---|---|
+| `CONFIG_PATH` | Path to the YAML config file (default: `config.yaml`) |
+| `SOZUNE_DEBUG` | When `true`, routing failures (`502`) include a body listing configured hosts/backends and a did-you-mean suggestion. Off by default to avoid leaking topology. See [Debugging](../advanced/debugging.md). |

--- a/src/labels/catalog.rs
+++ b/src/labels/catalog.rs
@@ -1,0 +1,218 @@
+use std::collections::HashMap;
+
+use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::util::fuzzy::closest_match;
+
+const GLOBAL_LABELS: &[&str] = &["enable", "network"];
+
+const SERVICE_FIELDS: &[&str] = &[
+    "host",
+    "port",
+    "priority",
+    "backendTimeout",
+    "tls",
+    "stripPrefix",
+    "httpsRedirect",
+    "httpsRedirectPort",
+    "stickySession",
+    "compress",
+    "path",
+    "prefix",
+    "pathRegex",
+    "redirect",
+    "redirectScheme",
+    "redirectTemplate",
+    "wwwAuthenticate",
+    "ratelimit.average",
+    "ratelimit.burst",
+    "auth.basic",
+];
+
+/// Field suffixes that accept arbitrary sub-keys (e.g. `headers.X-Foo`).
+/// Anything beginning with one of these is considered known.
+const SERVICE_FIELD_PREFIXES: &[&str] = &["headers."];
+
+const SUPPORTED_PROTOCOLS: &[&str] = &["http", "tcp", "udp"];
+
+/// Scan all labels and emit `W013UnknownLabel` for every `sozune.*` key that
+/// does not match a known shape. Typos like `sozune.http.web.timout` would be
+/// silently ignored otherwise; this surfaces them with a did-you-mean hint.
+pub fn detect_unknown_labels(labels: &HashMap<String, String>, diagnostics: &mut Vec<Diagnostic>) {
+    let mut unknown: Vec<&String> = labels
+        .keys()
+        .filter(|k| k.starts_with("sozune."))
+        .filter(|k| !is_known(k))
+        .collect();
+    unknown.sort();
+
+    for key in unknown {
+        let value = &labels[key];
+        let mut diag = Diagnostic::new(
+            DiagnosticCode::W013UnknownLabel,
+            format!("unknown label '{key}', ignored"),
+        )
+        .with_label(key)
+        .with_value(value);
+        if let Some(suggestion) = suggest(key) {
+            diag = diag.with_hint(format!("did you mean `{suggestion}`?"));
+        } else {
+            diag = diag
+                .with_hint("see https://sozune.dev/docs/labels for the list of supported labels");
+        }
+        diagnostics.push(diag);
+    }
+}
+
+fn is_known(full_key: &str) -> bool {
+    let Some(rest) = full_key.strip_prefix("sozune.") else {
+        return false;
+    };
+    if GLOBAL_LABELS.contains(&rest) {
+        return true;
+    }
+    let mut parts = rest.splitn(3, '.');
+    let (Some(protocol), Some(_service), Some(suffix)) = (parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    if !SUPPORTED_PROTOCOLS.contains(&protocol) {
+        // Unknown protocols are reported by W012, not W013.
+        return true;
+    }
+    if SERVICE_FIELDS.contains(&suffix) {
+        return true;
+    }
+    SERVICE_FIELD_PREFIXES
+        .iter()
+        .any(|p| suffix.starts_with(p) && suffix.len() > p.len())
+}
+
+/// Build a did-you-mean suggestion for an unknown key by replacing only the
+/// segments that don't match a known value, using Levenshtein distance.
+fn suggest(full_key: &str) -> Option<String> {
+    let rest = full_key.strip_prefix("sozune.")?;
+
+    if let Some(closest) = closest_match(rest, GLOBAL_LABELS, 2) {
+        return Some(format!("sozune.{closest}"));
+    }
+
+    let mut parts: Vec<&str> = rest.splitn(3, '.').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let (protocol, service, suffix) = (parts[0], parts[1], parts[2]);
+
+    let protocol_fixed = if SUPPORTED_PROTOCOLS.contains(&protocol) {
+        protocol.to_string()
+    } else {
+        closest_match(protocol, SUPPORTED_PROTOCOLS, 2)?.to_string()
+    };
+
+    let suffix_fixed = if SERVICE_FIELDS.contains(&suffix)
+        || SERVICE_FIELD_PREFIXES
+            .iter()
+            .any(|p| suffix.starts_with(p) && suffix.len() > p.len())
+    {
+        suffix.to_string()
+    } else {
+        closest_match(suffix, SERVICE_FIELDS, 2)?.to_string()
+    };
+
+    parts[0] = &protocol_fixed;
+    parts[2] = &suffix_fixed;
+    let _ = service;
+    Some(format!(
+        "sozune.{}.{}.{}",
+        protocol_fixed, parts[1], suffix_fixed
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn known_labels_are_silent() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(
+            &labels(&[
+                ("sozune.enable", "true"),
+                ("sozune.network", "internal"),
+                ("sozune.http.web.host", "example.com"),
+                ("sozune.http.web.port", "8080"),
+                ("sozune.http.web.ratelimit.average", "100"),
+                ("sozune.http.web.auth.basic", "u:h"),
+                ("sozune.http.web.headers.X-Foo", "bar"),
+                ("sozune.http.web.headers.response.X-Bar", "baz"),
+                ("non.sozune.key", "ignored"),
+            ]),
+            &mut diags,
+        );
+        assert!(diags.is_empty(), "got: {:?}", diags);
+    }
+
+    #[test]
+    fn unknown_protocol_is_not_reported_here() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(&labels(&[("sozune.ftp.legacy.host", "x")]), &mut diags);
+        assert!(diags.is_empty(), "W012 owns this case, not W013");
+    }
+
+    #[test]
+    fn typo_in_field_emits_w013_with_suggestion() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(&labels(&[("sozune.http.web.timeout", "5s")]), &mut diags);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::W013UnknownLabel);
+        let hint = diags[0].hint.as_deref().unwrap();
+        assert!(
+            hint.contains("backendTimeout"),
+            "expected suggestion, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn small_typo_in_field_emits_w013_with_suggestion() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(&labels(&[("sozune.http.web.prt", "8080")]), &mut diags);
+        assert_eq!(diags.len(), 1);
+        let hint = diags[0].hint.as_deref().unwrap();
+        assert!(hint.contains("port"), "got: {hint}");
+    }
+
+    #[test]
+    fn typo_in_global_emits_w013() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(&labels(&[("sozune.netwrok", "internal")]), &mut diags);
+        assert_eq!(diags.len(), 1);
+        let hint = diags[0].hint.as_deref().unwrap();
+        assert!(hint.contains("network"), "got: {hint}");
+    }
+
+    #[test]
+    fn unknown_label_without_close_match_falls_back_to_doc_link() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(
+            &labels(&[("sozune.http.web.completely_made_up_field", "x")]),
+            &mut diags,
+        );
+        assert_eq!(diags.len(), 1);
+        let hint = diags[0].hint.as_deref().unwrap();
+        assert!(hint.contains("sozune.dev"));
+    }
+
+    #[test]
+    fn missing_third_segment_is_unknown() {
+        let mut diags = Vec::new();
+        detect_unknown_labels(&labels(&[("sozune.http.web", "x")]), &mut diags);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, DiagnosticCode::W013UnknownLabel);
+    }
+}

--- a/src/labels/diagnostic.rs
+++ b/src/labels/diagnostic.rs
@@ -28,6 +28,7 @@ pub enum DiagnosticCode {
     W010NoIpFellBackToLocalhost,
     W011EmptyBasicAuth,
     W012InvalidProtocol,
+    W013UnknownLabel,
     // Info — surfaced only with --severity info
     I001PathDefaulted,
     I002PortDefaulted,
@@ -52,6 +53,7 @@ impl DiagnosticCode {
             DiagnosticCode::W010NoIpFellBackToLocalhost => "W010",
             DiagnosticCode::W011EmptyBasicAuth => "W011",
             DiagnosticCode::W012InvalidProtocol => "W012",
+            DiagnosticCode::W013UnknownLabel => "W013",
             DiagnosticCode::I001PathDefaulted => "I001",
             DiagnosticCode::I002PortDefaulted => "I002",
         }

--- a/src/labels/mod.rs
+++ b/src/labels/mod.rs
@@ -9,6 +9,7 @@
 //! validate reports cannot drift from what production actually does.
 
 pub mod candidate;
+pub mod catalog;
 pub mod diagnostic;
 pub mod fields;
 pub mod network;

--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::labels::candidate::Candidate;
+use crate::labels::catalog;
 use crate::labels::diagnostic::{Diagnostic, DiagnosticCode, ParseResult};
 use crate::labels::fields::{auth, core, headers, host, path, ratelimit, redirect};
 use crate::labels::network;
@@ -27,6 +28,8 @@ pub fn parse(candidate: &Candidate) -> ParseResult {
             diagnostics,
         };
     }
+
+    catalog::detect_unknown_labels(&candidate.labels, &mut diagnostics);
 
     let services = discover_services(&candidate.labels, &mut diagnostics);
     if services.is_empty() {
@@ -310,6 +313,21 @@ mod tests {
         assert_eq!(r.entrypoints.len(), 1);
         assert!(has_code(&r, DiagnosticCode::W001InvalidPort));
         assert_eq!(r.entrypoints.get("http_web").unwrap().config.port, 80);
+    }
+
+    #[test]
+    fn unknown_label_emits_w013_but_does_not_block_routing() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "example.com"),
+                ("sozune.http.web.timeout", "5s"),
+            ],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 1);
+        assert!(has_code(&r, DiagnosticCode::W013UnknownLabel));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod middleware;
 mod model;
 mod provider;
 mod proxy;
+mod util;
 
 pub use model::*;
 

--- a/src/middleware/diag.rs
+++ b/src/middleware/diag.rs
@@ -1,0 +1,156 @@
+//! Builders for runtime diagnostic responses returned when a request can't be
+//! routed. The header `X-Sozune-Diagnostic` is always set so operators can grep
+//! for the failure reason without parsing bodies. The body only carries
+//! configured-state details (known hosts, configured backends) when
+//! `SOZUNE_DEBUG=true`, to avoid leaking topology to the public.
+
+use axum::body::Body;
+use axum::http::{Response, StatusCode};
+use axum::response::IntoResponse;
+
+use crate::util::{debug_enabled, fuzzy::closest_match};
+
+const DIAG_HEADER: &str = "x-sozune-diagnostic";
+
+pub fn no_route_for_host(host: &str, known_hosts: &[String]) -> Response<Body> {
+    no_route_for_host_inner(host, known_hosts, debug_enabled())
+}
+
+pub fn no_healthy_backend(host: &str, configured_backends: &[(String, u16)]) -> Response<Body> {
+    no_healthy_backend_inner(host, configured_backends, debug_enabled())
+}
+
+fn no_route_for_host_inner(host: &str, known_hosts: &[String], debug: bool) -> Response<Body> {
+    let body = if debug {
+        let mut out =
+            format!("sozune: no route configured for host '{host}'.\n\nConfigured hosts:\n");
+        if known_hosts.is_empty() {
+            out.push_str("  (none — no entrypoints loaded)\n");
+        } else {
+            for h in known_hosts {
+                out.push_str(&format!("  - {h}\n"));
+            }
+        }
+        if let Some(suggestion) = suggest_host(host, known_hosts) {
+            out.push_str(&format!("\nDid you mean '{suggestion}'?\n"));
+        }
+        out.push_str("\nSet SOZUNE_DEBUG=false to hide this body in production.\n");
+        out
+    } else {
+        String::new()
+    };
+
+    build(StatusCode::BAD_GATEWAY, "no-route-for-host", body)
+}
+
+fn no_healthy_backend_inner(
+    host: &str,
+    configured_backends: &[(String, u16)],
+    debug: bool,
+) -> Response<Body> {
+    let body = if debug {
+        let mut out =
+            format!("sozune: no backend available for host '{host}'.\n\nConfigured backends:\n");
+        if configured_backends.is_empty() {
+            out.push_str("  (none)\n");
+        } else {
+            for (h, p) in configured_backends {
+                out.push_str(&format!("  - {h}:{p}\n"));
+            }
+        }
+        out.push_str("\nSet SOZUNE_DEBUG=false to hide this body in production.\n");
+        out
+    } else {
+        String::new()
+    };
+
+    build(StatusCode::BAD_GATEWAY, "no-healthy-backend", body)
+}
+
+fn suggest_host(host: &str, known_hosts: &[String]) -> Option<String> {
+    let refs: Vec<&str> = known_hosts.iter().map(|s| s.as_str()).collect();
+    closest_match(host, &refs, 3).map(|s| s.to_string())
+}
+
+fn build(status: StatusCode, reason: &str, body: String) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(DIAG_HEADER, reason)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(Body::from(body))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    async fn into_parts(resp: Response<Body>) -> (StatusCode, String, String) {
+        let status = resp.status();
+        let header = resp
+            .headers()
+            .get(DIAG_HEADER)
+            .map(|v| v.to_str().unwrap().to_string())
+            .unwrap_or_default();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        (status, header, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn header_always_set_on_no_route() {
+        let resp = no_route_for_host_inner("example.com", &["other.com".to_string()], false);
+        let (status, header, body) = into_parts(resp).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(header, "no-route-for-host");
+        assert!(body.is_empty(), "expected empty body, got: {body}");
+    }
+
+    #[tokio::test]
+    async fn debug_body_lists_hosts_and_suggests() {
+        let resp = no_route_for_host_inner(
+            "exmple.com",
+            &["example.com".to_string(), "api.example.com".to_string()],
+            true,
+        );
+        let (_, _, body) = into_parts(resp).await;
+        assert!(body.contains("example.com"));
+        assert!(body.contains("Did you mean"), "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn no_backend_diag_with_debug_lists_backends() {
+        let resp = no_healthy_backend_inner(
+            "example.com",
+            &[
+                ("10.0.0.1".to_string(), 8080),
+                ("10.0.0.2".to_string(), 8080),
+            ],
+            true,
+        );
+        let (_, header, body) = into_parts(resp).await;
+        assert_eq!(header, "no-healthy-backend");
+        assert!(body.contains("10.0.0.1:8080"));
+        assert!(body.contains("10.0.0.2:8080"));
+    }
+
+    #[tokio::test]
+    async fn no_backend_diag_without_debug_is_opaque() {
+        let resp = no_healthy_backend_inner("example.com", &[], false);
+        let (_, header, body) = into_parts(resp).await;
+        assert_eq!(header, "no-healthy-backend");
+        assert!(body.is_empty());
+    }
+
+    #[test]
+    fn debug_enabled_reads_env() {
+        unsafe { std::env::set_var("SOZUNE_DEBUG", "true") };
+        assert!(debug_enabled());
+        unsafe { std::env::set_var("SOZUNE_DEBUG", "1") };
+        assert!(debug_enabled());
+        unsafe { std::env::set_var("SOZUNE_DEBUG", "false") };
+        assert!(!debug_enabled());
+        unsafe { std::env::remove_var("SOZUNE_DEBUG") };
+        assert!(!debug_enabled());
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 mod compress;
+mod diag;
 mod proxy;
 pub mod rate_limit;
 
@@ -57,6 +58,12 @@ impl MiddlewareRouteTable {
         // Strip port from host header if present (e.g. "example.com:8080" -> "example.com")
         let hostname = host.split(':').next().unwrap_or(host);
         self.routes.get(hostname).cloned()
+    }
+
+    pub fn known_hosts(&self) -> Vec<String> {
+        let mut hosts: Vec<String> = self.routes.keys().cloned().collect();
+        hosts.sort();
+        hosts
     }
 }
 

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -9,6 +9,7 @@ use tracing::{debug, error, info, warn};
 
 use super::MiddlewareAppState;
 use super::compress;
+use super::diag;
 use super::rate_limit::RateLimitResult;
 
 /// Main proxy handler: identifies the route by Host header,
@@ -41,7 +42,7 @@ pub async fn handle_proxy(
         }
     };
 
-    let route = {
+    let (route, known_hosts) = {
         let table = match state.route_table.read() {
             Ok(guard) => guard,
             Err(e) => {
@@ -49,16 +50,18 @@ pub async fn handle_proxy(
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
         };
-
-        // Route lookup validates Host against configured hostnames
-        table.get_route_by_host(&host)
+        (table.get_route_by_host(&host), table.known_hosts())
     };
 
     let route = match route {
         Some(r) => r,
         None => {
-            debug!("No middleware route for host '{}'", host);
-            return StatusCode::BAD_GATEWAY.into_response();
+            info!(
+                "no route for host '{}' (known: {})",
+                host,
+                known_hosts.len()
+            );
+            return diag::no_route_for_host(&host, &known_hosts).into_response();
         }
     };
 
@@ -83,7 +86,7 @@ pub async fn handle_proxy(
         Some(b) => b.clone(),
         None => {
             error!("No backends configured for host '{}'", host);
-            return StatusCode::BAD_GATEWAY.into_response();
+            return diag::no_healthy_backend(&host, &route.backends).into_response();
         }
     };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,94 @@
+//! Small cross-module helpers (fuzzy matching, debug-mode flag).
+
+pub mod fuzzy {
+    /// Find the closest match in `haystack` for `needle`. Returns `None` if
+    /// nothing is close enough. Substring containment in either direction is
+    /// treated as distance 1 so cases like `timeout` → `backendTimeout` work
+    /// even though raw Levenshtein distance is large.
+    pub fn closest_match<'a>(
+        needle: &str,
+        haystack: &'a [&'a str],
+        max_distance: usize,
+    ) -> Option<&'a str> {
+        let needle_lower = needle.to_lowercase();
+        let mut best: Option<(&str, usize)> = None;
+        for &candidate in haystack {
+            let candidate_lower = candidate.to_lowercase();
+            let d = if candidate_lower.contains(&needle_lower)
+                || needle_lower.contains(&candidate_lower)
+            {
+                1
+            } else {
+                levenshtein(&needle_lower, &candidate_lower)
+            };
+            if d <= max_distance && best.map_or(true, |(_, bd)| d < bd) {
+                best = Some((candidate, d));
+            }
+        }
+        best.map(|(s, _)| s)
+    }
+
+    pub fn levenshtein(a: &str, b: &str) -> usize {
+        let a: Vec<char> = a.chars().collect();
+        let b: Vec<char> = b.chars().collect();
+        let (n, m) = (a.len(), b.len());
+        if n == 0 {
+            return m;
+        }
+        if m == 0 {
+            return n;
+        }
+        let mut prev: Vec<usize> = (0..=m).collect();
+        let mut curr = vec![0usize; m + 1];
+        for i in 1..=n {
+            curr[0] = i;
+            for j in 1..=m {
+                let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+                curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+            }
+            std::mem::swap(&mut prev, &mut curr);
+        }
+        prev[m]
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn levenshtein_basics() {
+            assert_eq!(levenshtein("", ""), 0);
+            assert_eq!(levenshtein("abc", ""), 3);
+            assert_eq!(levenshtein("", "abc"), 3);
+            assert_eq!(levenshtein("abc", "abc"), 0);
+            assert_eq!(levenshtein("abc", "abd"), 1);
+            assert_eq!(levenshtein("kitten", "sitting"), 3);
+        }
+
+        #[test]
+        fn closest_uses_substring_for_long_candidates() {
+            let opts = ["backendTimeout", "port"];
+            assert_eq!(closest_match("timeout", &opts, 2), Some("backendTimeout"));
+        }
+
+        #[test]
+        fn closest_returns_none_when_far_off() {
+            let opts = ["port", "host"];
+            assert!(closest_match("xyzzy", &opts, 2).is_none());
+        }
+
+        #[test]
+        fn closest_picks_shortest_distance() {
+            let opts = ["port", "host", "path"];
+            assert_eq!(closest_match("prt", &opts, 2), Some("port"));
+        }
+    }
+}
+
+/// Returns `true` when `SOZUNE_DEBUG=true`. Used to gate verbose runtime
+/// diagnostics that may leak configured hostnames or backend addresses.
+pub fn debug_enabled() -> bool {
+    std::env::var("SOZUNE_DEBUG")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false)
+}


### PR DESCRIPTION
Detect misspelled `sozune.*` labels at boot (W013 + did-you-mean) and replace silent 502s with an `X-Sozune-Diagnostic` header plus an explanatory body under `SOZUNE_DEBUG=true`.