### PR TITLE
Add --config CLI flag

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,8 +11,20 @@ pub mod validate;
     about = "Container-native HTTP/TCP/UDP proxy"
 )]
 pub struct Cli {
+    /// Path to the configuration file. Overrides the CONFIG_PATH env var.
+    #[arg(short, long, global = true, value_name = "PATH")]
+    pub config: Option<String>,
+
     #[command(subcommand)]
     pub command: Option<Command>,
+}
+
+/// Resolve the config path: CLI flag > env var > default.
+pub fn resolve_config_path(cli_override: Option<&str>) -> String {
+    if let Some(p) = cli_override {
+        return p.to_string();
+    }
+    std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string())
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -45,8 +45,8 @@ impl SeverityFilter {
     }
 }
 
-pub async fn run(args: ValidateArgs) -> anyhow::Result<i32> {
-    let config = load_config().await?;
+pub async fn run(args: ValidateArgs, config_path: &str) -> anyhow::Result<i32> {
+    let config = load_config(config_path).await?;
     let candidates = collect_candidates(&config, args.provider.as_deref()).await?;
     let mut report = build_report(candidates);
 
@@ -66,13 +66,11 @@ pub async fn run(args: ValidateArgs) -> anyhow::Result<i32> {
     Ok(exit_code(&report))
 }
 
-async fn load_config() -> anyhow::Result<AppConfig> {
-    let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string());
-
-    if !tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
+async fn load_config(config_path: &str) -> anyhow::Result<AppConfig> {
+    if !tokio::fs::try_exists(config_path).await.unwrap_or(false) {
         return Ok(AppConfig::default());
     }
-    let content = tokio::fs::read_to_string(&config_path).await?;
+    let content = tokio::fs::read_to_string(config_path).await?;
     Ok(serde_yaml::from_str(&content)?)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,10 +31,12 @@ async fn main() -> anyhow::Result<()> {
 
     init_tracing();
 
+    let config_path = cli::resolve_config_path(cli.config.as_deref());
+
     match cli.command.unwrap_or(Command::Serve) {
-        Command::Serve => serve().await,
+        Command::Serve => serve(&config_path).await,
         Command::Validate(args) => {
-            let exit = cli::validate::run(args).await?;
+            let exit = cli::validate::run(args, &config_path).await?;
             std::process::exit(exit);
         }
     }
@@ -52,14 +54,12 @@ fn init_tracing() {
         .init();
 }
 
-async fn serve() -> anyhow::Result<()> {
+async fn serve(config_path: &str) -> anyhow::Result<()> {
     info!("Starting Sozune proxy");
 
-    let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.yaml".to_string());
-
-    let config = if tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
+    let config = if tokio::fs::try_exists(config_path).await.unwrap_or(false) {
         info!("Loading configuration from: {}", config_path);
-        let config_content = tokio::fs::read_to_string(&config_path)
+        let config_content = tokio::fs::read_to_string(config_path)
             .await
             .context("Failed to read a config file")?;
 


### PR DESCRIPTION
## Summary
- Add a global `--config` / `-c` flag to set the configuration file path from the command line.
- Resolution order is now: CLI flag > `CONFIG_PATH` env var > default `config.yaml`.
- The flag is shared between `serve` and `validate` subcommands.

## Test plan
- [x] `cargo run -- --config config_dev.yaml` loads `config_dev.yaml`.
- [x] `CONFIG_PATH=config_dev.yaml cargo run` still works (back-compat).
- [x] `cargo run -- -c missing.yaml` falls back to default config (file-not-found path).
- [x] `cargo run -- --config config_dev.yaml validate` uses the same path.