### PR TITLE
Add Podman provider

### DIFF
--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -7,6 +7,7 @@ use crate::labels::diagnostic::Severity;
 use crate::labels::source::LabelSource;
 use crate::labels::{self, Candidate};
 use crate::provider::docker::DockerProvider;
+use crate::provider::podman::PodmanProvider;
 
 #[derive(Args, Debug)]
 pub struct ValidateArgs {
@@ -91,6 +92,20 @@ async fn collect_candidates(
                         Err(e) => eprintln!("docker: failed to collect candidates: {e}"),
                     },
                     Err(e) => eprintln!("docker: failed to connect: {e}"),
+                }
+            }
+        }
+    }
+
+    if want("podman") {
+        if let Some(podman_cfg) = &config.providers.podman {
+            if podman_cfg.enabled {
+                match PodmanProvider::new(podman_cfg.clone()) {
+                    Ok(provider) => match provider.collect().await {
+                        Ok(mut cs) => candidates.append(&mut cs),
+                        Err(e) => eprintln!("podman: failed to collect candidates: {e}"),
+                    },
+                    Err(e) => eprintln!("podman: failed to connect: {e}"),
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct AcmeConfig {
 #[derive(Deserialize, Debug, Default, Clone)]
 pub struct ProvidersConfig {
     pub docker: Option<DockerConfig>,
+    pub podman: Option<PodmanConfig>,
     pub config_file: Option<ConfigFileConfig>,
     pub http: Option<HttpProviderConfig>,
 }
@@ -52,6 +53,19 @@ pub struct DockerConfig {
     #[serde(
         default,
         deserialize_with = "deserialize_docker_expose_by_default_with_env"
+    )]
+    pub expose_by_default: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct PodmanConfig {
+    #[serde(default, deserialize_with = "deserialize_podman_enabled_with_env")]
+    pub enabled: bool,
+    #[serde(default, deserialize_with = "deserialize_podman_endpoint_with_env")]
+    pub endpoint: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_podman_expose_by_default_with_env"
     )]
     pub expose_by_default: bool,
 }
@@ -202,6 +216,24 @@ impl Default for DockerConfig {
             endpoint: "/var/run/docker.sock".to_string(),
             expose_by_default: false,
         }
+    }
+}
+
+impl Default for PodmanConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_podman_endpoint(),
+            expose_by_default: false,
+        }
+    }
+}
+
+fn default_podman_endpoint() -> String {
+    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+        format!("{runtime_dir}/podman/podman.sock")
+    } else {
+        "/run/podman/podman.sock".to_string()
     }
 }
 
@@ -420,6 +452,22 @@ deserialize_bool_with_env!(
 );
 
 deserialize_bool_with_env!(
+    deserialize_podman_enabled_with_env,
+    "SOZUNE_PROVIDER_PODMAN_ENABLED",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_podman_endpoint_with_env,
+    "SOZUNE_PROVIDER_PODMAN_ENDPOINT",
+    default_podman_endpoint
+);
+deserialize_bool_with_env!(
+    deserialize_podman_expose_by_default_with_env,
+    "SOZUNE_PROVIDER_PODMAN_EXPOSE_BY_DEFAULT",
+    false
+);
+
+deserialize_bool_with_env!(
     deserialize_config_file_enabled_with_env,
     "SOZUNE_PROVIDER_CONFIG_FILE_ENABLED",
     false
@@ -594,6 +642,27 @@ cluster_setup_delay_ms: 1000
         assert_eq!(config.buffer_size, 32768);
         assert_eq!(config.startup_delay_ms, 2000);
         assert_eq!(config.cluster_setup_delay_ms, 1000);
+    }
+
+    #[test]
+    fn test_podman_config_deserialization() {
+        let yaml = r#"
+enabled: true
+endpoint: /run/podman/podman.sock
+expose_by_default: true
+"#;
+        let config: PodmanConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.endpoint, "/run/podman/podman.sock");
+        assert!(config.expose_by_default);
+    }
+
+    #[test]
+    fn test_podman_config_defaults() {
+        let config = PodmanConfig::default();
+        assert!(!config.enabled);
+        assert!(!config.expose_by_default);
+        assert!(config.endpoint.ends_with("podman.sock"));
     }
 
     #[test]

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -19,6 +19,7 @@ use tracing::{debug, error, info, warn};
 pub struct DockerProvider {
     docker: Docker,
     config: DockerConfig,
+    name: &'static str,
     /// Tracks container_id -> IP so we can clean up when the container stops
     /// (stopped containers no longer expose their network IP via inspect)
     container_ips: std::sync::Mutex<HashMap<String, String>>,
@@ -35,14 +36,14 @@ impl Provider for DockerProvider {
     }
 
     fn name(&self) -> &'static str {
-        "docker"
+        self.name
     }
 }
 
 #[async_trait]
 impl LabelSource for DockerProvider {
     fn provider_name(&self) -> &'static str {
-        "docker"
+        self.name
     }
 
     async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
