### PR TITLE
Add Docker Swarm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ curl -H "Host: whoami.localhost" http://localhost
 
 - [Installation](documentation/getting-started/installation.md) · [Quick start](documentation/getting-started/quick-start.md)
 - [Docker labels reference](documentation/configuration/docker-labels.md)
+- [Swarm provider](documentation/configuration/swarm-provider.md) · [HTTP provider](documentation/configuration/http-provider.md)
 - [Configuration file & env vars](documentation/configuration/overview.md)
 - [REST API](documentation/configuration/api.md)
 - Routing — [Hostnames](documentation/routing/hostnames.md) · [Path matching](documentation/routing/path-matching.md) · [Load balancing](documentation/routing/load-balancing.md) · [TCP](documentation/routing/tcp.md)

--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -46,7 +46,7 @@ middleware:
 
 | Section | Purpose |
 |---|---|
-| `providers` | Sources for entrypoint discovery: Docker, HTTP polling, file. |
+| `providers` | Sources for entrypoint discovery: Docker, Swarm, HTTP polling, file. |
 | `api` | REST API for live entrypoint management. |
 | `acme` | Let's Encrypt provisioning. |
 | `proxy` | Sōzu listeners and runtime tuning. |
@@ -60,6 +60,12 @@ providers:
     enabled: true
     endpoint: "/var/run/docker.sock"
     expose_by_default: false
+  swarm:
+    enabled: false
+    endpoint: "/var/run/docker.sock"
+    expose_by_default: false
+    # network: sozune-public   # optional: only consider VIPs on this overlay
+    refresh_interval: 15
   http:
     enabled: false
     url: "https://config.example.com/entrypoints"
@@ -75,6 +81,11 @@ providers:
 | `docker.enabled` | `false` | Enables Docker label discovery |
 | `docker.endpoint` | `/var/run/docker.sock` | Docker socket path |
 | `docker.expose_by_default` | `false` | If true, every container is candidate without `sozune.enable=true` |
+| `swarm.enabled` | `false` | Enables Docker Swarm service discovery (must point to a manager) |
+| `swarm.endpoint` | `/var/run/docker.sock` | Docker socket on a Swarm manager |
+| `swarm.expose_by_default` | `false` | If true, every service is candidate without `sozune.enable=true` |
+| `swarm.network` | `""` | Optional overlay network filter |
+| `swarm.refresh_interval` | `15` | Periodic poll interval, in seconds (safety net behind the event stream) |
 | `http.enabled` | `false` | Enables polling a remote URL for JSON entrypoints |
 | `http.url` | — | URL to poll |
 | `http.poll_interval` | `30` | Polling interval, in seconds |
@@ -131,6 +142,11 @@ Every field above can be overridden through an environment variable. The env var
 | `providers.docker.enabled` | `SOZUNE_PROVIDER_DOCKER_ENABLED` |
 | `providers.docker.endpoint` | `SOZUNE_PROVIDER_DOCKER_ENDPOINT` |
 | `providers.docker.expose_by_default` | `SOZUNE_PROVIDER_DOCKER_EXPOSE_BY_DEFAULT` |
+| `providers.swarm.enabled` | `SOZUNE_PROVIDER_SWARM_ENABLED` |
+| `providers.swarm.endpoint` | `SOZUNE_PROVIDER_SWARM_ENDPOINT` |
+| `providers.swarm.expose_by_default` | `SOZUNE_PROVIDER_SWARM_EXPOSE_BY_DEFAULT` |
+| `providers.swarm.network` | `SOZUNE_PROVIDER_SWARM_NETWORK` |
+| `providers.swarm.refresh_interval` | `SOZUNE_PROVIDER_SWARM_REFRESH_INTERVAL` |
 | `providers.http.enabled` | `SOZUNE_PROVIDER_HTTP_ENABLED` |
 | `providers.http.url` | `SOZUNE_PROVIDER_HTTP_URL` |
 | `providers.http.poll_interval` | `SOZUNE_PROVIDER_HTTP_POLL_INTERVAL` |

