### PR TITLE
Add TCP entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sōzune (pronounce *Sozuné*) is a modern reverse proxy built on [Sōzu](https:/
 - **HTTP/2** — negotiated through ALPN on every TLS listener.
 - **Hot reload** — REST API applies changes on the fly, no downtime.
 - **Wildcard & regex hostnames** — `*.example.com`, `/cdn[0-9]+/.example.com`.
-- **Multi-protocol** — HTTP, HTTPS, WebSocket.
+- **Multi-protocol** — HTTP, HTTPS, WebSocket, raw TCP passthrough.
 
 ## Quick start
 
@@ -56,7 +56,7 @@ curl -H "Host: whoami.localhost" http://localhost
 - [Docker labels reference](documentation/configuration/docker-labels.md)
 - [Configuration file & env vars](documentation/configuration/overview.md)
 - [REST API](documentation/configuration/api.md)
-- Routing — [Hostnames](documentation/routing/hostnames.md) · [Path matching](documentation/routing/path-matching.md) · [Load balancing](documentation/routing/load-balancing.md)
+- Routing — [Hostnames](documentation/routing/hostnames.md) · [Path matching](documentation/routing/path-matching.md) · [Load balancing](documentation/routing/load-balancing.md) · [TCP](documentation/routing/tcp.md)
 - TLS — [Overview](documentation/tls/overview.md) · [ACME / Let's Encrypt](documentation/tls/acme.md)
 - Middleware — [Basic auth](documentation/middleware/auth.md) · [Custom headers](documentation/middleware/headers.md) · [Strip prefix](documentation/middleware/strip-prefix.md) · [Redirects](documentation/middleware/redirects.md) · [Rate limit](documentation/middleware/rate-limit.md) · [Response compression](documentation/middleware/compress.md) · [Backend timeout](documentation/middleware/backend-timeout.md)
 - Advanced — [Health checks](documentation/advanced/health-checks.md) · [WebSocket](documentation/advanced/websocket.md) · [Access logs](documentation/advanced/access-logs.md) · [Debugging](documentation/advanced/debugging.md)

--- a/documentation/configuration/docker-labels.md
+++ b/documentation/configuration/docker-labels.md
@@ -48,16 +48,19 @@ Where `<service>` is your own identifier — it groups labels for the same logic
 | `sozune.http.<svc>.backendTimeout` | [Backend timeout](/documentation/middleware/backend-timeout) |
 | `sozune.http.<svc>.stickySession` | [Sticky sessions](/documentation/routing/load-balancing) |
 
-## Routing — TCP / UDP
+## Routing — TCP
 
-| Label | Description |
-|---|---|
-| `sozune.tcp.<svc>.host` | Hostname for the TCP service |
-| `sozune.tcp.<svc>.port` | Backend port |
-| `sozune.udp.<svc>.host` | Hostname for the UDP service |
-| `sozune.udp.<svc>.port` | Backend port |
+TCP routing requires a listener declared under `proxy.tcp` in the main config. Labels then attach a backend to that listener by name. See [TCP routing](/documentation/routing/tcp) for the full picture.
 
-> **Note:** TCP and UDP entrypoints are recognised at the label-parsing level but are not currently proxied — the Sōzu TCP worker integration is not yet wired in.
+| Label | Example | Description |
+|---|---|---|
+| `sozune.tcp.<svc>.entrypoint` | `postgres` | Listener name declared under `proxy.tcp`. **Required.** |
+| `sozune.tcp.<svc>.port` | `5432` | Backend port on the container. |
+| `sozune.tcp.<svc>.priority` | `100` | Higher wins when multiple services share the same listener (default `0`). |
+
+## Routing — UDP
+
+> **Note:** UDP entrypoints are recognised at the label-parsing level but are not currently proxied — the Sōzu UDP worker integration is not yet wired in.
 
 ## Full example
 
@@ -76,4 +79,11 @@ services:
       - "sozune.http.api.ratelimit.average=100"
       - "sozune.http.api.ratelimit.burst=50"
       - "sozune.http.api.headers.X-Powered-By=sozune"
+
+  db:
+    image: postgres:16
+    labels:
+      - "sozune.enable=true"
+      - "sozune.tcp.db.entrypoint=postgres"
+      - "sozune.tcp.db.port=5432"
 ```

--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -30,6 +30,9 @@ proxy:
     listen_address: 80
   https:
     listen_address: 443
+  tcp:
+    - name: postgres
+      listen: 5432
   max_buffers: 500
   buffer_size: 16384
   startup_delay_ms: 1000
@@ -94,6 +97,7 @@ providers:
 |---|---|---|
 | `proxy.http.listen_address` | `80` | Port for the HTTP listener |
 | `proxy.https.listen_address` | `443` | Port for the HTTPS listener |
+| `proxy.tcp` | `[]` | List of TCP listeners. Each entry has `name` (referenced by labels) and `listen` (port). See [TCP routing](../routing/tcp.md). |
 | `proxy.max_buffers` | `500` | Max number of buffers in the Sōzu pool |
 | `proxy.buffer_size` | `16384` | Buffer size, in bytes |
 | `proxy.startup_delay_ms` | `1000` | Delay before applying the initial config (gives Sōzu workers time to boot) |

--- a/documentation/getting-started/quick-start.md
+++ b/documentation/getting-started/quick-start.md
@@ -50,3 +50,4 @@ curl -H "Host: whoami.localhost" http://localhost
 
 - [Full Docker labels reference](/documentation/configuration/docker-labels)
 - [REST API](/documentation/configuration/api)
+- [TCP routing](/documentation/routing/tcp) for non-HTTP services

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -29,6 +29,7 @@ Sozune is a reverse proxy built on [Sōzu](https://github.com/sozu-proxy/sozu). 
 - [Hostnames](/documentation/routing/hostnames)
 - [Path matching](/documentation/routing/path-matching)
 - [Load balancing](/documentation/routing/load-balancing)
+- [TCP](/documentation/routing/tcp)
 
 ## TLS
 

--- a/documentation/routing/tcp.md
+++ b/documentation/routing/tcp.md
@@ -1,0 +1,61 @@
+# TCP routing
+
+Sozune can forward raw TCP traffic to your services. The model mirrors Traefik's:
+
+- **Listeners are declared statically** in `config.yaml`. Each listener binds a port at startup.
+- **Backends attach dynamically** through Docker labels and reference a listener by name.
+
+A label that points at an undeclared listener is ignored with a warning. Sozune does not open ports on the fly from labels alone — by design, to keep startup state predictable.
+
+## Declare listeners
+
+```yaml
+proxy:
+  http:
+    listen_address: 80
+  https:
+    listen_address: 443
+  tcp:
+    - name: postgres
+      listen: 5432
+    - name: redis
+      listen: 6379
+```
+
+| Field | Description |
+|---|---|
+| `name` | Identifier referenced by service labels. Must be unique across `proxy.tcp`. |
+| `listen` | Port to bind on `0.0.0.0`. |
+
+## Attach a backend with Docker labels
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    labels:
+      - "sozune.enable=true"
+      - "sozune.tcp.db.entrypoint=postgres"
+      - "sozune.tcp.db.port=5432"
+```
+
+| Label | Description |
+|---|---|
+| `sozune.tcp.<svc>.entrypoint` | Name of a listener declared under `proxy.tcp`. **Required.** Routes are dropped with diagnostic `E005` if missing. |
+| `sozune.tcp.<svc>.port` | Backend port on the container. Defaults to `8080` (informational diagnostic emitted). |
+| `sozune.tcp.<svc>.priority` | Higher wins when multiple services share the same listener (default `0`). |
+
+The container's IP is resolved through the same network rules as HTTP — see [Docker labels](../configuration/docker-labels.md) and `sozune.network` to pick a network when the container is on several.
+
+## Limitations
+
+- **No TLS termination.** Sōzu's TCP path is pure passthrough — TLS bytes flow as-is. For client-side STARTTLS protocols (PostgreSQL, MySQL) this is fine; for terminating TLS, use an HTTPS entrypoint instead.
+- **No half-close.** Sōzu treats a client `FIN` as a full disconnect, so protocols that rely on half-closing one direction to signal end-of-stream may misbehave. Most request/response and long-lived stream protocols are unaffected.
+- **No IP allowlist or connection-rate limit yet.** Track the [roadmap](https://github.com/kemeter/sozune/blob/main/ROADMAP.md) for `IP allowlist / denylist` and TCP-level rate limiting.
+
+## Errors and diagnostics
+
+| Code | Meaning |
+|---|---|
+| `E005` | A `sozune.tcp.<svc>` service has no `entrypoint=` label. The route is dropped. |
+| Log: `references undeclared listener` | The label points at a name not present in `proxy.tcp`. The route is dropped. Add the listener to the config or fix the label. |

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -733,6 +733,7 @@ mod tests {
                         rate_limit: None,
                         sticky_session: false,
                         compress: false,
+                        entrypoint: None,
                     },
                     source: Some("docker".to_string()),
                     backend_weights: std::collections::HashMap::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,8 @@ pub struct ConfigFileConfig {
 pub struct ProxyConfig {
     pub http: HttpConfig,
     pub https: HttpsConfig,
+    #[serde(default)]
+    pub tcp: Vec<TcpListenerConfig>,
     #[serde(
         default = "default_max_buffers",
         deserialize_with = "deserialize_max_buffers_with_env"
@@ -175,6 +177,12 @@ pub struct HttpsConfig {
         deserialize_with = "deserialize_https_port_with_env"
     )]
     pub listen_address: u16,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct TcpListenerConfig {
+    pub name: String,
+    pub listen: u16,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -278,6 +286,7 @@ impl Default for ProxyConfig {
         Self {
             http: Default::default(),
             https: Default::default(),
+            tcp: Vec::new(),
             max_buffers: default_max_buffers(),
             buffer_size: default_buffer_size(),
             startup_delay_ms: default_startup_delay_ms(),
@@ -692,5 +701,38 @@ https:
         assert_eq!(config.startup_delay_ms, 1000);
         assert_eq!(config.cluster_setup_delay_ms, 500);
         assert_eq!(config.reload_throttle_ms, 500);
+    }
+
+    #[test]
+    fn test_proxy_config_tcp_listeners() {
+        let yaml = r#"
+http:
+  listen_address: 80
+https:
+  listen_address: 443
+tcp:
+  - name: postgres
+    listen: 5432
+  - name: mysql
+    listen: 3306
+"#;
+        let config: ProxyConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.tcp.len(), 2);
+        assert_eq!(config.tcp[0].name, "postgres");
+        assert_eq!(config.tcp[0].listen, 5432);
+        assert_eq!(config.tcp[1].name, "mysql");
+        assert_eq!(config.tcp[1].listen, 3306);
+    }
+
+    #[test]
+    fn test_proxy_config_tcp_defaults_to_empty() {
+        let yaml = r#"
+http:
+  listen_address: 80
+https:
+  listen_address: 443
+"#;
+        let config: ProxyConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.tcp.is_empty());
     }
 }

--- a/src/labels/catalog.rs
+++ b/src/labels/catalog.rs
@@ -26,6 +26,7 @@ const SERVICE_FIELDS: &[&str] = &[
     "ratelimit.average",
     "ratelimit.burst",
     "auth.basic",
+    "entrypoint",
 ];
 
 /// Field suffixes that accept arbitrary sub-keys (e.g. `headers.X-Foo`).

--- a/src/labels/diagnostic.rs
+++ b/src/labels/diagnostic.rs
@@ -15,6 +15,7 @@ pub enum DiagnosticCode {
     E002MissingHost,
     E003InspectFailed,
     E004NoServices,
+    E005MissingTcpEntrypoint,
     // Warnings — silent fallbacks today
     W001InvalidPort,
     W002InvalidPriority,
@@ -41,6 +42,7 @@ impl DiagnosticCode {
             DiagnosticCode::E002MissingHost => "E002",
             DiagnosticCode::E003InspectFailed => "E003",
             DiagnosticCode::E004NoServices => "E004",
+            DiagnosticCode::E005MissingTcpEntrypoint => "E005",
             DiagnosticCode::W001InvalidPort => "W001",
             DiagnosticCode::W002InvalidPriority => "W002",
             DiagnosticCode::W003InvalidTimeout => "W003",

--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -138,6 +138,10 @@ fn build_entrypoint(
     backend_ip: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<Entrypoint> {
+    if protocol == "tcp" {
+        return build_tcp_entrypoint(labels, service_name, backend_ip, diagnostics);
+    }
+
     let prefix = format!("sozune.{protocol}.{service_name}.");
 
     let hostnames = host::parse_hostnames(labels, &prefix, diagnostics)?;
@@ -197,6 +201,67 @@ fn build_entrypoint(
             rate_limit,
             sticky_session,
             compress,
+            entrypoint: None,
+        },
+        source: None,
+    })
+}
+
+fn build_tcp_entrypoint(
+    labels: &HashMap<String, String>,
+    service_name: &str,
+    backend_ip: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Entrypoint> {
+    let prefix = format!("sozune.tcp.{service_name}.");
+    let entrypoint_key = format!("{prefix}entrypoint");
+
+    let entrypoint_ref = match labels.get(&entrypoint_key) {
+        Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => {
+            diagnostics.push(
+                Diagnostic::new(
+                    DiagnosticCode::E005MissingTcpEntrypoint,
+                    "TCP service requires an entrypoint reference",
+                )
+                .with_label(&entrypoint_key)
+                .with_hint(
+                    "set `sozune.tcp.<name>.entrypoint=<listener-name>` matching a listener declared in `proxy.tcp`",
+                ),
+            );
+            return None;
+        }
+    };
+
+    let port = core::parse_port(labels, &prefix, "tcp", diagnostics);
+    let priority = core::parse_priority(labels, &prefix, diagnostics);
+
+    Some(Entrypoint {
+        id: format!("tcp_{service_name}"),
+        backends: vec![backend_ip.to_string()],
+        name: service_name.to_string(),
+        protocol: Protocol::Tcp,
+        backend_weights: HashMap::new(),
+        config: EntrypointConfig {
+            hostnames: Vec::new(),
+            port,
+            path: None,
+            tls: false,
+            strip_prefix: false,
+            https_redirect: false,
+            https_redirect_port: None,
+            redirect: None,
+            redirect_scheme: None,
+            redirect_template: None,
+            www_authenticate: None,
+            priority,
+            auth: None,
+            headers: Vec::new(),
+            backend_timeout: None,
+            rate_limit: None,
+            sticky_session: false,
+            compress: false,
+            entrypoint: Some(entrypoint_ref),
         },
         source: None,
     })
@@ -371,17 +436,49 @@ mod tests {
                 ("sozune.http.web.host", "web.example.com"),
                 ("sozune.http.api.host", "api.example.com"),
                 ("sozune.http.api.port", "9000"),
-                ("sozune.tcp.db.host", "db.example.com"),
+                ("sozune.tcp.db.entrypoint", "postgres"),
+                ("sozune.tcp.db.port", "5432"),
             ],
             vec![net("bridge", "10.0.0.1")],
         );
         let r = parse(&c);
         assert_eq!(r.entrypoints.len(), 3);
         assert_eq!(r.entrypoints.get("http_api").unwrap().config.port, 9000);
-        assert!(matches!(
-            r.entrypoints.get("tcp_db").unwrap().protocol,
-            Protocol::Tcp
-        ));
+        let tcp = r.entrypoints.get("tcp_db").unwrap();
+        assert!(matches!(tcp.protocol, Protocol::Tcp));
+        assert_eq!(tcp.config.entrypoint.as_deref(), Some("postgres"));
+        assert_eq!(tcp.config.port, 5432);
+    }
+
+    #[test]
+    fn tcp_without_entrypoint_label_is_dropped_with_e005() {
+        let c = candidate(
+            &[("sozune.enable", "true"), ("sozune.tcp.db.port", "5432")],
+            vec![net("bridge", "10.0.0.1")],
+        );
+        let r = parse(&c);
+        assert!(r.entrypoints.is_empty());
+        assert!(has_code(&r, DiagnosticCode::E005MissingTcpEntrypoint));
+    }
+
+    #[test]
+    fn tcp_happy_path_minimal() {
+        let c = candidate(
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.tcp.echo.entrypoint", "tcpecho"),
+                ("sozune.tcp.echo.port", "9000"),
+            ],
+            vec![net("bridge", "172.18.0.4")],
+        );
+        let r = parse(&c);
+        assert_eq!(r.entrypoints.len(), 1);
+        let ep = r.entrypoints.get("tcp_echo").unwrap();
+        assert!(matches!(ep.protocol, Protocol::Tcp));
+        assert_eq!(ep.config.entrypoint.as_deref(), Some("tcpecho"));
+        assert_eq!(ep.config.port, 9000);
+        assert_eq!(ep.backends, vec!["172.18.0.4"]);
+        assert!(ep.config.hostnames.is_empty());
     }
 
     #[test]

--- a/src/model/entrypoint.rs
+++ b/src/model/entrypoint.rs
@@ -52,6 +52,8 @@ pub struct EntrypointConfig {
     pub sticky_session: bool,
     #[serde(default)]
     pub compress: bool,
+    #[serde(default)]
+    pub entrypoint: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]

--- a/src/provider/http.rs
+++ b/src/provider/http.rs
@@ -146,6 +146,7 @@ mod tests {
                 rate_limit: None,
                 sticky_session: false,
                 compress: false,
+                entrypoint: None,
             },
             source: None,
             backend_weights: HashMap::new(),

--- a/src/proxy/sozu.rs
+++ b/src/proxy/sozu.rs
@@ -9,11 +9,11 @@ use sozu_command_lib::{
         AddBackend, AddCertificate, CertificateAndKey, Cluster, Header, HeaderPosition,
         LoadBalancingAlgorithms, LoadBalancingParams, PathRule,
         RedirectPolicy as SozuRedirectPolicy, RedirectScheme as SozuRedirectScheme, RemoveBackend,
-        Request, RequestHttpFrontend, ResponseStatus, RulePosition, SocketAddress, Status,
-        TlsVersion, WorkerRequest, WorkerResponse, request::RequestType,
+        Request, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition,
+        SocketAddress, Status, TlsVersion, WorkerRequest, WorkerResponse, request::RequestType,
     },
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
@@ -33,12 +33,88 @@ use tracing::{debug, error, info};
 /// class of bug impossible.
 type RoutingSnapshot = BTreeMap<String, Entrypoint>;
 
+/// Command channel for a single Sōzu TCP worker, paired with the port it
+/// binds. We need the port at routing time to build `RequestTcpFrontend`.
+struct TcpListenerChannel {
+    port: u16,
+    channel: Channel<WorkerRequest, WorkerResponse>,
+}
+
+/// TCP workers keyed by listener name (matches `proxy.tcp[].name`).
+/// One worker = one listener.
+type TcpChannels = HashMap<String, TcpListenerChannel>;
+
 fn snapshot_from_storage(storage: &BTreeMap<String, Entrypoint>) -> RoutingSnapshot {
     storage
         .iter()
-        .filter(|(_, ep)| matches!(ep.protocol, Protocol::Http))
+        .filter(|(_, ep)| matches!(ep.protocol, Protocol::Http | Protocol::Tcp))
         .map(|(id, ep)| (id.clone(), ep.clone()))
         .collect()
+}
+
+fn spawn_tcp_workers(
+    config: &ProxyConfig,
+) -> anyhow::Result<(TcpChannels, Vec<thread::JoinHandle<()>>)> {
+    let mut channels: TcpChannels = HashMap::new();
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
+    let max_buffers = config.max_buffers;
+    let buffer_size = config.buffer_size;
+    let timeout = Duration::from_millis(config.startup_delay_ms);
+
+    for tcp_cfg in &config.tcp {
+        if channels.contains_key(&tcp_cfg.name) {
+            anyhow::bail!(
+                "duplicate TCP listener name `{}` in proxy.tcp",
+                tcp_cfg.name
+            );
+        }
+
+        let listener_config =
+            ListenerBuilder::new_tcp(SocketAddress::new_v4(0, 0, 0, 0, tcp_cfg.listen))
+                .to_tcp(None)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Could not create TCP listener `{}` on :{}: {}",
+                        tcp_cfg.name,
+                        tcp_cfg.listen,
+                        e
+                    )
+                })?;
+
+        let (mut command, proxy_chan) = Channel::generate(1000, 10000).map_err(|e| {
+            anyhow::anyhow!("Could not create TCP channel for `{}`: {}", tcp_cfg.name, e)
+        })?;
+
+        let listener_name = tcp_cfg.name.clone();
+        let listener_port = tcp_cfg.listen;
+        let handle = thread::spawn(move || {
+            if let Err(e) = sozu_lib::tcp::testing::start_tcp_worker(
+                listener_config,
+                max_buffers,
+                buffer_size,
+                proxy_chan,
+            ) {
+                error!("TCP worker `{}` failed: {}", listener_name, e);
+            }
+        });
+
+        wait_for_worker_ready(&mut command, &format!("TCP[{}]", tcp_cfg.name), timeout)?;
+        info!(
+            "Sōzu TCP worker `{}` running on 0.0.0.0:{}",
+            tcp_cfg.name, listener_port
+        );
+
+        channels.insert(
+            tcp_cfg.name.clone(),
+            TcpListenerChannel {
+                port: listener_port,
+                channel: command,
+            },
+        );
+        handles.push(handle);
+    }
+
+    Ok((channels, handles))
 }
 
 pub fn start_sozu_proxy(
@@ -112,6 +188,9 @@ pub fn start_sozu_proxy(
     wait_for_worker_ready(&mut command_channel, "HTTP", timeout)?;
     wait_for_worker_ready(&mut command_channel_https, "HTTPS", timeout)?;
 
+    // Spawn one Sōzu TCP worker per declared listener.
+    let (mut tcp_channels, tcp_worker_handles) = spawn_tcp_workers(config)?;
+
     // Initial configuration will be handled by provider reload signals
     info!("Waiting for providers to populate configuration");
 
@@ -155,6 +234,7 @@ pub fn start_sozu_proxy(
                         &storage_reload,
                         &mut command_channel,
                         &mut command_channel_https,
+                        &mut tcp_channels,
                         http_port,
                         https_port,
                         cluster_setup_delay_ms,
@@ -199,6 +279,7 @@ pub fn start_sozu_proxy(
                                 &storage_reload,
                                 &mut command_channel,
                                 &mut command_channel_https,
+                                &mut tcp_channels,
                                 http_port,
                                 https_port,
                                 cluster_setup_delay_ms,
@@ -294,6 +375,12 @@ pub fn start_sozu_proxy(
         return Err(anyhow::anyhow!("HTTPS worker failed"));
     }
 
+    for handle in tcp_worker_handles {
+        if let Err(e) = handle.join() {
+            error!("TCP worker thread panicked: {:?}", e);
+        }
+    }
+
     if let Err(e) = reload_handle.join() {
         error!("Reload handler thread panicked: {:?}", e);
     }
@@ -306,6 +393,7 @@ fn handle_reload(
     storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     command_channel: &mut Channel<WorkerRequest, WorkerResponse>,
     command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
+    tcp_channels: &mut TcpChannels,
     http_port: u16,
     https_port: u16,
     cluster_setup_delay_ms: u64,
@@ -330,6 +418,7 @@ fn handle_reload(
         &current_snapshot,
         command_channel,
         command_channel_https,
+        tcp_channels,
         http_port,
         https_port,
         acme_challenge_port,
@@ -341,6 +430,7 @@ fn handle_reload(
     match configure_sozu_routing(
         command_channel,
         command_channel_https,
+        tcp_channels,
         &storage_read,
         http_port,
         https_port,
@@ -392,6 +482,7 @@ fn update_middleware_routes(
 fn configure_sozu_routing(
     command_channel: &mut Channel<WorkerRequest, WorkerResponse>,
     command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
+    tcp_channels: &mut TcpChannels,
     storage: &BTreeMap<String, Entrypoint>,
     http_port: u16,
     https_port: u16,
@@ -458,10 +549,7 @@ fn configure_sozu_routing(
                 )?;
             }
             Protocol::Tcp => {
-                debug!(
-                    "TCP protocol not yet implemented for entrypoint: {}",
-                    entrypoint.name
-                );
+                configure_tcp_entrypoint(tcp_channels, cluster_id, entrypoint);
             }
             Protocol::Udp => {
                 debug!(
@@ -838,6 +926,117 @@ fn configure_http_entrypoint(
     Ok(())
 }
 
+fn configure_tcp_entrypoint(
+    tcp_channels: &mut TcpChannels,
+    cluster_id: &str,
+    entrypoint: &Entrypoint,
+) {
+    debug!(
+        "Configuring TCP cluster `{}` (backends: {:?})",
+        entrypoint.name, entrypoint.backends
+    );
+    let listener_name = match entrypoint.config.entrypoint.as_deref() {
+        Some(name) => name,
+        None => {
+            error!(
+                "TCP entrypoint `{}` has no listener reference, skipping",
+                entrypoint.name
+            );
+            return;
+        }
+    };
+
+    let listener = match tcp_channels.get_mut(listener_name) {
+        Some(c) => c,
+        None => {
+            error!(
+                "TCP entrypoint `{}` references undeclared listener `{}`, skipping. \
+                 Declare it under `proxy.tcp` in the config.",
+                entrypoint.name, listener_name
+            );
+            return;
+        }
+    };
+    let listener_port = listener.port;
+    let channel = &mut listener.channel;
+
+    let cluster = Cluster {
+        cluster_id: cluster_id.to_string(),
+        sticky_session: false,
+        https_redirect: false,
+        proxy_protocol: None,
+        load_balancing: LoadBalancingAlgorithms::RoundRobin as i32,
+        load_metric: None,
+        answer_503: None,
+        http2: None,
+        authorized_hashes: Vec::new(),
+        https_redirect_port: None,
+        www_authenticate: None,
+        ..Default::default()
+    };
+
+    if let Err(e) = send_to_worker(
+        channel,
+        format!("add-cluster-tcp-{}", cluster_id),
+        RequestType::AddCluster(cluster),
+    ) {
+        debug!(
+            "Failed to add TCP cluster {} on listener {} (may already exist): {}",
+            cluster_id, listener_name, e
+        );
+    }
+
+    let tcp_front = RequestTcpFrontend {
+        cluster_id: cluster_id.to_string(),
+        address: SocketAddress::new_v4(0, 0, 0, 0, listener_port),
+        ..Default::default()
+    };
+
+    if let Err(e) = send_to_worker(
+        channel,
+        format!("add-frontend-tcp-{}", cluster_id),
+        RequestType::AddTcpFrontend(tcp_front),
+    ) {
+        debug!(
+            "Failed to add TCP frontend for cluster {} on listener {}: {}",
+            cluster_id, listener_name, e
+        );
+    }
+
+    for (idx, backend_host) in entrypoint.backends.iter().enumerate() {
+        let address = match parse_backend_address(backend_host, entrypoint.config.port) {
+            Ok(addr) => addr,
+            Err(e) => {
+                error!(
+                    "Invalid TCP backend address {}:{} for {}: {}",
+                    backend_host, entrypoint.config.port, cluster_id, e
+                );
+                continue;
+            }
+        };
+        let weight = entrypoint
+            .backend_weights
+            .get(backend_host)
+            .copied()
+            .unwrap_or(100) as i32;
+        let backend = AddBackend {
+            cluster_id: cluster_id.to_string(),
+            backend_id: format!("{}-backend-{}", cluster_id, idx),
+            address,
+            load_balancing_parameters: Some(LoadBalancingParams { weight }),
+            sticky_id: None,
+            backup: None,
+        };
+        if let Err(e) = send_to_worker(
+            channel,
+            format!("add-backend-tcp-{}-{}", cluster_id, idx),
+            RequestType::AddBackend(backend),
+        ) {
+            debug!("Failed to add TCP backend {}-{}: {}", cluster_id, idx, e);
+        }
+    }
+}
+
 fn wait_for_worker_ready(
     channel: &mut Channel<WorkerRequest, WorkerResponse>,
     name: &str,
@@ -1151,6 +1350,7 @@ fn apply_routing_diff(
     current: &RoutingSnapshot,
     command_channel: &mut Channel<WorkerRequest, WorkerResponse>,
     command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
+    tcp_channels: &mut TcpChannels,
     http_port: u16,
     https_port: u16,
     acme_challenge_port: Option<u16>,
@@ -1159,19 +1359,27 @@ fn apply_routing_diff(
     for (cluster_id, old) in previous {
         if !current.contains_key(cluster_id) {
             info!("Removing stale cluster: {}", cluster_id);
-            remove_http_frontends(
-                command_channel,
-                command_channel_https,
-                cluster_id,
-                old,
-                http_port,
-                https_port,
-            );
-            remove_backends(command_channel, command_channel_https, cluster_id, old);
-            remove_cluster(command_channel, command_channel_https, cluster_id);
+            match old.protocol {
+                Protocol::Http => {
+                    remove_http_frontends(
+                        command_channel,
+                        command_channel_https,
+                        cluster_id,
+                        old,
+                        http_port,
+                        https_port,
+                    );
+                    remove_backends(command_channel, command_channel_https, cluster_id, old);
+                    remove_cluster(command_channel, command_channel_https, cluster_id);
 
-            if acme_challenge_port.is_some() {
-                remove_acme_frontends(command_channel, &old.config.hostnames, http_port);
+                    if acme_challenge_port.is_some() {
+                        remove_acme_frontends(command_channel, &old.config.hostnames, http_port);
+                    }
+                }
+                Protocol::Tcp => {
+                    remove_tcp_entrypoint(tcp_channels, cluster_id, old);
+                }
+                Protocol::Udp => {}
             }
         }
     }
@@ -1183,20 +1391,84 @@ fn apply_routing_diff(
             && old != new
         {
             info!("Updating changed cluster: {}", cluster_id);
-            remove_http_frontends(
-                command_channel,
-                command_channel_https,
-                cluster_id,
-                old,
-                http_port,
-                https_port,
-            );
-            remove_backends(command_channel, command_channel_https, cluster_id, old);
+            match old.protocol {
+                Protocol::Http => {
+                    remove_http_frontends(
+                        command_channel,
+                        command_channel_https,
+                        cluster_id,
+                        old,
+                        http_port,
+                        https_port,
+                    );
+                    remove_backends(command_channel, command_channel_https, cluster_id, old);
 
-            if acme_challenge_port.is_some() && old.config.hostnames != new.config.hostnames {
-                remove_acme_frontends(command_channel, &old.config.hostnames, http_port);
+                    if acme_challenge_port.is_some() && old.config.hostnames != new.config.hostnames
+                    {
+                        remove_acme_frontends(command_channel, &old.config.hostnames, http_port);
+                    }
+                }
+                Protocol::Tcp => {
+                    remove_tcp_entrypoint(tcp_channels, cluster_id, old);
+                }
+                Protocol::Udp => {}
             }
         }
+    }
+}
+
+fn remove_tcp_entrypoint(
+    tcp_channels: &mut TcpChannels,
+    cluster_id: &str,
+    entrypoint: &Entrypoint,
+) {
+    let Some(listener_name) = entrypoint.config.entrypoint.as_deref() else {
+        return;
+    };
+    let Some(listener) = tcp_channels.get_mut(listener_name) else {
+        return;
+    };
+    let listener_port = listener.port;
+    let channel = &mut listener.channel;
+
+    for (idx, backend_host) in entrypoint.backends.iter().enumerate() {
+        let address = match parse_backend_address(backend_host, entrypoint.config.port) {
+            Ok(addr) => addr,
+            Err(_) => continue,
+        };
+        let remove = RemoveBackend {
+            cluster_id: cluster_id.to_string(),
+            backend_id: format!("{}-backend-{}", cluster_id, idx),
+            address,
+        };
+        if let Err(e) = send_to_worker(
+            channel,
+            format!("rm-backend-tcp-{}-{}", cluster_id, idx),
+            RequestType::RemoveBackend(remove),
+        ) {
+            debug!("Failed to remove TCP backend {}-{}: {}", cluster_id, idx, e);
+        }
+    }
+
+    let tcp_front = RequestTcpFrontend {
+        cluster_id: cluster_id.to_string(),
+        address: SocketAddress::new_v4(0, 0, 0, 0, listener_port),
+        ..Default::default()
+    };
+    if let Err(e) = send_to_worker(
+        channel,
+        format!("rm-frontend-tcp-{}", cluster_id),
+        RequestType::RemoveTcpFrontend(tcp_front),
+    ) {
+        debug!("Failed to remove TCP frontend for {}: {}", cluster_id, e);
+    }
+
+    if let Err(e) = send_to_worker(
+        channel,
+        format!("rm-cluster-tcp-{}", cluster_id),
+        RequestType::RemoveCluster(cluster_id.to_string()),
+    ) {
+        debug!("Failed to remove TCP cluster {}: {}", cluster_id, e);
     }
 }
 

--- a/tests/e2e/07-tcp.sh
+++ b/tests/e2e/07-tcp.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# TCP entrypoints: declared listener forwards to a backend resolved via Docker labels.
+# Sourced by run-all.sh.
+
+log "[07] TCP: listener accepts connections"
+
+if wait_for_tcp_open "127.0.0.1" "$TCP_ECHO_PORT"; then
+    pass "TCP listener on $TCP_ECHO_PORT is open"
+else
+    fail "TCP listener on $TCP_ECHO_PORT did not open"
+fi
+
+log "[07] TCP: bidirectional forwarding"
+
+response=$(tcp_send "127.0.0.1" "$TCP_ECHO_PORT" "ping-sozune")
+if [[ "$response" == *"ping-sozune"* ]]; then
+    pass "echo backend reachable through TCP entrypoint"
+else
+    fail "echo backend did not reply (got: '$response')"
+fi
+
+log "[07] TCP: second listener also forwards"
+
+if wait_for_tcp_open "127.0.0.1" "$TCP_RR_PORT"; then
+    pass "TCP listener on $TCP_RR_PORT is open"
+else
+    fail "TCP listener on $TCP_RR_PORT did not open"
+fi
+
+response=$(tcp_send "127.0.0.1" "$TCP_RR_PORT" "")
+if [[ "$response" == *"backend-a"* || "$response" == *"backend-b"* ]]; then
+    pass "second listener forwards to its declared backend"
+else
+    fail "second listener did not forward (got: '$response')"
+fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -13,6 +13,8 @@ HTTP_PORT=18080
 HTTPS_PORT=18443
 API_PORT=18888
 MIDDLEWARE_PORT=13037
+TCP_ECHO_PORT=15555
+TCP_RR_PORT=15556
 API_USER="admin"
 API_PASSWORD="test-secret-token"
 API_PASSWORD_HASH=$(printf '%s' "$API_PASSWORD" | sha256sum | cut -d' ' -f1)
@@ -62,6 +64,27 @@ wait_for_status() {
         local status
         status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 -H "Host: $host" "$url" 2>/dev/null || echo "000")
         if [[ "$status" == "$expected" ]]; then
+            return 0
+        fi
+        sleep 0.5
+        i=$((i + 1))
+    done
+    return 1
+}
+
+tcp_send() {
+    local host="$1" port="$2" payload="$3"
+    # `nc -w 2` waits 2s of idle on the socket before closing — gives the
+    # backend time to respond. We avoid socat's shut-down half-close because
+    # Sōzu's TCP path closes the full connection on FIN, racing the response.
+    printf '%s' "$payload" | timeout 5 nc -w 2 "$host" "$port" 2>/dev/null || true
+}
+
+wait_for_tcp_open() {
+    local host="$1" port="$2"
+    local i=0
+    while [[ $i -lt $MAX_RETRIES ]]; do
+        if timeout 1 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
             return 0
         fi
         sleep 0.5

--- a/tests/e2e/run-all.sh
+++ b/tests/e2e/run-all.sh
@@ -55,6 +55,11 @@ proxy:
     listen_address: $HTTP_PORT
   https:
     listen_address: $HTTPS_PORT
+  tcp:
+    - name: tcpecho
+      listen: $TCP_ECHO_PORT
+    - name: tcprr
+      listen: $TCP_RR_PORT
   max_buffers: 500
   buffer_size: 16384
   startup_delay_ms: 1000
@@ -190,6 +195,33 @@ services:
       - "sozune.enable=true"
       - "sozune.http.svcws.host=$HOST_WS"
       - "sozune.http.svcws.port=8080"
+      - "sozune.network=${COMPOSE_PROJECT}_default"
+
+  svc-tcpecho:
+    image: alpine/socat
+    command: ["TCP-LISTEN:9000,fork,reuseaddr", "EXEC:cat"]
+    labels:
+      - "sozune.enable=true"
+      - "sozune.tcp.tcpecho.entrypoint=tcpecho"
+      - "sozune.tcp.tcpecho.port=9000"
+      - "sozune.network=${COMPOSE_PROJECT}_default"
+
+  svc-tcprr-a:
+    image: alpine/socat
+    command: ["TCP-LISTEN:9000,fork,reuseaddr", "SYSTEM:'echo backend-a'"]
+    labels:
+      - "sozune.enable=true"
+      - "sozune.tcp.tcprr.entrypoint=tcprr"
+      - "sozune.tcp.tcprr.port=9000"
+      - "sozune.network=${COMPOSE_PROJECT}_default"
+
+  svc-tcprr-b:
+    image: alpine/socat
+    command: ["TCP-LISTEN:9000,fork,reuseaddr", "SYSTEM:'echo backend-b'"]
+    labels:
+      - "sozune.enable=true"
+      - "sozune.tcp.tcprr.entrypoint=tcprr"
+      - "sozune.tcp.tcprr.port=9000"
       - "sozune.network=${COMPOSE_PROJECT}_default"
 EOF
 


### PR DESCRIPTION
TCP routing in the Traefik style: listeners declared statically in `proxy.tcp`, backends attached dynamically through Docker labels referencing a listener by name.

```yaml
proxy:
  tcp:
    - name: postgres
      listen: 5432
```

```yaml
labels:
  - "sozune.enable=true"
  - "sozune.tcp.db.entrypoint=postgres"
  - "sozune.tcp.db.port=5432"
```

A label pointing at an undeclared listener is dropped with a warning. Pure Sōzu TCP passthrough — no TLS termination, no half-close. Multi-backend round-robin works at the Sōzu level.