@@ -68,7 +69,7 @@ impl LabelSource for DockerProvider {
                 .unwrap_or_else(|| id.clone());
             let networks = self.extract_networks(&id).await;
             candidates.push(Candidate {
-                provider: "docker",
+                provider: self.name,
                 id,
                 display_name,
                 labels,
@@ -82,6 +83,13 @@ impl LabelSource for DockerProvider {
 
 impl DockerProvider {
     pub fn new(config: DockerConfig) -> Result<Self, bollard::errors::Error> {
+        Self::new_named(config, "docker")
+    }
+
+    pub fn new_named(
+        config: DockerConfig,
+        name: &'static str,
+    ) -> Result<Self, bollard::errors::Error> {
         let docker = if config.endpoint.starts_with("unix://") {
             Docker::connect_with_socket(&config.endpoint, 120, bollard::API_DEFAULT_VERSION)?
         } else if config.endpoint.starts_with("/") {
@@ -96,6 +104,7 @@ impl DockerProvider {
         Ok(Self {
             docker,
             config,
+            name,
             container_ips: std::sync::Mutex::new(HashMap::new()),
         })
     }
@@ -125,7 +134,7 @@ impl DockerProvider {
                         };
 
                         for (key, mut entrypoint) in initial_entrypoints {
-                            entrypoint.source = Some("docker".to_string());
+                            entrypoint.source = Some(self.name.to_string());
 
                             if !storage_write.contains_key(&key) {
                                 info!("Found new container entrypoint: {}", key);
@@ -243,7 +252,7 @@ impl DockerProvider {
                                                     } else {
                                                         let mut entrypoint = entrypoint;
                                                         entrypoint.source =
-                                                            Some("docker".to_string());
+                                                            Some(self.name.to_string());
                                                         storage_write.insert(key, entrypoint);
                                                     }
                                                 }
@@ -337,7 +346,7 @@ impl DockerProvider {
                                                     }
                                                 } else {
                                                     let mut entrypoint = entrypoint;
-                                                    entrypoint.source = Some("docker".to_string());
+                                                    entrypoint.source = Some(self.name.to_string());
                                                     storage_write.insert(key, entrypoint);
                                                 }
                                             }
@@ -486,7 +495,7 @@ impl DockerProvider {
             .unwrap_or_default();
 
         Ok(Some(Candidate {
-            provider: "docker",
+            provider: self.name,
             id: container_id.to_string(),
             display_name,
             labels,
@@ -504,7 +513,7 @@ impl DockerProvider {
         networks: Vec<NetworkInfo>,
     ) -> Candidate {
         Candidate {
-            provider: "docker",
+            provider: self.name,
             display_name: container_id.clone(),
             id: container_id,
             labels,

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -2,6 +2,7 @@ use crate::config::AppConfig;
 use crate::model::Entrypoint;
 use crate::provider::{
     Provider, config::ConfigProvider, docker::DockerProvider, http::HttpProvider,
+    podman::PodmanProvider,
 };
 use anyhow::Context;
 use std::collections::BTreeMap;
@@ -74,10 +75,26 @@ pub async fn start_services(
                 .context("Failed to create Docker provider")?;
 
             if let Err(e) = docker_provider
-                .start_service(Arc::clone(&storage), reload_tx.clone(), acme_notify)
+                .start_service(Arc::clone(&storage), reload_tx.clone(), Arc::clone(&acme_notify))
                 .await
             {
                 error!("Docker service failed: {}", e);
+            }
+        }
+    }
+
+    // Start Podman service if enabled (Docker API-compatible socket)
+    if let Some(podman_config) = &config.providers.podman {
+        if podman_config.enabled {
+            info!("Starting Podman service");
+            let podman_provider = PodmanProvider::new(podman_config.clone())
+                .context("Failed to create Podman provider")?;
+
+            if let Err(e) = podman_provider
+                .start_service(Arc::clone(&storage), reload_tx.clone(), acme_notify)
+                .await
+            {
+                error!("Podman service failed: {}", e);
             }
         }
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -12,3 +12,4 @@ pub mod config;
 pub mod docker;
 pub mod factory;
 pub mod http;
+pub mod podman;

--- a/src/provider/podman.rs
+++ b/src/provider/podman.rs
@@ -1,0 +1,60 @@
+use crate::config::{DockerConfig, PodmanConfig};
+use crate::labels::candidate::Candidate;
+use crate::labels::source::LabelSource;
+use crate::model::Entrypoint;
+use crate::provider::Provider;
+use crate::provider::docker::DockerProvider;
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+use tokio::sync::mpsc;
+
+pub struct PodmanProvider {
+    inner: DockerProvider,
+}
+
+impl PodmanProvider {
+    pub fn new(config: PodmanConfig) -> Result<Self, bollard::errors::Error> {
+        let docker_config = DockerConfig {
+            enabled: config.enabled,
+            endpoint: config.endpoint,
+            expose_by_default: config.expose_by_default,
+        };
+        Ok(Self {
+            inner: DockerProvider::new_named(docker_config, "podman")?,
+        })
+    }
+
+    pub async fn start_service(
+        &self,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<tokio::sync::Notify>,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .start_service(storage, reload_tx, acme_notify)
+            .await
+    }
+}
+
+#[async_trait]
+impl Provider for PodmanProvider {
+    async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        self.inner.provide().await
+    }
+
+    fn name(&self) -> &'static str {
+        "podman"
+    }
+}
+
+#[async_trait]
+impl LabelSource for PodmanProvider {
+    fn provider_name(&self) -> &'static str {
+        "podman"
+    }
+
+    async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
+        self.inner.collect().await
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `PodmanProvider` that wraps `DockerProvider` and connects to the Podman Docker-compatible socket.
- Parameterize `DockerProvider` with a `name` field so the same code path can identify itself as `docker` or `podman` in logs, candidates, and entrypoint `source`.
- Wire Podman config into `ProvidersConfig`, `factory`, and `validate` (with `SOZUNE_PROVIDER_PODMAN_*` env vars and a rootless-friendly default endpoint at `$XDG_RUNTIME_DIR/podman/podman.sock`).

## Test plan
- [x] `cargo check` clean
- [x] `cargo test --bin sozune config::` (8/8 passing, including new `PodmanConfig` tests)
- [x] End-to-end against Podman 5.4 rootless socket: container with `sozune.http.web.host`/`sozune.http.web.port` labels reported as routed, IP `10.89.0.2` extracted via `extract_networks`
- [ ] Validate with rootful Podman in a real deployment