### PR TITLE
Add Kubernetes provider with annotation-based discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /registry
 sozune.db
 ROADMAP.md
+.prd/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +44,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -121,6 +140,40 @@ name = "asn1-rs-impl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -239,6 +292,17 @@ dependencies = [
  "hyper-util",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.17",
+ "instant",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -401,6 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +561,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -646,6 +739,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +761,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -671,6 +796,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -699,6 +845,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -907,6 +1062,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -935,6 +1100,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1140,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1029,6 +1227,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-named-pipe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,13 +1270,27 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1241,6 +1473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "instant-acme"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1627,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+dependencies = [
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "kawa"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1705,101 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kube"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-runtime",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf471ece8ff8d24735ce78dac4d091e9fcb8d74811aeb6b75de4d1c3f5de0f1"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-http-proxy",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls",
+ "rustls-pemfile",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http",
+ "json-patch",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fbf1f6ffa98e65f1d2a9a69338bb60605d46be7edf00237784b89e62c9bd44"
+dependencies = [
+ "ahash",
+ "async-broadcast",
+ "async-stream",
+ "async-trait",
+ "backoff",
+ "educe",
+ "futures",
+ "hashbrown 0.14.5",
+ "json-patch",
+ "jsonptr",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1681,9 +2068,30 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1725,6 +2133,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +2184,26 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2226,14 +2697,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2261,16 +2745,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2342,13 +2826,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2378,6 +2884,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -2467,6 +2983,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2661,6 +3188,8 @@ dependencies = [
  "hyper",
  "hyper-util",
  "instant-acme",
+ "k8s-openapi",
+ "kube",
  "mime_guess",
  "notify",
  "rcgen",
@@ -2911,6 +3440,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -2964,6 +3494,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2975,16 +3506,19 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3072,6 +3606,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ sha2 = "0.10"
 subtle = "2"
 rust-embed = "8"
 mime_guess = "2"
+kube = { version = "0.96", default-features = false, features = ["client", "runtime", "rustls-tls"] }
+k8s-openapi = { version = "0.23", features = ["latest"] }
 
 [profile.release]
 strip = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,7 @@ pub struct ProvidersConfig {
     pub docker: Option<DockerConfig>,
     pub podman: Option<PodmanConfig>,
     pub swarm: Option<SwarmConfig>,
+    pub kubernetes: Option<KubernetesConfig>,
     pub config_file: Option<ConfigFileConfig>,
     pub http: Option<HttpProviderConfig>,
 }
@@ -92,6 +93,35 @@ pub struct SwarmConfig {
         deserialize_with = "deserialize_swarm_refresh_interval_with_env"
     )]
     pub refresh_interval: u64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct KubernetesConfig {
+    #[serde(default, deserialize_with = "deserialize_kubernetes_enabled_with_env")]
+    pub enabled: bool,
+    /// Path to a kubeconfig file. Empty string means in-cluster (ServiceAccount).
+    #[serde(
+        default,
+        deserialize_with = "deserialize_kubernetes_kubeconfig_with_env"
+    )]
+    pub kubeconfig: String,
+    /// Restrict discovery to a single namespace. Empty string means all namespaces.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_kubernetes_namespace_with_env"
+    )]
+    pub namespace: String,
+    /// Ingress class name to filter on (only Ingresses with this class are picked up).
+    #[serde(
+        default = "default_kubernetes_ingress_class",
+        deserialize_with = "deserialize_kubernetes_ingress_class_with_env"
+    )]
+    pub ingress_class: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_kubernetes_expose_by_default_with_env"
+    )]
+    pub expose_by_default: bool,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -284,6 +314,22 @@ impl Default for SwarmConfig {
 
 fn default_swarm_refresh_interval() -> u64 {
     15
+}
+
+impl Default for KubernetesConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            kubeconfig: String::new(),
+            namespace: String::new(),
+            ingress_class: default_kubernetes_ingress_class(),
+            expose_by_default: false,
+        }
+    }
+}
+
+fn default_kubernetes_ingress_class() -> String {
+    "sozune".to_string()
 }
 
 fn default_swarm_endpoint() -> String {
@@ -551,6 +597,34 @@ deserialize_with_env!(
 );
 
 deserialize_bool_with_env!(
+    deserialize_kubernetes_enabled_with_env,
+    "SOZUNE_PROVIDER_KUBERNETES_ENABLED",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_kubernetes_kubeconfig_with_env,
+    "SOZUNE_PROVIDER_KUBERNETES_KUBECONFIG",
+    "",
+    literal
+);
+deserialize_string_with_env!(
+    deserialize_kubernetes_namespace_with_env,
+    "SOZUNE_PROVIDER_KUBERNETES_NAMESPACE",
+    "",
+    literal
+);
+deserialize_string_with_env!(
+    deserialize_kubernetes_ingress_class_with_env,
+    "SOZUNE_PROVIDER_KUBERNETES_INGRESS_CLASS",
+    default_kubernetes_ingress_class
+);
+deserialize_bool_with_env!(
+    deserialize_kubernetes_expose_by_default_with_env,
+    "SOZUNE_PROVIDER_KUBERNETES_EXPOSE_BY_DEFAULT",
+    false
+);
+
+deserialize_bool_with_env!(
     deserialize_config_file_enabled_with_env,
     "SOZUNE_PROVIDER_CONFIG_FILE_ENABLED",
     false
@@ -755,6 +829,33 @@ expose_by_default: true
         assert!(!config.enabled);
         assert!(!config.expose_by_default);
         assert!(config.endpoint.ends_with("podman.sock"));
+    }
+
+    #[test]
+    fn test_kubernetes_config_deserialization() {
+        let yaml = r#"
+enabled: true
+kubeconfig: /home/user/.kube/config
+namespace: default
+ingress_class: sozune
+expose_by_default: false
+"#;
+        let config: KubernetesConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.kubeconfig, "/home/user/.kube/config");
+        assert_eq!(config.namespace, "default");
+        assert_eq!(config.ingress_class, "sozune");
+        assert!(!config.expose_by_default);
+    }
+
+    #[test]
+    fn test_kubernetes_config_defaults() {
+        let config = KubernetesConfig::default();
+        assert!(!config.enabled);
+        assert!(config.kubeconfig.is_empty());
+        assert!(config.namespace.is_empty());
+        assert_eq!(config.ingress_class, "sozune");
+        assert!(!config.expose_by_default);
     }
 
     #[test]

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -2,7 +2,7 @@ use crate::config::AppConfig;
 use crate::model::Entrypoint;
 use crate::provider::{
     Provider, config::ConfigProvider, docker::DockerProvider, http::HttpProvider,
-    podman::PodmanProvider, swarm::SwarmProvider,
+    kubernetes::KubernetesProvider, podman::PodmanProvider, swarm::SwarmProvider,
 };
 use anyhow::Context;
 use std::collections::BTreeMap;
