### PR TITLE
Surface unhealthy backends on the dashboard

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -98,6 +98,8 @@ export interface Entrypoint {
   config: EntrypointConfig;
   source?: string | null;
   backend_weights?: Record<string, number>;
+  /** Backend addresses (`host:port`) currently marked down by the health checker. */
+  unhealthy_backends?: string[];
 }
 
 export function listEntrypoints(): Promise<Entrypoint[]> {

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -79,7 +79,7 @@
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h4a2 2 0 0 1 2 2v9a2 2 0 0 0-2-2H2zM14 3h-4a2 2 0 0 0-2 2v9a2 2 0 0 1 2-2h4z"/></svg>
           <span>Documentation</span>
         </a>
-        <div class="version mono">v0.10.0</div>
+        <div class="version mono">v0.11.0</div>
       </div>
     </aside>
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -32,8 +32,17 @@
     http: entrypoints.filter((e) => e.protocol === 'Http').length,
     tcp: entrypoints.filter((e) => e.protocol === 'Tcp').length,
     backends: entrypoints.reduce((n, e) => n + e.backends.length, 0),
+    backendsDown: entrypoints.reduce((n, e) => n + (e.unhealthy_backends?.length ?? 0), 0),
     tls: entrypoints.filter((e) => e.config.tls).length
   });
+
+  function isBackendDown(ep: Entrypoint, backend: string): boolean {
+    return (ep.unhealthy_backends ?? []).includes(`${backend}:${ep.config.port}`);
+  }
+
+  function downCount(ep: Entrypoint): number {
+    return ep.backends.filter((b) => isBackendDown(ep, b)).length;
+  }
 
   async function load(silent = false) {
     if (!silent) loading = true;
@@ -94,7 +103,13 @@
   <div class="stat-card">
     <div class="stat-label">Backends</div>
     <div class="stat-value">{stats.backends}</div>
-    <div class="stat-sub">across all entrypoints</div>
+    <div class="stat-sub">
+      {#if stats.backendsDown > 0}
+        <span class="stat-down">{stats.backendsDown} down</span> · {stats.backends - stats.backendsDown} healthy
+      {:else}
+        across all entrypoints
+      {/if}
+    </div>
   </div>
   <div class="stat-card">
     <div class="stat-label">TLS enabled</div>
@@ -178,9 +193,18 @@
             <td>
               <div class="backends-cell">
                 <span class="backend-count mono">{ep.backends.length}</span>
-                <div class="health-bar" title="{ep.backends.length} backends">
-                  {#each ep.backends as _b, i}
-                    <span class="health-seg" style="animation-delay: {i * 40}ms"></span>
+                <div
+                  class="health-bar"
+                  title={downCount(ep) > 0
+                    ? `${ep.backends.length - downCount(ep)}/${ep.backends.length} healthy`
+                    : `${ep.backends.length} backends, all healthy`}
+                >
+                  {#each ep.backends as b, i}
+                    <span
+                      class="health-seg"
+                      class:down={isBackendDown(ep, b)}
+                      style="animation-delay: {i * 40}ms"
+                    ></span>
                   {/each}
                 </div>
               </div>
@@ -506,6 +530,13 @@
     border-radius: 2px;
     opacity: 0;
     animation: fade-in 0.4s forwards;
+  }
+  .health-seg.down {
+    background: var(--danger);
+  }
+  .stat-down {
+    color: var(--danger);
+    font-weight: 600;
   }
   @keyframes fade-in {
     to { opacity: 1; }

--- a/dashboard/src/routes/entrypoints/[id]/+page.svelte
+++ b/dashboard/src/routes/entrypoints/[id]/+page.svelte
@@ -13,6 +13,10 @@
 
   const id = $derived($page.params.id ?? '');
 
+  function isBackendDown(ep: Entrypoint, backend: string): boolean {
+    return (ep.unhealthy_backends ?? []).includes(`${backend}:${ep.config.port}`);
+  }
+
   async function load(silent = false) {
     if (!id) {
       return;
@@ -159,6 +163,7 @@
           <tr>
             <th>Address</th>
             <th>Weight</th>
+            <th>Status</th>
           </tr>
         </thead>
         <tbody>
@@ -166,6 +171,13 @@
             <tr>
               <td class="mono">{backend}</td>
               <td class="mono">{entrypoint.backend_weights?.[backend] ?? 1}</td>
+              <td>
+                {#if isBackendDown(entrypoint, backend)}
+                  <span class="status-pill down">down</span>
+                {:else}
+                  <span class="status-pill up">healthy</span>
+                {/if}
+              </td>
             </tr>
           {/each}
         </tbody>
@@ -373,6 +385,24 @@
     padding: 0.55rem 0.5rem;
     border-bottom: 1px solid var(--border);
     font-size: 0.8rem;
+  }
+  .status-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+  }
+  .status-pill.up {
+    background: var(--success-bg);
+    color: var(--success);
+  }
+  .status-pill.down {
+    background: var(--danger-bg);
+    color: var(--danger);
   }
   .backends-table tbody tr:last-child td,
   .kv-table tbody tr:last-child td {

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -9,7 +9,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -22,6 +22,28 @@ pub struct AppState {
     pub storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     pub reload_tx: mpsc::Sender<()>,
     pub users: Vec<ApiUser>,
+    pub unhealthy_backends: Arc<RwLock<HashSet<String>>>,
+}
+
+/// Build the JSON payload for an entrypoint, augmenting it with the
+/// `unhealthy_backends` list (subset of `backends` that the health checker
+/// has marked down). Empty when every backend is reachable.
+fn entrypoint_payload(entrypoint: &Entrypoint, unhealthy: &HashSet<String>) -> serde_json::Value {
+    let unhealthy_for_ep: Vec<String> = entrypoint
+        .backends
+        .iter()
+        .map(|b| format!("{}:{}", b, entrypoint.config.port))
+        .filter(|key| unhealthy.contains(key))
+        .collect();
+
+    let mut value = serde_json::json!(entrypoint);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "unhealthy_backends".to_string(),
+            serde_json::json!(unhealthy_for_ep),
+        );
+    }
+    value
 }
 
 #[derive(Deserialize)]
@@ -115,6 +137,7 @@ pub async fn serve(
     config: ApiConfig,
     storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     reload_tx: mpsc::Sender<()>,
+    unhealthy_backends: Arc<RwLock<HashSet<String>>>,
 ) -> anyhow::Result<()> {
     if config.users.is_empty() {
         anyhow::bail!(
@@ -126,6 +149,7 @@ pub async fn serve(
         storage,
         reload_tx,
         users: config.users.clone(),
+        unhealthy_backends,
     };
 
     let protected = Router::new()
@@ -238,7 +262,17 @@ async fn list_entrypoints(State(state): State<AppState>) -> (StatusCode, Json<se
             );
         }
     };
-    let list: Vec<&Entrypoint> = storage.values().collect();
+    let unhealthy = match state.unhealthy_backends.read() {
+        Ok(guard) => guard.clone(),
+        Err(e) => {
+            error!("Unhealthy-backends lock poisoned: {}", e);
+            HashSet::new()
+        }
+    };
+    let list: Vec<serde_json::Value> = storage
+        .values()
+        .map(|ep| entrypoint_payload(ep, &unhealthy))
+        .collect();
     (StatusCode::OK, Json(serde_json::json!(list)))
 }
 
@@ -256,9 +290,19 @@ async fn get_entrypoint(
             );
         }
     };
+    let unhealthy = match state.unhealthy_backends.read() {
+        Ok(guard) => guard.clone(),
+        Err(e) => {
+            error!("Unhealthy-backends lock poisoned: {}", e);
+            HashSet::new()
+        }
+    };
 
     match storage.get(&id) {
-        Some(entrypoint) => (StatusCode::OK, Json(serde_json::json!(entrypoint))),
+        Some(entrypoint) => (
+            StatusCode::OK,
+            Json(entrypoint_payload(entrypoint, &unhealthy)),
+        ),
         None => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": "entrypoint not found"})),
@@ -452,6 +496,7 @@ mod tests {
             storage: Arc::new(RwLock::new(BTreeMap::new())),
             reload_tx,
             users,
+            unhealthy_backends: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,13 +129,19 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
         }
     });
 
+    // Build the health checker up-front so its unhealthy-backend state can be
+    // shared with the API (read by `GET /entrypoints`) and the runtime task.
+    let health_checker = proxy::health::HealthChecker::new(Arc::clone(&storage), reload_tx.clone());
+    let unhealthy_backends = health_checker.unhealthy_backends();
+
     let storage_server = storage.clone();
     let reload_tx_api = reload_tx.clone();
     let api_config = config.api.clone();
+    let unhealthy_api = Arc::clone(&unhealthy_backends);
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
-            api::server::serve(api_config, storage_server, reload_tx_api).await?;
+            api::server::serve(api_config, storage_server, reload_tx_api, unhealthy_api).await?;
         }
 
         Ok::<(), anyhow::Error>(())