--- a/documentation/configuration/swarm-provider.md
+++ b/documentation/configuration/swarm-provider.md
@@ -1,0 +1,105 @@
+# Swarm provider
+
+The Swarm provider discovers entrypoints from Docker Swarm services. Sozune connects to a Swarm **manager**, lists services, and reads `sozune.*` labels declared on the service spec (not on the underlying tasks/containers).
+
+This is the right provider when your stack is deployed with `docker stack deploy` or `docker service create` instead of plain `docker run`.
+
+## Configuration
+
+```yaml
+providers:
+  swarm:
+    enabled: true
+    endpoint: "/var/run/docker.sock"
+    expose_by_default: false
+    network: "sozune-public"
+    refresh_interval: 15
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enables the Swarm provider |
+| `endpoint` | `/var/run/docker.sock` | Docker socket. Must point to a **Swarm manager** node. |
+| `expose_by_default` | `false` | If `true`, every service is a candidate even without `sozune.enable=true` |
+| `network` | `""` | Optional overlay network name. When set, Sozune ignores VIPs on other networks. |
+| `refresh_interval` | `15` | Periodic poll interval in seconds (safety net behind the event stream) |
+
+## How it works
+
+1. Sozune subscribes to Docker events filtered on `type=service` for near-real-time reactions to `service create`, `service update` and `service rm`.
+2. A periodic poll (`refresh_interval`) re-runs the same diff against the Swarm API. This is a safety net for missed events or disconnected streams.
+3. On every diff, Sozune replaces the full set of `source: "swarm"` entrypoints in storage and triggers a reload.
+
+Service labels are parsed by the same engine the file, Docker, Podman and HTTP providers use, so `sozune validate` reports the exact diagnostics the runtime applies.
+
+## Example service
+
+```bash
+docker service create \
+  --name my-api \
+  --label sozune.enable=true \
+  --label sozune.http.host=api.example.com \
+  --label sozune.http.port=8080 \
+  --network sozune-public \
+  --replicas 3 \
+  my-api:latest
+```
+
+## Example stack file
+
+Deploy with `docker stack deploy -c stack.yml mystack`:
+
+```yaml
+version: "3.9"
+
+networks:
+  sozune-public:
+    external: true
+
+services:
+  api:
+    image: my-api:latest
+    networks:
+      - sozune-public
+    deploy:
+      replicas: 3
+      labels:
+        sozune.enable: "true"
+        sozune.http.host: "api.example.com"
+        sozune.http.port: "8080"
+        sozune.network: "sozune-public"
+```
+
+> **Important:** put `sozune.*` labels under `deploy.labels`, not `services.api.labels`. Service-level labels live on the running tasks (containers); only `deploy.labels` are stored on the **service** spec, which is what Sozune reads.
+
+## Backend resolution
+
+Swarm exposes two endpoint modes:
+
+- **`vip` (default).** Swarm assigns one virtual IP per attached overlay network and load-balances behind it. Sozune uses that VIP as the single backend, so scaling the service does not churn Sozune's cluster — Swarm balances internally.
+- **`dnsrr`.** Swarm relies on DNS round-robin. The Docker API does **not** expose individual task IPs through `bollard 0.20`, so Sozune cannot enumerate per-replica backends in this mode. If a VIP is still attached, Sozune falls back to it and logs a warning. For production multi-replica routing through Sozune, prefer `vip` (the Swarm default).
+
+The `network` config field, when set, restricts which overlay's VIP Sozune considers. This is useful when the same service is attached to several overlays (e.g. a public ingress overlay plus a private backend overlay).
+
+## Coexistence with the Docker provider
+
+On a Swarm node, the local Docker socket exposes both `services` (Swarm) and `containers` (the tasks running locally). If you enable both `providers.docker` and `providers.swarm` against the same socket, you will discover the same workload twice — once at the service level and once at the task level — with potentially conflicting labels.
+
+**Recommendation:** pick one. Use `swarm` when your stack is service-deployed; use `docker` for plain single-host containers.
+
+Each provider tags its entries with a distinct `source` (`swarm` vs `docker`), so a misconfiguration is visible through the API or dashboard, but Sozune does not deduplicate across providers.
+
+## Requirements
+
+- The `endpoint` socket **must** point to a manager node. On a worker, the Docker daemon refuses Swarm API calls and Sozune logs an error per poll.
+- Sozune itself must be able to reach the chosen overlay network. The simplest setup is to run Sozune as a Swarm service attached to the same overlay as the discovered services. Otherwise, expose ports with `mode=host`.
+
+## Environment variables
+
+| Field | Env var |
+|---|---|
+| `providers.swarm.enabled` | `SOZUNE_PROVIDER_SWARM_ENABLED` |
+| `providers.swarm.endpoint` | `SOZUNE_PROVIDER_SWARM_ENDPOINT` |
+| `providers.swarm.expose_by_default` | `SOZUNE_PROVIDER_SWARM_EXPOSE_BY_DEFAULT` |
+| `providers.swarm.network` | `SOZUNE_PROVIDER_SWARM_NETWORK` |
+| `providers.swarm.refresh_interval` | `SOZUNE_PROVIDER_SWARM_REFRESH_INTERVAL` |

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -20,6 +20,7 @@ Sozune is a reverse proxy built on [Sōzu](https://github.com/sozu-proxy/sozu). 
 
 - [Configuration overview](/documentation/configuration/overview)
 - [Docker labels](/documentation/configuration/docker-labels)
+- [Swarm provider](/documentation/configuration/swarm-provider)
 - [HTTP provider](/documentation/configuration/http-provider)
 - [REST API](/documentation/configuration/api)
 - [Dashboard](/documentation/configuration/dashboard)

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ pub struct AcmeConfig {
 pub struct ProvidersConfig {
     pub docker: Option<DockerConfig>,
     pub podman: Option<PodmanConfig>,
+    pub swarm: Option<SwarmConfig>,
     pub config_file: Option<ConfigFileConfig>,
     pub http: Option<HttpProviderConfig>,
 }
@@ -68,6 +69,29 @@ pub struct PodmanConfig {
         deserialize_with = "deserialize_podman_expose_by_default_with_env"
     )]
     pub expose_by_default: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct SwarmConfig {
+    #[serde(default, deserialize_with = "deserialize_swarm_enabled_with_env")]
+    pub enabled: bool,
+    #[serde(
+        default = "default_swarm_endpoint",
+        deserialize_with = "deserialize_swarm_endpoint_with_env"
+    )]
+    pub endpoint: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_swarm_expose_by_default_with_env"
+    )]
+    pub expose_by_default: bool,
+    #[serde(default, deserialize_with = "deserialize_swarm_network_with_env")]
+    pub network: String,
+    #[serde(
+        default = "default_swarm_refresh_interval",
+        deserialize_with = "deserialize_swarm_refresh_interval_with_env"
+    )]
+    pub refresh_interval: u64,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -244,6 +268,26 @@ impl Default for PodmanConfig {
             expose_by_default: false,
         }
     }
+}
+
+impl Default for SwarmConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: "/var/run/docker.sock".to_string(),
+            expose_by_default: false,
+            network: String::new(),
+            refresh_interval: default_swarm_refresh_interval(),
+        }
+    }
+}
+
+fn default_swarm_refresh_interval() -> u64 {
+    15
+}
+
+fn default_swarm_endpoint() -> String {
+    "/var/run/docker.sock".to_string()
 }
 
 fn default_podman_endpoint() -> String {
@@ -478,6 +522,35 @@ deserialize_bool_with_env!(
 );
 
 deserialize_bool_with_env!(
+    deserialize_swarm_enabled_with_env,
+    "SOZUNE_PROVIDER_SWARM_ENABLED",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_swarm_endpoint_with_env,
+    "SOZUNE_PROVIDER_SWARM_ENDPOINT",
+    "/var/run/docker.sock",
+    literal
+);
+deserialize_bool_with_env!(
+    deserialize_swarm_expose_by_default_with_env,
+    "SOZUNE_PROVIDER_SWARM_EXPOSE_BY_DEFAULT",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_swarm_network_with_env,
+    "SOZUNE_PROVIDER_SWARM_NETWORK",
+    "",
+    literal
+);
+deserialize_with_env!(
+    deserialize_swarm_refresh_interval_with_env,
+    "SOZUNE_PROVIDER_SWARM_REFRESH_INTERVAL",
+    u64,
+    default_swarm_refresh_interval
+);
+
+deserialize_bool_with_env!(
     deserialize_config_file_enabled_with_env,
     "SOZUNE_PROVIDER_CONFIG_FILE_ENABLED",
     false
@@ -682,6 +755,46 @@ expose_by_default: true
         assert!(!config.enabled);
         assert!(!config.expose_by_default);
         assert!(config.endpoint.ends_with("podman.sock"));
+    }
+
+    #[test]
+    fn test_swarm_config_deserialization() {
+        let yaml = r#"
+enabled: true
+endpoint: /var/run/docker.sock
+expose_by_default: true
+network: traefik-public
+refresh_interval: 30
+"#;
+        let config: SwarmConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.endpoint, "/var/run/docker.sock");
+        assert!(config.expose_by_default);
+        assert_eq!(config.network, "traefik-public");
+        assert_eq!(config.refresh_interval, 30);
+    }
+
+    #[test]
+    fn test_swarm_config_defaults() {
+        let config = SwarmConfig::default();
+        assert!(!config.enabled);
+        assert!(!config.expose_by_default);
+        assert_eq!(config.endpoint, "/var/run/docker.sock");
+        assert!(config.network.is_empty());
+        assert_eq!(config.refresh_interval, 15);
+    }
+
+    #[test]
+    fn test_swarm_config_partial_yaml_uses_defaults() {
+        let yaml = r#"
+enabled: true
+"#;
+        let config: SwarmConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.endpoint, "/var/run/docker.sock");
+        assert!(!config.expose_by_default);
+        assert!(config.network.is_empty());
+        assert_eq!(config.refresh_interval, 15);
     }
 
     #[test]

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -2,7 +2,7 @@ use crate::config::AppConfig;
 use crate::model::Entrypoint;
 use crate::provider::{
     Provider, config::ConfigProvider, docker::DockerProvider, http::HttpProvider,
-    podman::PodmanProvider,
+    podman::PodmanProvider, swarm::SwarmProvider,
 };
 use anyhow::Context;
 use std::collections::BTreeMap;
@@ -112,6 +112,28 @@ pub async fn start_services(
                 .await
             {
                 error!("Podman service failed: {}", e);
+            }
+        });
+    }
+
+    // Start Swarm service if enabled
+    if let Some(swarm_config) = &config.providers.swarm
+        && swarm_config.enabled
+    {
+        info!("Starting Swarm service");
+        let swarm_provider = Arc::new(
+            SwarmProvider::new(swarm_config.clone()).context("Failed to create Swarm provider")?,
+        );
+        let storage_swarm = Arc::clone(&storage);
+        let reload_tx_swarm = reload_tx.clone();
+        let acme_notify_swarm = Arc::clone(&acme_notify);
+
+        tokio::spawn(async move {
+            if let Err(e) = swarm_provider
+                .start_service(storage_swarm, reload_tx_swarm, acme_notify_swarm)
+                .await
+            {
+                error!("Swarm service failed: {}", e);
             }
         });
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -13,3 +13,4 @@ pub mod docker;
 pub mod factory;
 pub mod http;
 pub mod podman;
+pub mod swarm;

--- a/src/provider/swarm.rs
+++ b/src/provider/swarm.rs
@@ -7,7 +7,7 @@ use crate::model::Entrypoint;
 use crate::provider::Provider;
 use async_trait::async_trait;
 use bollard::Docker;
-use bollard::models::EndpointSpecModeEnum;
+use bollard::models::{EndpointSpecModeEnum, LocalNodeState};
 use bollard::query_parameters::{EventsOptions, ListNetworksOptions, ListServicesOptions};
 use futures_util::StreamExt;
 use std::collections::{BTreeMap, HashMap};
@@ -119,6 +119,36 @@ impl SwarmProvider {
         Ok(candidates)
     }
 
+    /// Verify the configured endpoint points to an active Swarm manager.
+    /// Returns a descriptive error when the daemon is not in Swarm mode or
+    /// when this node is a worker — both surface as cryptic 503s on every
+    /// list_services call otherwise.
+    async fn verify_swarm_manager(&self) -> anyhow::Result<()> {
+        let info = self.docker.info().await.map_err(|e| {
+            anyhow::anyhow!("docker info failed on '{}': {}", self.config.endpoint, e)
+        })?;
+        let swarm = info
+            .swarm
+            .ok_or_else(|| anyhow::anyhow!("docker info returned no Swarm section"))?;
+
+        match swarm.local_node_state {
+            Some(LocalNodeState::ACTIVE) => {}
+            other => anyhow::bail!(
+                "endpoint '{}' is not in Swarm mode (LocalNodeState={:?}); run `docker swarm init` or point endpoint to a manager",
+                self.config.endpoint,
+                other
+            ),
+        }
+
+        if swarm.control_available != Some(true) {
+            anyhow::bail!(
+                "endpoint '{}' is a Swarm worker, not a manager; the swarm provider must talk to a manager node",
+                self.config.endpoint
+            );
+        }
+        Ok(())
+    }
+
     /// Start the Swarm provider: initial sync, then run the event stream and
     /// the periodic poll concurrently. The poll catches up on anything the
     /// event stream may have dropped (reconnections, missed messages).
@@ -128,6 +158,11 @@ impl SwarmProvider {
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
     ) -> anyhow::Result<()> {
+        if let Err(e) = self.verify_swarm_manager().await {
+            error!("Swarm provider disabled: {}", e);
+            return Ok(());
+        }
+
         // Initial sync: run one poll iteration's worth of work synchronously
         // before kicking off the loops, so storage is populated by the time
         // start_services() returns.

--- a/src/provider/swarm.rs
+++ b/src/provider/swarm.rs
@@ -1,0 +1,456 @@
+use crate::config::SwarmConfig;
+use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::diagnostic::{Diagnostic, Severity};
+use crate::labels::source::LabelSource;
+use crate::labels::{self};
+use crate::model::Entrypoint;
+use crate::provider::Provider;
+use async_trait::async_trait;
+use bollard::Docker;
+use bollard::models::EndpointSpecModeEnum;
+use bollard::query_parameters::{EventsOptions, ListNetworksOptions, ListServicesOptions};
+use futures_util::StreamExt;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::sync::{Notify, mpsc};
+use tracing::{debug, error, info, warn};
+
+const SOURCE: &str = "swarm";
+
+pub struct SwarmProvider {
+    docker: Docker,
+    config: SwarmConfig,
+}
+
+impl SwarmProvider {
+    pub fn new(config: SwarmConfig) -> Result<Self, bollard::errors::Error> {
+        let docker = if config.endpoint.starts_with("unix://") {
+            Docker::connect_with_socket(&config.endpoint, 120, bollard::API_DEFAULT_VERSION)?
+        } else if config.endpoint.starts_with('/') {
+            Docker::connect_with_socket(
+                &format!("unix://{}", config.endpoint),
+                120,
+                bollard::API_DEFAULT_VERSION,
+            )?
+        } else {
+            Docker::connect_with_local_defaults()?
+        };
+        Ok(Self { docker, config })
+    }
+
+    /// Build the network_id -> network_name map (cluster-scoped).
+    /// Used to translate VIP NetworkID into the human name `sozune.network` matches against.
+    async fn network_id_to_name(&self) -> HashMap<String, String> {
+        match self.docker.list_networks(None::<ListNetworksOptions>).await {
+            Ok(networks) => networks
+                .into_iter()
+                .filter_map(|n| Some((n.id?, n.name?)))
+                .collect(),
+            Err(e) => {
+                warn!("swarm: failed to list networks for VIP resolution: {}", e);
+                HashMap::new()
+            }
+        }
+    }
+
+    async fn build_candidates(&self) -> Result<Vec<Candidate>, bollard::errors::Error> {
+        let services = self
+            .docker
+            .list_services(None::<ListServicesOptions>)
+            .await?;
+
+        let net_map = self.network_id_to_name().await;
+
+        let mut candidates = Vec::with_capacity(services.len());
+        for service in services {
+            let id = service.id.clone().unwrap_or_default();
+            let spec = match service.spec {
+                Some(s) => s,
+                None => continue,
+            };
+            let display_name = spec.name.clone().unwrap_or_else(|| id.clone());
+            let labels = spec.labels.unwrap_or_default();
+
+            // bollard 0.20 does not expose per-task NetworkAttachments, so we
+            // cannot resolve individual task IPs in dnsrr mode. The Swarm VIP
+            // (when present) still works because Docker keeps load-balancing
+            // behind it. Warn loudly so misconfigured services are visible.
+            if let Some(endpoint_spec) = spec.endpoint_spec.as_ref()
+                && matches!(endpoint_spec.mode, Some(EndpointSpecModeEnum::DNSRR))
+            {
+                warn!(
+                    "swarm: service '{}' uses dnsrr endpoint mode; sozune cannot enumerate individual task IPs and will fall back to the VIP if available",
+                    display_name
+                );
+            }
+
+            let networks = service
+                .endpoint
+                .as_ref()
+                .and_then(|e| e.virtual_ips.as_ref())
+                .map(|vips| {
+                    vips.iter()
+                        .filter_map(|vip| {
+                            let nid = vip.network_id.clone()?;
+                            let name = net_map.get(&nid).cloned().unwrap_or(nid);
+                            // Honour the optional network filter from config: drop VIPs
+                            // outside the configured overlay so they cannot be picked up
+                            // by `resolve_ip` as a fallback.
+                            if !self.config.network.is_empty() && name != self.config.network {
+                                return None;
+                            }
+                            let ip = vip.addr.as_ref().map(|a| strip_cidr(a).to_string());
+                            Some(NetworkInfo { name, ip })
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+
+            candidates.push(Candidate {
+                provider: SOURCE,
+                id,
+                display_name,
+                labels,
+                networks,
+                enabled_default: self.config.expose_by_default,
+            });
+        }
+        Ok(candidates)
+    }
+
+    /// Start the Swarm provider: initial sync, then run the event stream and
+    /// the periodic poll concurrently. The poll catches up on anything the
+    /// event stream may have dropped (reconnections, missed messages).
+    pub async fn start_service(
+        self: Arc<Self>,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+    ) -> anyhow::Result<()> {
+        // Initial sync: run one poll iteration's worth of work synchronously
+        // before kicking off the loops, so storage is populated by the time
+        // start_services() returns.
+        if let Err(e) = self
+            .sync_once(&storage, &reload_tx, &acme_notify, true)
+            .await
+        {
+            warn!("Swarm provider initial sync failed: {}", e);
+        }
+
+        let poll = {
+            let provider = Arc::clone(&self);
+            let storage = Arc::clone(&storage);
+            let reload_tx = reload_tx.clone();
+            let acme_notify = Arc::clone(&acme_notify);
+            tokio::spawn(async move {
+                if let Err(e) = provider
+                    .start_polling(storage, reload_tx, acme_notify)
+                    .await
+                {
+                    error!("Swarm polling loop failed: {}", e);
+                }
+            })
+        };
+
+        let events = {
+            let provider = Arc::clone(&self);
+            let storage = Arc::clone(&storage);
+            let reload_tx = reload_tx.clone();
+            let acme_notify = Arc::clone(&acme_notify);
+            tokio::spawn(async move {
+                if let Err(e) = provider
+                    .start_event_listener(storage, reload_tx, acme_notify)
+                    .await
+                {
+                    error!("Swarm event listener failed: {}", e);
+                }
+            })
+        };
+
+        let _ = tokio::try_join!(poll, events);
+        Ok(())
+    }
+
+    /// One synchronous diff-and-apply pass against the API. Returns true if
+    /// storage was modified. Used by both the initial sync and the event
+    /// stream (debounced through the poll loop's regular cadence).
+    async fn sync_once(
+        &self,
+        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: &mpsc::Sender<()>,
+        acme_notify: &Arc<Notify>,
+        log_when_idle: bool,
+    ) -> anyhow::Result<bool> {
+        let new_entrypoints = self.provide().await?;
+
+        let needs_update = {
+            let storage_read = match storage.read() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("Storage lock poisoned in Swarm provider: {}", e);
+                    return Ok(false);
+                }
+            };
+
+            let old_ids: std::collections::HashSet<&String> = storage_read
+                .iter()
+                .filter(|(_, ep)| ep.source.as_deref() == Some(SOURCE))
+                .map(|(id, _)| id)
+                .collect();
+
+            let new_ids: std::collections::HashSet<&String> = new_entrypoints.keys().collect();
+
+            old_ids != new_ids
+                || new_entrypoints.iter().any(|(id, ep)| {
+                    storage_read.get(id).is_none_or(|existing| {
+                        existing.backends != ep.backends
+                            || existing.config.hostnames != ep.config.hostnames
+                            || existing.config.port != ep.config.port
+                    })
+                })
+        };
+
+        if !needs_update {
+            if log_when_idle {
+                info!("No Swarm services with sozune labels found on initial scan");
+            }
+            return Ok(false);
+        }
+
+        {
+            let mut storage_write = match storage.write() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("Storage lock poisoned in Swarm provider: {}", e);
+                    return Ok(false);
+                }
+            };
+            storage_write.retain(|_, ep| ep.source.as_deref() != Some(SOURCE));
+            for (id, mut entrypoint) in new_entrypoints {
+                entrypoint.source = Some(SOURCE.to_string());
+                debug!("Swarm provider entrypoint: {}", id);
+                storage_write.insert(id, entrypoint);
+            }
+        }
+
+        info!("Swarm provider config changed, triggering reload");
+        if let Err(e) = reload_tx.send(()).await {
+            warn!("Failed to send reload signal: {}", e);
+        }
+        acme_notify.notify_one();
+        Ok(true)
+    }
+
+    /// Subscribe to Docker events filtered on `type=service`. Each event
+    /// triggers a sync_once. We do not try to be clever about which event
+    /// means what — Swarm service create/update/remove all warrant a re-diff.
+    pub async fn start_event_listener(
+        &self,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+    ) -> anyhow::Result<()> {
+        info!("Starting Swarm event listener");
+
+        loop {
+            let mut filters = HashMap::new();
+            filters.insert("type".to_string(), vec!["service".to_string()]);
+
+            let mut events = self.docker.events(Some(EventsOptions {
+                since: None,
+                until: None,
+                filters: Some(filters),
+            }));
+
+            while let Some(event_result) = events.next().await {
+                match event_result {
+                    Ok(event) => {
+                        if let Some(action) = &event.action {
+                            debug!("Swarm event: {} (actor={:?})", action, event.actor);
+                            if let Err(e) = self
+                                .sync_once(&storage, &reload_tx, &acme_notify, false)
+                                .await
+                            {
+                                warn!("Swarm sync after event failed: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Swarm event stream error: {}, reconnecting in 5s", e);
+                        break;
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    }
+
+    /// Periodic poll: rebuild the full set of `swarm`-sourced entrypoints from
+    /// the API, diff against storage, and replace-all on change. Mirrors the
+    /// HTTP provider strategy and acts as a safety net even once the event
+    /// stream is wired up.
+    pub async fn start_polling(
+        &self,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Starting Swarm provider polling on {} every {}s",
+            self.config.endpoint, self.config.refresh_interval
+        );
+
+        let mut interval = tokio::time::interval(Duration::from_secs(self.config.refresh_interval));
+
+        loop {
+            interval.tick().await;
+
+            let new_entrypoints = match self.provide().await {
+                Ok(eps) => eps,
+                Err(e) => {
+                    warn!("Swarm provider poll failed: {}", e);
+                    continue;
+                }
+            };
+
+            let needs_update = {
+                let storage_read = match storage.read() {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        error!("Storage lock poisoned in Swarm provider: {}", e);
+                        continue;
+                    }
+                };
+
+                let old_ids: std::collections::HashSet<&String> = storage_read
+                    .iter()
+                    .filter(|(_, ep)| ep.source.as_deref() == Some(SOURCE))
+                    .map(|(id, _)| id)
+                    .collect();
+
+                let new_ids: std::collections::HashSet<&String> = new_entrypoints.keys().collect();
+
+                old_ids != new_ids
+                    || new_entrypoints.iter().any(|(id, ep)| {
+                        storage_read.get(id).is_none_or(|existing| {
+                            existing.backends != ep.backends
+                                || existing.config.hostnames != ep.config.hostnames
+                                || existing.config.port != ep.config.port
+                        })
+                    })
+            };
+
+            if !needs_update {
+                continue;
+            }
+
+            {
+                let mut storage_write = match storage.write() {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        error!("Storage lock poisoned in Swarm provider: {}", e);
+                        continue;
+                    }
+                };
+                storage_write.retain(|_, ep| ep.source.as_deref() != Some(SOURCE));
+                for (id, mut entrypoint) in new_entrypoints {
+                    entrypoint.source = Some(SOURCE.to_string());
+                    debug!("Swarm provider entrypoint: {}", id);
+                    storage_write.insert(id, entrypoint);
+                }
+            }
+
+            info!("Swarm provider config changed, triggering reload");
+            if let Err(e) = reload_tx.send(()).await {
+                warn!("Failed to send reload signal: {}", e);
+            }
+            acme_notify.notify_one();
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for SwarmProvider {
+    async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        let candidates = self.build_candidates().await.map_err(anyhow::Error::new)?;
+        let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
+
+        for candidate in candidates {
+            let result = labels::parse(&candidate);
+            log_diagnostics(&candidate, &result.diagnostics);
+
+            for (key, entrypoint) in result.entrypoints {
+                let backend_ip = entrypoint.backends.first().cloned().unwrap_or_default();
+                if let Some(existing) = entrypoints.get_mut(&key) {
+                    if !backend_ip.is_empty() && !existing.backends.contains(&backend_ip) {
+                        existing.backends.push(backend_ip);
+                    }
+                } else {
+                    entrypoints.insert(key, entrypoint);
+                }
+            }
+        }
+
+        Ok(entrypoints)
+    }
+
+    fn name(&self) -> &'static str {
+        SOURCE
+    }
+}
+
+#[async_trait]
+impl LabelSource for SwarmProvider {
+    fn provider_name(&self) -> &'static str {
+        SOURCE
+    }
+
+    async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
+        self.build_candidates().await.map_err(anyhow::Error::new)
+    }
+}
+
+/// Swarm reports VIPs as `10.0.0.5/24`. The `/CIDR` is metadata, not part of
+/// the routable IP — strip it.
+fn strip_cidr(addr: &str) -> &str {
+    addr.split('/').next().unwrap_or(addr)
+}
+
+fn log_diagnostics(candidate: &Candidate, diagnostics: &[Diagnostic]) {
+    for d in diagnostics {
+        let target = format!("{}/{}", candidate.provider, candidate.display_name);
+        match d.severity() {
+            Severity::Error => error!(
+                "[{}] {}: {} (label={})",
+                target,
+                d.code.as_str(),
+                d.message,
+                d.label.as_deref().unwrap_or("-")
+            ),
+            Severity::Warn => warn!(
+                "[{}] {}: {} (label={}, value={:?})",
+                target,
+                d.code.as_str(),
+                d.message,
+                d.label.as_deref().unwrap_or("-"),
+                d.value.as_deref().unwrap_or("")
+            ),
+            Severity::Info => debug!("[{}] {}: {}", target, d.code.as_str(), d.message),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_cidr_removes_suffix() {
+        assert_eq!(strip_cidr("10.0.0.5/24"), "10.0.0.5");
+        assert_eq!(strip_cidr("10.0.0.5"), "10.0.0.5");
+        assert_eq!(strip_cidr(""), "");
+        assert_eq!(strip_cidr("fd00::1/64"), "fd00::1");
+    }
+}

--- a/tests/e2e/swarm/01-discovery.sh
+++ b/tests/e2e/swarm/01-discovery.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Swarm provider: VIP discovery, scale via service update, removal cleanup,
+# source tagging via REST API.
+# Sourced by run-swarm.sh.
+
+log "[01] Swarm: discovery via VIP"
+
+if wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_A" "200"; then
+    pass "svca reachable through Sozune (Swarm VIP)"
+else
+    fail "svca NOT reachable (timeout)"
+fi
+
+if wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_B" "200"; then
+    pass "svcb reachable through Sozune (Swarm VIP)"
+else
+    fail "svcb NOT reachable (timeout)"
+fi
+
+log "[01] Swarm: source tag via REST API"
+
+api_response=$(curl -sf --max-time 5 \
+    -H "Authorization: Basic $API_BASIC_AUTH" \
+    "http://127.0.0.1:$API_PORT/entrypoints" 2>/dev/null || echo "")
+
+if [[ -z "$api_response" ]]; then
+    fail "API call /entrypoints failed"
+else
+    swarm_count=$(echo "$api_response" | grep -o '"source":"swarm"' | wc -l)
+    if [[ "$swarm_count" -ge 2 ]]; then
+        pass "API reports >=2 entrypoints with source=swarm (got $swarm_count)"
+    else
+        fail "API reports only $swarm_count entrypoints with source=swarm (expected >=2)"
+        echo "$api_response" | head -c 500
+    fi
+fi
+
+log "[01] Swarm: scale service via update"
+
+docker service scale "${STACK_NAME}_svcb=4" >/dev/null
+sleep "$ROUTE_DELAY"
+
+# Scale change keeps the same VIP, so traffic should remain on the same backend
+# entry. We just verify the route still works after scaling — i.e. the event
+# stream did not corrupt storage.
+if wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_B" "200"; then
+    pass "svcb still reachable after scaling to 4 replicas"
+else
+    fail "svcb NOT reachable after scale to 4"
+fi
+
+log "[01] Swarm: service removal cleans up route"
+
+docker service rm "${STACK_NAME}_svca" >/dev/null
+sleep "$ROUTE_DELAY"
+
+got_status=$(wait_for_not_200 "http://127.0.0.1:$HTTP_PORT/" "$HOST_A")
+if [[ "$got_status" != "200" ]]; then
+    pass "svca route cleaned up after service rm (got $got_status)"
+else
+    fail "svca route NOT cleaned up after service rm (still returning 200)"
+fi
+
+if wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_B" "200"; then
+    pass "svcb still reachable after svca removal"
+else
+    fail "svcb impacted by svca removal — possible cross-service cleanup bug"
+fi

--- a/tests/e2e/swarm/compose.swarm.yaml
+++ b/tests/e2e/swarm/compose.swarm.yaml
@@ -1,0 +1,32 @@
+version: "3.9"
+
+# Stack used by run-swarm.sh — deployed with `docker stack deploy`.
+# All sozune.* labels live under deploy.labels (service-level), not
+# services.*.labels (task-level), because Sozune reads ServiceSpec.Labels.
+
+networks:
+  sozune-swarm-test:
+    external: true
+
+services:
+  svca:
+    image: traefik/whoami
+    networks:
+      - sozune-swarm-test
+    deploy:
+      replicas: 1
+      labels:
+        sozune.enable: "true"
+        sozune.http.svca.host: "svca.swarm-test.localhost"
+        sozune.network: "sozune-swarm-test"
+
+  svcb:
+    image: traefik/whoami
+    networks:
+      - sozune-swarm-test
+    deploy:
+      replicas: 2
+      labels:
+        sozune.enable: "true"
+        sozune.http.svcb.host: "svcb.swarm-test.localhost"
+        sozune.network: "sozune-swarm-test"

--- a/tests/e2e/swarm/lib-swarm.sh
+++ b/tests/e2e/swarm/lib-swarm.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Shared helpers for the Swarm e2e suite.
+# Sourced by run-swarm.sh; not meant to be run standalone.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SWARM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+STACK_NAME="sozune-swarm-test"
+OVERLAY_NETWORK="sozune-swarm-test"
+COMPOSE_FILE="$SWARM_DIR/compose.swarm.yaml"
+SOZUNE_CONTAINER="sozune-swarm-runner"
+# Pick an image whose glibc is >= the one used to build the host binary.
+# ubuntu:rolling tracks the latest Ubuntu and matches typical dev hosts.
+SOZUNE_IMAGE="ubuntu:rolling"
+
+CONFIG_FILE="$SWARM_DIR/config.swarm.yaml"
+
+HTTP_PORT=18090
+HTTPS_PORT=18493
+API_PORT=18898
+MIDDLEWARE_PORT=13047
+
+API_USER="admin"
+API_PASSWORD="swarm-test-secret"
+API_PASSWORD_HASH=$(printf '%s' "$API_PASSWORD" | sha256sum | cut -d' ' -f1)
+API_BASIC_AUTH=$(printf '%s:%s' "$API_USER" "$API_PASSWORD" | base64 -w0)
+
+HOST_A="svca.swarm-test.localhost"
+HOST_B="svcb.swarm-test.localhost"
+
+STARTUP_DELAY=4
+ROUTE_DELAY=8
+MAX_RETRIES=40
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+SWARM_INITIALIZED_BY_US=0
+
+log()  { echo -e "${YELLOW}[SWARM]${NC} $*"; }
+pass() { echo -e "${GREEN}[PASS]${NC} $*"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "${YELLOW}[SKIP]${NC} $*"; SKIPPED=$((SKIPPED + 1)); }
+
+is_swarm_active() {
+    local state
+    state=$(docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null || echo "inactive")
+    [[ "$state" == "active" ]]
+}
+
+ensure_swarm() {
+    if is_swarm_active; then
+        log "Swarm already active on this daemon, reusing it"
+        SWARM_INITIALIZED_BY_US=0
+    else
+        log "Initializing Swarm (single-node)..."
+        docker swarm init --advertise-addr 127.0.0.1 >/dev/null
+        SWARM_INITIALIZED_BY_US=1
+    fi
+}
+
+leave_swarm_if_ours() {
+    if [[ "$SWARM_INITIALIZED_BY_US" == "1" ]]; then
+        log "Leaving the Swarm we created..."
+        docker swarm leave --force >/dev/null 2>&1 || true
+    fi
+}
+
+# Wait for every replica of every service in the stack to reach Running state.
+wait_for_stack_ready() {
+    local i=0
+    while [[ $i -lt $MAX_RETRIES ]]; do
+        local pending
+        pending=$(docker stack services "$STACK_NAME" --format '{{.Replicas}}' 2>/dev/null \
+                  | awk -F'/' '$1 != $2 { print }' | wc -l)
+        if [[ "$pending" == "0" ]]; then
+            return 0
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# Wait for an HTTP route through the sozune container to reach `expected` status.
+wait_for_status() {
+    local url="$1" host="$2" expected="$3"
+    local i=0
+    while [[ $i -lt $MAX_RETRIES ]]; do
+        local status
+        status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+                  -H "Host: $host" "$url" 2>/dev/null || echo "000")
+        if [[ "$status" == "$expected" ]]; then
+            return 0
+        fi
+        sleep 0.5
+        i=$((i + 1))
+    done
+    return 1
+}
+
+wait_for_not_200() {
+    local url="$1" host="$2"
+    local i=0
+    while [[ $i -lt $MAX_RETRIES ]]; do
+        local status
+        status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+                  -H "Host: $host" "$url" 2>/dev/null || echo "000")
+        if [[ "$status" != "200" ]]; then
+            echo "$status"
+            return 0
+        fi
+        sleep 0.5
+        i=$((i + 1))
+    done
+    echo "200"
+    return 1
+}

--- a/tests/e2e/swarm/run-swarm.sh
+++ b/tests/e2e/swarm/run-swarm.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Functional test orchestrator for the Sozune Swarm provider.
+# Inits Swarm, deploys a stack, runs Sozune in a container attached to the
+# overlay (so it can reach VIPs), then runs all suite scripts in order.
+#
+# Requirements: docker (with Swarm capability), curl, cargo
+
+set -euo pipefail
+
+SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SWARM_DIR/lib-swarm.sh"
+
+cleanup() {
+    log "Cleaning up..."
+    docker rm -f "$SOZUNE_CONTAINER" >/dev/null 2>&1 || true
+    docker stack rm "$STACK_NAME" >/dev/null 2>&1 || true
+    # Wait for the stack tasks to release their overlay attachments before we
+    # try to remove it.
+    local i=0
+    while [[ $i -lt 30 ]] && docker network inspect "$OVERLAY_NETWORK" --format '{{len .Containers}}' 2>/dev/null | grep -qv '^0$'; do
+        sleep 1
+        i=$((i + 1))
+    done
+    docker network rm "$OVERLAY_NETWORK" >/dev/null 2>&1 || true
+    leave_swarm_if_ours
+    rm -f "$CONFIG_FILE"
+}
+trap cleanup EXIT
+
+# -- Build sozune --
+log "Building sozune..."
+cargo build --quiet --manifest-path "$PROJECT_DIR/Cargo.toml" 2>&1
+SOZUNE_BIN="$PROJECT_DIR/target/debug/sozune"
+if [[ ! -x "$SOZUNE_BIN" ]]; then
+    echo "Build failed: $SOZUNE_BIN not found"
+    exit 1
+fi
+
+# -- Swarm init + overlay + stack deploy --
+ensure_swarm
+
+log "Creating attachable overlay '$OVERLAY_NETWORK'..."
+docker network create --driver overlay --attachable --scope swarm \
+    "$OVERLAY_NETWORK" >/dev/null
+
+log "Deploying stack '$STACK_NAME'..."
+docker stack deploy -c "$COMPOSE_FILE" "$STACK_NAME" >/dev/null
+
+log "Waiting for stack services to be ready..."
+if ! wait_for_stack_ready; then
+    fail "Stack did not converge in time"
+    docker stack services "$STACK_NAME"
+    exit 1
+fi
+
+# -- Config file (read by sozune inside the container) --
+log "Generating sozune config..."
+cat > "$CONFIG_FILE" <<EOF
+providers:
+  swarm:
+    enabled: true
+    endpoint: "/var/run/docker.sock"
+    expose_by_default: false
+    network: "$OVERLAY_NETWORK"
+    refresh_interval: 5
+
+api:
+  enabled: true
+  listen_address: "0.0.0.0:$API_PORT"
+  users:
+    - name: "$API_USER"
+      hash: "$API_PASSWORD_HASH"
+      role: admin
+
+proxy:
+  http:
+    listen_address: $HTTP_PORT
+  https:
+    listen_address: $HTTPS_PORT
+  max_buffers: 500
+  buffer_size: 16384
+  startup_delay_ms: 1000
+  cluster_setup_delay_ms: 200
+
+middleware:
+  port: $MIDDLEWARE_PORT
+EOF
+
+# -- Run sozune as a container attached to the overlay --
+# The Docker socket gives it access to the Swarm API. The overlay
+# attachment lets it route to service VIPs.
+log "Starting sozune container on overlay '$OVERLAY_NETWORK'..."
+docker run -d --rm \
+    --name "$SOZUNE_CONTAINER" \
+    --network "$OVERLAY_NETWORK" \
+    -p "127.0.0.1:$HTTP_PORT:$HTTP_PORT" \
+    -p "127.0.0.1:$API_PORT:$API_PORT" \
+    -v "/var/run/docker.sock:/var/run/docker.sock:ro" \
+    -v "$SOZUNE_BIN:/sozune:ro" \
+    -v "$CONFIG_FILE:/config.yaml:ro" \
+    -e CONFIG_PATH=/config.yaml \
+    -e RUST_LOG=sozune=debug \
+    "$SOZUNE_IMAGE" \
+    /sozune >/dev/null
+
+sleep "$STARTUP_DELAY"
+
+if ! docker ps --format '{{.Names}}' | grep -q "^$SOZUNE_CONTAINER$"; then
+    fail "sozune container died on startup"
+    docker logs "$SOZUNE_CONTAINER" 2>&1 | tail -50 || true
+    exit 1
+fi
+
+log "Waiting for routes to propagate..."
+sleep "$ROUTE_DELAY"
+
+# -- Run suites --
+for suite in "$SWARM_DIR"/[0-9][0-9]-*.sh; do
+    echo ""
+    source "$suite"
+done
+
+# -- Summary --
+echo ""
+echo "=============================="
+echo -e "  ${GREEN}Passed: $PASSED${NC}  ${RED}Failed: $FAILED${NC}  ${YELLOW}Skipped: $SKIPPED${NC}"
+echo "=============================="
+
+if [[ $FAILED -gt 0 ]]; then
+    log "sozune logs (last 80 lines):"
+    docker logs "$SOZUNE_CONTAINER" 2>&1 | tail -80 || true
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- New `swarm` provider that discovers entrypoints from Docker Swarm services via the manager API
- Reads `sozune.*` labels from `ServiceSpec.Labels`, resolves backends from the per-overlay VIP, and reuses the existing label parser (same diagnostics as `validate`)
- Reactive: subscribes to `type=service` events for near-real-time updates, with a periodic poll (`refresh_interval`, default 15s) as a safety net
- Optional `network` config to filter VIPs to a single overlay
- `dnsrr` endpoint mode is detected and warned about (bollard 0.20 does not expose per-task IPs); falls back to the VIP if attached
- Coexists with the `docker`/`podman`/`http` providers; entries are tagged `source=swarm` and replace-all on diff

## Test plan

- [x] `cargo test --bin sozune` (156 passed, includes new `swarm_config_*` and `strip_cidr` unit tests)
- [x] `bash tests/e2e/swarm/run-swarm.sh` (6 passed: VIP discovery, source tag via REST API, scale, service rm cleanup, no cross-service impact)
- [x] Manual verification: storage drops to expected backends (`10.0.1.2`, `10.0.1.5`), no `127.0.0.1` fallback, route 404s within seconds of `service rm`
- [ ] CI must run on a daemon capable of `docker swarm init` for the e2e suite (the unit tests run anywhere)