@@ -134,6 +134,31 @@ pub async fn start_services(
                 .await
             {
                 error!("Swarm service failed: {}", e);
+            }
+        });
+    }
+
+    // Start Kubernetes service if enabled
+    if let Some(kubernetes_config) = &config.providers.kubernetes
+        && kubernetes_config.enabled
+    {
+        info!("Starting Kubernetes service");
+        let kubernetes_provider = KubernetesProvider::new(kubernetes_config.clone())
+            .context("Failed to create Kubernetes provider")?;
+        let storage_kubernetes = Arc::clone(&storage);
+        let reload_tx_kubernetes = reload_tx.clone();
+        let acme_notify_kubernetes = Arc::clone(&acme_notify);
+
+        tokio::spawn(async move {
+            if let Err(e) = kubernetes_provider
+                .start_service(
+                    storage_kubernetes,
+                    reload_tx_kubernetes,
+                    acme_notify_kubernetes,
+                )
+                .await
+            {
+                error!("Kubernetes service failed: {}", e);
             }
         });
     }

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -1,16 +1,24 @@
 use crate::config::KubernetesConfig;
+use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::diagnostic::{Diagnostic, Severity};
+use crate::labels::source::LabelSource;
+use crate::labels::{self};
 use crate::model::Entrypoint;
 use crate::provider::Provider;
 use anyhow::Context;
 use async_trait::async_trait;
-use k8s_openapi::api::core::v1::Namespace;
+use futures_util::StreamExt;
+use k8s_openapi::api::core::v1::{Namespace, Service};
 use kube::api::ListParams;
 use kube::config::{KubeConfigOptions, Kubeconfig};