@@ -152,14 +158,9 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     });
 
     // Start backend health checker
-    let health_task = tokio::spawn({
-        let storage_health = Arc::clone(&storage);
-        let reload_tx_health = reload_tx.clone();
-        async move {
-            let checker = proxy::health::HealthChecker::new(storage_health, reload_tx_health);
-            checker.run().await;
-            Ok::<(), anyhow::Error>(())
-        }
+    let health_task = tokio::spawn(async move {
+        health_checker.run().await;
+        Ok::<(), anyhow::Error>(())
     });
 
     // Start middleware server


### PR DESCRIPTION
## Summary

The health checker has been tracking down backends server-side for a while, but the dashboard had no way to surface that — every entrypoint looked green even when its backends were unreachable. This PR plumbs the unhealthy state through the API and renders it on both the entrypoint list and detail pages.

### Backend
- Lift `HealthChecker` construction to top-level so its `Arc<RwLock<HashSet<String>>>` of unhealthy backends can be shared.
- Pass that set into `api::server::serve()` and into `AppState`.
- `GET /entrypoints` and `GET /entrypoints/{id}` now augment each payload with an `unhealthy_backends: ["host:port", …]` field (subset of the entrypoint's own backends that are currently down).

### Dashboard
- Bump version footer from `v0.10.0` → `v0.11.0` (matches `Cargo.toml`).
- Entrypoints list: red segments in the health bar for down backends; "Backends" stat card now shows `N down · M healthy` when applicable.
- Entrypoint detail: new "Status" column on the backends table with a green "healthy" / red "down" pill.

## Test plan
- [x] `cargo test` — 162/162 passing.
- [x] `cargo fmt --check` clean.
- [x] `bun run check` — 0 errors.
- [x] `bun run lint` clean.
- [x] `bun run build` succeeds.
- [x] Manual verification with a mix of reachable (5173, 8081) and unreachable (4503, 4504) backends — API exposes the right list, dashboard renders red/green correctly on both list and detail pages.