-use kube::{Api, Client, Config};
-use std::collections::BTreeMap;
+use kube::runtime::watcher::{self, Event};
+use kube::{Api, Client, Config, Resource};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Notify, mpsc};
-use tracing::{info, warn};
+use tracing::{debug, error, info, warn};
+
+const PROVIDER_NAME: &str = "kubernetes";
 
 pub struct KubernetesProvider {
     config: KubernetesConfig,
@@ -20,7 +28,16 @@ pub struct KubernetesProvider {
 #[async_trait]
 impl Provider for KubernetesProvider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
-        Ok(BTreeMap::new())
+        let candidates = self.collect().await?;
+        let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
+        for candidate in candidates {
+            let result = labels::parse(&candidate);
+            log_diagnostics(&candidate, &result.diagnostics);
+            for (key, entrypoint) in result.entrypoints {
+                entrypoints.insert(key, entrypoint);
+            }
+        }
+        Ok(entrypoints)
     }
 
     fn name(&self) -> &'static str {
@@ -28,19 +45,38 @@ impl Provider for KubernetesProvider {
     }
 }
 
+#[async_trait]
+impl LabelSource for KubernetesProvider {
+    fn provider_name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
+        let client = self.build_client().await?;
+        let services: Api<Service> = self.scoped_api(&client);
+        let list = services
+            .list(&ListParams::default())
+            .await
+            .context("Failed to list Kubernetes services")?;
+
+        let mut out = Vec::new();
+        for svc in list.items {
+            if let Some(candidate) = self.service_to_candidate(&svc) {
+                out.push(candidate);
+            }
+        }
+        Ok(out)
+    }
+}
+
 impl KubernetesProvider {
     pub fn new(config: KubernetesConfig) -> anyhow::Result<Self> {
         Ok(Self {
             config,
-            name: "kubernetes",
+            name: PROVIDER_NAME,
         })
     }
 
-    /// Build a Kubernetes client.
-    ///
-    /// - empty `kubeconfig` → in-cluster ServiceAccount or auto-discovered
-    ///   kubeconfig (`$KUBECONFIG` / `~/.kube/config`) via `Client::try_default`.
-    /// - non-empty `kubeconfig` → load that exact file.
     async fn build_client(&self) -> anyhow::Result<Client> {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
@@ -60,11 +96,67 @@ impl KubernetesProvider {
         }
     }
 
+    /// Build a namespaced or cluster-wide Api handle depending on config.
+    fn scoped_api<K>(&self, client: &Client) -> Api<K>
+    where
+        K: Resource<Scope = k8s_openapi::NamespaceResourceScope>,
+        <K as Resource>::DynamicType: Default,
+    {
+        if self.config.namespace.is_empty() {
+            Api::all(client.clone())
+        } else {
+            Api::namespaced(client.clone(), &self.config.namespace)
+        }
+    }
+
+    /// Convert a Service into a `Candidate`. Returns `None` for Services that
+    /// have no `sozune.*` annotation and are not opted-in via `expose_by_default`.
+    fn service_to_candidate(&self, svc: &Service) -> Option<Candidate> {
+        let metadata = &svc.metadata;
+        let namespace = metadata.namespace.as_deref().unwrap_or("default");
+        let name = metadata.name.as_deref()?;
+
+        let annotations: HashMap<String, String> = metadata
+            .annotations
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        let has_sozune_annotation = annotations.keys().any(|k| k.starts_with("sozune."));
+        if !has_sozune_annotation && !self.config.expose_by_default {
+            return None;
+        }
+
+        let cluster_ip = svc
+            .spec
+            .as_ref()
+            .and_then(|s| s.cluster_ip.clone())
+            .filter(|ip| !ip.is_empty() && ip != "None");
+
+        let networks = match cluster_ip {
+            Some(ip) => vec![NetworkInfo {
+                name: "cluster".to_string(),
+                ip: Some(ip),
+            }],
+            None => Vec::new(),
+        };
+
+        let id = format!("{namespace}/{name}");
+        Some(Candidate {
+            provider: self.name,
+            id: id.clone(),
+            display_name: id,
+            labels: annotations,
+            networks,
+            enabled_default: self.config.expose_by_default,
+        })
+    }
+
     pub async fn start_service(
         &self,
-        _storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        _reload_tx: mpsc::Sender<()>,
-        _acme_notify: Arc<Notify>,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
     ) -> anyhow::Result<()> {
         info!(
             "Starting Kubernetes provider (namespace={}, ingress_class={}, expose_by_default={})",
@@ -79,30 +171,270 @@ impl KubernetesProvider {
 
         let client = self.build_client().await?;
 
-        match client.apiserver_version().await {
-            Ok(version) => info!(
-                "Connected to Kubernetes cluster (version {}.{}, git {})",
-                version.major, version.minor, version.git_version
-            ),
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "Failed to query Kubernetes API server: {}",
-                    e
-                ));
+        let version = client
+            .apiserver_version()
+            .await
+            .context("Failed to query Kubernetes API server")?;
+        info!(
+            "Connected to Kubernetes cluster (version {}.{}, git {})",
+            version.major, version.minor, version.git_version
+        );
+
+        let ns_api: Api<Namespace> = Api::all(client.clone());
+        let ns_list = ns_api
+            .list(&ListParams::default())
+            .await
+            .context("Failed to list namespaces")?;
+        info!(
+            "Kubernetes auth OK: {} namespace(s) visible to ServiceAccount",
+            ns_list.items.len()
+        );
+
+        self.watch_services(client, storage, reload_tx, acme_notify)
+            .await
+    }
+
+    async fn watch_services(
+        &self,
+        client: Client,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+    ) -> anyhow::Result<()> {
+        let services: Api<Service> = self.scoped_api(&client);
+        let stream = watcher::watcher(services, watcher::Config::default());
+        tokio::pin!(stream);
+
+        info!("Kubernetes Service watcher started");
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(Event::Apply(svc)) | Ok(Event::InitApply(svc)) => {
+                    self.upsert_service(&svc, &storage, &reload_tx, &acme_notify)
+                        .await;
+                }
+                Ok(Event::Delete(svc)) => {
+                    self.remove_service(&svc, &storage, &reload_tx).await;
+                }
+                Ok(Event::Init) => {
+                    debug!("Service watcher restart: reinitialising");
+                }
+                Ok(Event::InitDone) => {
+                    debug!("Service watcher initial sync complete");
+                }
+                Err(e) => {
+                    error!("Service watcher error: {}", e);
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
             }
         }
 
-        let ns_api: Api<Namespace> = Api::all(client.clone());
-        match ns_api.list(&ListParams::default()).await {
-            Ok(list) => info!(
-                "Kubernetes auth OK: {} namespace(s) visible to ServiceAccount",
-                list.items.len()
-            ),
-            Err(e) => return Err(anyhow::anyhow!("Failed to list namespaces: {}", e)),
+        warn!("Kubernetes Service watcher stopped");
+        Ok(())
+    }
+
+    async fn upsert_service(
+        &self,
+        svc: &Service,
+        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: &mpsc::Sender<()>,
+        acme_notify: &Arc<Notify>,
+    ) {
+        let Some(candidate) = self.service_to_candidate(svc) else {
+            return;
+        };
+
+        let result = labels::parse(&candidate);
+        log_diagnostics(&candidate, &result.diagnostics);
+
+        if result.entrypoints.is_empty() {
+            return;
         }
 
-        warn!("Kubernetes provider discovery is not implemented yet");
+        let mut storage_changed = false;
+        {
+            let mut storage_write = match storage.write() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("Storage lock poisoned in Kubernetes upsert: {}", e);
+                    return;
+                }
+            };
 
-        Ok(())
+            for (key, mut entrypoint) in result.entrypoints {
+                entrypoint.source = Some(self.name.to_string());
+                info!(
+                    "Kubernetes upsert {} from service {}",
+                    key, candidate.display_name
+                );
+                storage_write.insert(key, entrypoint);
+                storage_changed = true;
+            }
+        }
+
+        if storage_changed {
+            if let Err(e) = reload_tx.send(()).await {
+                error!(
+                    "Failed to send reload signal after Kubernetes upsert: {}",
+                    e
+                );
+            }
+            acme_notify.notify_one();
+        }
+    }
+
+    async fn remove_service(
+        &self,
+        svc: &Service,
+        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: &mpsc::Sender<()>,
+    ) {
+        let Some(candidate) = self.service_to_candidate(svc) else {
+            return;
+        };
+
+        let result = labels::parse(&candidate);
+        if result.entrypoints.is_empty() {
+            return;
+        }
+
+        let mut storage_changed = false;
+        {
+            let mut storage_write = match storage.write() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("Storage lock poisoned in Kubernetes remove: {}", e);
+                    return;
+                }
+            };
+
+            for key in result.entrypoints.keys() {
+                if storage_write.remove(key).is_some() {
+                    info!(
+                        "Kubernetes remove {} from service {}",
+                        key, candidate.display_name
+                    );
+                    storage_changed = true;
+                }
+            }
+        }
+
+        if storage_changed && let Err(e) = reload_tx.send(()).await {
+            error!(
+                "Failed to send reload signal after Kubernetes remove: {}",
+                e
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::ServiceSpec;
+    use kube::api::ObjectMeta;
+    use std::collections::BTreeMap;
+
+    fn make_provider(expose_by_default: bool) -> KubernetesProvider {
+        KubernetesProvider {
+            config: KubernetesConfig {
+                enabled: true,
+                kubeconfig: String::new(),
+                namespace: String::new(),
+                ingress_class: "sozune".to_string(),
+                expose_by_default,
+            },
+            name: PROVIDER_NAME,
+        }
+    }
+
+    fn make_service(
+        name: &str,
+        namespace: &str,
+        annotations: &[(&str, &str)],
+        cluster_ip: Option<&str>,
+    ) -> Service {
+        let mut anns = BTreeMap::new();
+        for (k, v) in annotations {
+            anns.insert((*k).to_string(), (*v).to_string());
+        }
+        Service {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                annotations: if anns.is_empty() { None } else { Some(anns) },
+                ..Default::default()
+            },
+            spec: Some(ServiceSpec {
+                cluster_ip: cluster_ip.map(|s| s.to_string()),
+                ..Default::default()
+            }),
+            status: None,
+        }
+    }
+
+    #[test]
+    fn service_without_sozune_annotation_is_skipped() {
+        let provider = make_provider(false);
+        let svc = make_service("api", "default", &[("app", "api")], Some("10.0.0.1"));
+        assert!(provider.service_to_candidate(&svc).is_none());
+    }
+
+    #[test]
+    fn service_with_sozune_annotation_becomes_candidate() {
+        let provider = make_provider(false);
+        let svc = make_service(
+            "api",
+            "default",
+            &[
+                ("sozune.enable", "true"),
+                ("sozune.http.web.host", "x.test"),
+            ],
+            Some("10.0.0.1"),
+        );
+        let candidate = provider.service_to_candidate(&svc).expect("candidate");
+        assert_eq!(candidate.id, "default/api");
+        assert_eq!(candidate.networks.len(), 1);
+        assert_eq!(candidate.networks[0].name, "cluster");
+        assert_eq!(candidate.networks[0].ip.as_deref(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn expose_by_default_picks_up_unannotated_service() {
+        let provider = make_provider(true);
+        let svc = make_service("api", "default", &[], Some("10.0.0.1"));
+        assert!(provider.service_to_candidate(&svc).is_some());
+    }
+
+    #[test]
+    fn headless_service_has_no_network() {
+        let provider = make_provider(true);
+        let svc = make_service("headless", "default", &[], Some("None"));
+        let candidate = provider.service_to_candidate(&svc).expect("candidate");
+        assert!(candidate.networks.is_empty());
+    }
+}
+
+fn log_diagnostics(candidate: &Candidate, diagnostics: &[Diagnostic]) {
+    for d in diagnostics {
+        let target = format!("{}/{}", candidate.provider, candidate.display_name);
+        match d.severity() {
+            Severity::Error => error!(
+                "[{}] {}: {} (label={})",
+                target,
+                d.code.as_str(),
+                d.message,
+                d.label.as_deref().unwrap_or("-")
+            ),
+            Severity::Warn => warn!(
+                "[{}] {}: {} (label={}, value={:?})",
+                target,
+                d.code.as_str(),
+                d.message,
+                d.label.as_deref().unwrap_or("-"),
+                d.value.as_deref().unwrap_or("")
+            ),
+            Severity::Info => debug!("[{}] {}: {}", target, d.code.as_str(), d.message),
+        }
     }
 }

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -1,7 +1,12 @@
 use crate::config::KubernetesConfig;
 use crate::model::Entrypoint;
 use crate::provider::Provider;
+use anyhow::Context;
 use async_trait::async_trait;
+use k8s_openapi::api::core::v1::Namespace;
+use kube::api::ListParams;
+use kube::config::{KubeConfigOptions, Kubeconfig};
+use kube::{Api, Client, Config};
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Notify, mpsc};
@@ -31,6 +36,30 @@ impl KubernetesProvider {
         })
     }
 
+    /// Build a Kubernetes client.
+    ///
+    /// - empty `kubeconfig` → in-cluster ServiceAccount or auto-discovered
+    ///   kubeconfig (`$KUBECONFIG` / `~/.kube/config`) via `Client::try_default`.
+    /// - non-empty `kubeconfig` → load that exact file.
+    async fn build_client(&self) -> anyhow::Result<Client> {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        if self.config.kubeconfig.is_empty() {
+            Client::try_default()
+                .await
+                .context("Failed to build Kubernetes client from default config")
+        } else {
+            let kubeconfig = Kubeconfig::read_from(&self.config.kubeconfig).with_context(|| {
+                format!("Failed to read kubeconfig at {}", self.config.kubeconfig)
+            })?;
+            let kube_config =
+                Config::from_custom_kubeconfig(kubeconfig, &KubeConfigOptions::default())
+                    .await
+                    .context("Failed to build kube Config from kubeconfig")?;
+            Client::try_from(kube_config).context("Failed to build Kubernetes client from Config")
+        }
+    }
+
     pub async fn start_service(
         &self,
         _storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
@@ -48,9 +77,31 @@ impl KubernetesProvider {
             self.config.expose_by_default,
         );
 
-        warn!(
-            "Kubernetes provider is a stub: discovery is not implemented yet (see .prd/kubernetes-provider.md)"
-        );
+        let client = self.build_client().await?;
+
+        match client.apiserver_version().await {
+            Ok(version) => info!(
+                "Connected to Kubernetes cluster (version {}.{}, git {})",
+                version.major, version.minor, version.git_version
+            ),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to query Kubernetes API server: {}",
+                    e
+                ));
+            }
+        }
+
+        let ns_api: Api<Namespace> = Api::all(client.clone());
+        match ns_api.list(&ListParams::default()).await {
+            Ok(list) => info!(
+                "Kubernetes auth OK: {} namespace(s) visible to ServiceAccount",
+                list.items.len()
+            ),
+            Err(e) => return Err(anyhow::anyhow!("Failed to list namespaces: {}", e)),
+        }
+
+        warn!("Kubernetes provider discovery is not implemented yet");
 
         Ok(())
     }

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -1,0 +1,57 @@
+use crate::config::KubernetesConfig;
+use crate::model::Entrypoint;
+use crate::provider::Provider;
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+use tokio::sync::{Notify, mpsc};
+use tracing::{info, warn};
+
+pub struct KubernetesProvider {
+    config: KubernetesConfig,
+    name: &'static str,
+}
+
+#[async_trait]
+impl Provider for KubernetesProvider {
+    async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        Ok(BTreeMap::new())
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+impl KubernetesProvider {
+    pub fn new(config: KubernetesConfig) -> anyhow::Result<Self> {
+        Ok(Self {
+            config,
+            name: "kubernetes",
+        })
+    }
+
+    pub async fn start_service(
+        &self,
+        _storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        _reload_tx: mpsc::Sender<()>,
+        _acme_notify: Arc<Notify>,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Starting Kubernetes provider (namespace={}, ingress_class={}, expose_by_default={})",
+            if self.config.namespace.is_empty() {
+                "<all>"
+            } else {
+                self.config.namespace.as_str()
+            },
+            self.config.ingress_class,
+            self.config.expose_by_default,
+        );
+
+        warn!(
+            "Kubernetes provider is a stub: discovery is not implemented yet (see .prd/kubernetes-provider.md)"
+        );
+
+        Ok(())
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -12,5 +12,6 @@ pub mod config;
 pub mod docker;
 pub mod factory;
 pub mod http;
+pub mod kubernetes;
 pub mod podman;
 pub mod swarm;


### PR DESCRIPTION
## Summary
- Adds `kube` 0.96 + `k8s-openapi` 0.23 with rustls-tls.
- New `KubernetesConfig` (kubeconfig, namespace, ingress_class, expose_by_default) wired through the same env-override pattern as other providers.
- `KubernetesProvider` connects in-cluster (ServiceAccount) or via kubeconfig path, watches `Service` resources, and routes `sozune.*` annotations through the shared label catalog.
- Backends are resolved from `Service.spec.clusterIP` for now — EndpointSlice support and Ingress come in follow-up PRs.

## Test plan
- [x] cargo test --bin sozune (158 tests passing)
- [x] kind cluster + Service annotated with sozune.* → entrypoint appears in storage within 1s
- [x] Delete the Service → entrypoint removed
- [x] expose_by_default=true picks up unannotated Services

## Follow-ups
- PR2: backend resolution from EndpointSlice (ready pod IPs, scale-up/down tracking)
- PR3: Ingress watcher + docs + e2e tests + release-build fix