### PR TITLE
Resolve Kubernetes backends from EndpointSlice pod IPs

### DIFF
--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -143,8 +143,10 @@ pub async fn start_services(
         && kubernetes_config.enabled
     {
         info!("Starting Kubernetes service");
-        let kubernetes_provider = KubernetesProvider::new(kubernetes_config.clone())
-            .context("Failed to create Kubernetes provider")?;
+        let kubernetes_provider = Arc::new(
+            KubernetesProvider::new(kubernetes_config.clone())
+                .context("Failed to create Kubernetes provider")?,
+        );
         let storage_kubernetes = Arc::clone(&storage);
         let reload_tx_kubernetes = reload_tx.clone();
         let acme_notify_kubernetes = Arc::clone(&acme_notify);

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use k8s_openapi::api::core::v1::{Namespace, Service};
+use k8s_openapi::api::discovery::v1::EndpointSlice;
 use kube::api::ListParams;
 use kube::config::{KubeConfigOptions, Kubeconfig};
 use kube::runtime::watcher::{self, Event};
@@ -19,10 +20,16 @@ use tokio::sync::{Notify, mpsc};
 use tracing::{debug, error, info, warn};
 
 const PROVIDER_NAME: &str = "kubernetes";
+const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
+
+/// Maps `namespace/service` → list of ready pod IPs, populated from
+/// EndpointSlice watch events. Used to resolve backends for Services.
+type EndpointsCache = Arc<RwLock<HashMap<String, Vec<String>>>>;
 
 pub struct KubernetesProvider {
     config: KubernetesConfig,
     name: &'static str,
+    endpoints: EndpointsCache,
 }
 
 #[async_trait]
@@ -74,6 +81,7 @@ impl KubernetesProvider {
         Ok(Self {
             config,
             name: PROVIDER_NAME,
+            endpoints: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -111,6 +119,11 @@ impl KubernetesProvider {
 
     /// Convert a Service into a `Candidate`. Returns `None` for Services that
     /// have no `sozune.*` annotation and are not opted-in via `expose_by_default`.
+    ///
+    /// The candidate carries a single representative network IP (first ready
+    /// pod IP if available, otherwise `Service.spec.clusterIP`) to satisfy the
+    /// label parser. Multiple backends are injected by `upsert_service` after
+    /// parsing — the parser produces only one backend per candidate by design.
     fn service_to_candidate(&self, svc: &Service) -> Option<Candidate> {
         let metadata = &svc.metadata;
         let namespace = metadata.namespace.as_deref().unwrap_or("default");
@@ -127,13 +140,17 @@ impl KubernetesProvider {
             return None;
         }
 
-        let cluster_ip = svc
-            .spec
-            .as_ref()
-            .and_then(|s| s.cluster_ip.clone())
-            .filter(|ip| !ip.is_empty() && ip != "None");
+        let id = format!("{namespace}/{name}");
 
-        let networks = match cluster_ip {
+        let pod_ips = self.pod_ips_for(&id);
+        let representative_ip = pod_ips.first().cloned().or_else(|| {
+            svc.spec
+                .as_ref()
+                .and_then(|s| s.cluster_ip.clone())
+                .filter(|ip| !ip.is_empty() && ip != "None")
+        });
+
+        let networks = match representative_ip {
             Some(ip) => vec![NetworkInfo {
                 name: "cluster".to_string(),
                 ip: Some(ip),
@@ -141,7 +158,6 @@ impl KubernetesProvider {
             None => Vec::new(),
         };
 
-        let id = format!("{namespace}/{name}");
         Some(Candidate {
             provider: self.name,
             id: id.clone(),
@@ -152,8 +168,17 @@ impl KubernetesProvider {
         })
     }
 
+    /// Read all ready pod IPs known for a `namespace/service` from the cache.
+    fn pod_ips_for(&self, svc_id: &str) -> Vec<String> {
+        self.endpoints
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(svc_id).cloned())
+            .unwrap_or_default()
+    }
+
     pub async fn start_service(
-        &self,
+        self: Arc<Self>,
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
@@ -190,8 +215,37 @@ impl KubernetesProvider {
             ns_list.items.len()
         );
 
-        self.watch_services(client, storage, reload_tx, acme_notify)
-            .await
+        let svc_provider = Arc::clone(&self);
+        let svc_storage = Arc::clone(&storage);
+        let svc_reload = reload_tx.clone();
+        let svc_acme = Arc::clone(&acme_notify);
+        let svc_client = client.clone();
+        let svc_handle = tokio::spawn(async move {
+            if let Err(e) = svc_provider
+                .watch_services(svc_client, svc_storage, svc_reload, svc_acme)
+                .await
+            {
+                error!("Kubernetes Service watcher failed: {}", e);
+            }
+        });
+
+        let ep_provider = Arc::clone(&self);
+        let ep_storage = Arc::clone(&storage);
+        let ep_reload = reload_tx.clone();
+        let ep_acme = Arc::clone(&acme_notify);
+        let ep_client = client.clone();
+        let ep_handle = tokio::spawn(async move {
+            if let Err(e) = ep_provider
+                .watch_endpoint_slices(ep_client, ep_storage, ep_reload, ep_acme)
+                .await
+            {
+                error!("Kubernetes EndpointSlice watcher failed: {}", e);
+            }
+        });
+
+        let _ = tokio::try_join!(svc_handle, ep_handle);
+        warn!("Kubernetes watchers stopped");
+        Ok(())
     }
 
     async fn watch_services(
@@ -233,6 +287,150 @@ impl KubernetesProvider {
         Ok(())
     }
 
+    async fn watch_endpoint_slices(
+        &self,
+        client: Client,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+    ) -> anyhow::Result<()> {
+        let slices: Api<EndpointSlice> = self.scoped_api(&client);
+        let stream = watcher::watcher(slices, watcher::Config::default());
+        tokio::pin!(stream);
+
+        info!("Kubernetes EndpointSlice watcher started");
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(Event::Apply(slice)) | Ok(Event::InitApply(slice)) => {
+                    if let Some(svc_id) = self.apply_slice(&slice) {
+                        self.refresh_service(&client, &svc_id, &storage, &reload_tx, &acme_notify)
+                            .await;
+                    }
+                }
+                Ok(Event::Delete(slice)) => {
+                    if let Some(svc_id) = self.remove_slice(&slice) {
+                        self.refresh_service(&client, &svc_id, &storage, &reload_tx, &acme_notify)
+                            .await;
+                    }
+                }
+                Ok(Event::Init) | Ok(Event::InitDone) => {}
+                Err(e) => {
+                    error!("EndpointSlice watcher error: {}", e);
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+            }
+        }
+
+        warn!("Kubernetes EndpointSlice watcher stopped");
+        Ok(())
+    }
+
+    /// Update the endpoints cache from a slice. Returns `Some(namespace/service)`
+    /// when the slice belongs to a service we can resolve, `None` otherwise.
+    fn apply_slice(&self, slice: &EndpointSlice) -> Option<String> {
+        let namespace = slice.metadata.namespace.as_deref()?;
+        let service_name = slice
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(SERVICE_NAME_LABEL))?;
+
+        let svc_id = format!("{namespace}/{service_name}");
+
+        let ips: Vec<String> = slice
+            .endpoints
+            .iter()
+            .filter(|ep| ep.conditions.as_ref().and_then(|c| c.ready).unwrap_or(true))
+            .flat_map(|ep| ep.addresses.iter().cloned())
+            .filter(|ip| !ip.is_empty())
+            .collect();
+
+        let mut cache = match self.endpoints.write() {
+            Ok(guard) => guard,
+            Err(e) => {
+                error!("Endpoints cache poisoned: {}", e);
+                return None;
+            }
+        };
+
+        // Aggregate across multiple slices for the same service: rebuild the
+        // bucket for this slice but merge with other slices we've seen.
+        let slice_key = slice.metadata.name.as_deref().unwrap_or("");
+        let bucket = cache.entry(svc_id.clone()).or_default();
+        // Strategy: store unique IPs across all slices. Slice deletes will
+        // rebuild from a full re-list, so a per-slice diff is not needed here.
+        for ip in ips {
+            if !bucket.contains(&ip) {
+                bucket.push(ip);
+            }
+        }
+
+        debug!(
+            "EndpointSlice {} applied: {} ready endpoint(s) for {}",
+            slice_key,
+            bucket.len(),
+            svc_id
+        );
+
+        Some(svc_id)
+    }
+
+    /// Drop a slice's contribution from the cache. Because we don't track
+    /// per-slice IPs, we simply clear the service's bucket — the surviving
+    /// slices will repopulate it on their next Apply (kube re-emits Apply for
+    /// every slice the service still owns when one is deleted).
+    fn remove_slice(&self, slice: &EndpointSlice) -> Option<String> {
+        let namespace = slice.metadata.namespace.as_deref()?;
+        let service_name = slice
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(SERVICE_NAME_LABEL))?;
+
+        let svc_id = format!("{namespace}/{service_name}");
+
+        if let Ok(mut cache) = self.endpoints.write() {
+            cache.remove(&svc_id);
+        }
+
+        Some(svc_id)
+    }
+
+    /// Re-fetch a Service and re-run the upsert path so its entrypoint picks
+    /// up the freshest backend list from the endpoints cache.
+    async fn refresh_service(
+        &self,
+        client: &Client,
+        svc_id: &str,
+        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: &mpsc::Sender<()>,
+        acme_notify: &Arc<Notify>,
+    ) {
+        let Some((namespace, name)) = svc_id.split_once('/') else {
+            return;
+        };
+        let api: Api<Service> = Api::namespaced(client.clone(), namespace);
+        match api.get(name).await {
+            Ok(svc) => {
+                self.upsert_service(&svc, storage, reload_tx, acme_notify)
+                    .await;
+            }
+            Err(kube::Error::Api(err)) if err.code == 404 => {
+                debug!(
+                    "Service {} not found during endpoint refresh (likely deleted)",
+                    svc_id
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to refresh service {} after endpoint change: {}",
+                    svc_id, e
+                );
+            }
+        }
+    }
+
     async fn upsert_service(
         &self,
         svc: &Service,
@@ -251,6 +449,11 @@ impl KubernetesProvider {
             return;
         }
 
+        // Replace the parser's single-IP backend list with every ready pod IP
+        // known for this service. When the cache is empty we keep the parser's
+        // backend (clusterIP fallback or 127.0.0.1).
+        let pod_ips = self.pod_ips_for(&candidate.id);
+
         let mut storage_changed = false;
         {
             let mut storage_write = match storage.write() {
@@ -263,12 +466,22 @@ impl KubernetesProvider {
 
             for (key, mut entrypoint) in result.entrypoints {
                 entrypoint.source = Some(self.name.to_string());
-                info!(
-                    "Kubernetes upsert {} from service {}",
-                    key, candidate.display_name
-                );
-                storage_write.insert(key, entrypoint);
-                storage_changed = true;
+                if !pod_ips.is_empty() {
+                    entrypoint.backends = pod_ips.clone();
+                }
+                let backends = entrypoint.backends.len();
+                let existing_changed = match storage_write.get(&key) {
+                    Some(existing) => existing != &entrypoint,
+                    None => true,
+                };
+                if existing_changed {
+                    info!(
+                        "Kubernetes upsert {} from service {} ({} backend(s))",
+                        key, candidate.display_name, backends
+                    );
+                    storage_write.insert(key, entrypoint);
+                    storage_changed = true;
+                }
             }
         }
 
@@ -332,6 +545,7 @@ impl KubernetesProvider {
 mod tests {
     use super::*;
     use k8s_openapi::api::core::v1::ServiceSpec;
+    use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
     use kube::api::ObjectMeta;
     use std::collections::BTreeMap;
 
@@ -345,6 +559,7 @@ mod tests {
                 expose_by_default,
             },
             name: PROVIDER_NAME,
+            endpoints: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -370,6 +585,37 @@ mod tests {
                 ..Default::default()
             }),
             status: None,
+        }
+    }
+
+    fn make_slice(
+        slice_name: &str,
+        namespace: &str,
+        service_name: &str,
+        endpoints: Vec<(Vec<&str>, Option<bool>)>,
+    ) -> EndpointSlice {
+        let mut labels = BTreeMap::new();
+        labels.insert(SERVICE_NAME_LABEL.to_string(), service_name.to_string());
+        EndpointSlice {
+            address_type: "IPv4".to_string(),
+            metadata: ObjectMeta {
+                name: Some(slice_name.to_string()),
+                namespace: Some(namespace.to_string()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            endpoints: endpoints
+                .into_iter()
+                .map(|(addrs, ready)| Endpoint {
+                    addresses: addrs.into_iter().map(|s| s.to_string()).collect(),
+                    conditions: ready.map(|r| EndpointConditions {
+                        ready: Some(r),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .collect(),
+            ports: None,
         }
     }
 
@@ -412,6 +658,109 @@ mod tests {
         let svc = make_service("headless", "default", &[], Some("None"));
         let candidate = provider.service_to_candidate(&svc).expect("candidate");
         assert!(candidate.networks.is_empty());
+    }
+
+    #[test]
+    fn endpoint_slice_populates_pod_ips() {
+        let provider = make_provider(true);
+        let slice = make_slice(
+            "api-abc",
+            "default",
+            "api",
+            vec![
+                (vec!["10.244.0.5"], Some(true)),
+                (vec!["10.244.0.6"], Some(true)),
+            ],
+        );
+        assert_eq!(provider.apply_slice(&slice).as_deref(), Some("default/api"));
+        assert_eq!(
+            provider.pod_ips_for("default/api"),
+            vec!["10.244.0.5".to_string(), "10.244.0.6".to_string()]
+        );
+    }
+
+    #[test]
+    fn not_ready_endpoints_are_excluded() {
+        let provider = make_provider(true);
+        let slice = make_slice(
+            "api-abc",
+            "default",
+            "api",
+            vec![
+                (vec!["10.244.0.5"], Some(true)),
+                (vec!["10.244.0.6"], Some(false)),
+            ],
+        );
+        provider.apply_slice(&slice);
+        assert_eq!(
+            provider.pod_ips_for("default/api"),
+            vec!["10.244.0.5".to_string()]
+        );
+    }
+
+    #[test]
+    fn candidate_uses_first_pod_ip_as_representative() {
+        let provider = make_provider(true);
+        let slice = make_slice(
+            "api-abc",
+            "default",
+            "api",
+            vec![
+                (vec!["10.244.0.5"], Some(true)),
+                (vec!["10.244.0.6"], Some(true)),
+            ],
+        );
+        provider.apply_slice(&slice);
+        let svc = make_service(
+            "api",
+            "default",
+            &[("sozune.enable", "true")],
+            Some("10.0.0.1"),
+        );
+        let candidate = provider.service_to_candidate(&svc).expect("candidate");
+        assert_eq!(candidate.networks.len(), 1);
+        assert_eq!(candidate.networks[0].ip.as_deref(), Some("10.244.0.5"));
+    }
+
+    #[test]
+    fn endpoints_fall_back_to_cluster_ip_when_cache_empty() {
+        let provider = make_provider(true);
+        let svc = make_service(
+            "api",
+            "default",
+            &[("sozune.enable", "true")],
+            Some("10.0.0.1"),
+        );
+        let candidate = provider.service_to_candidate(&svc).expect("candidate");
+        assert_eq!(candidate.networks.len(), 1);
+        assert_eq!(candidate.networks[0].ip.as_deref(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn remove_slice_clears_service_bucket() {
+        let provider = make_provider(true);
+        let slice = make_slice(
+            "api-abc",
+            "default",
+            "api",
+            vec![(vec!["10.244.0.5"], Some(true))],
+        );
+        provider.apply_slice(&slice);
+        assert!(
+            provider
+                .endpoints
+                .read()
+                .unwrap()
+                .contains_key("default/api")
+        );
+        provider.remove_slice(&slice);
+        assert!(
+            !provider
+                .endpoints
+                .read()
+                .unwrap()
+                .contains_key("default/api")
+        );
     }
 }
 

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -22,9 +22,11 @@ use tracing::{debug, error, info, warn};
 const PROVIDER_NAME: &str = "kubernetes";
 const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 
-/// Maps `namespace/service` → list of ready pod IPs, populated from
-/// EndpointSlice watch events. Used to resolve backends for Services.
-type EndpointsCache = Arc<RwLock<HashMap<String, Vec<String>>>>;
+/// Maps `namespace/service` → (slice name → ready pod IPs from that slice).
+/// We track per-slice attribution so an Apply that shrinks a slice (e.g.
+/// scale-down) correctly drops the IPs that left, instead of accumulating
+/// stale endpoints across events.
+type EndpointsCache = Arc<RwLock<HashMap<String, HashMap<String, Vec<String>>>>>;
 
 pub struct KubernetesProvider {
     config: KubernetesConfig,
@@ -168,13 +170,27 @@ impl KubernetesProvider {
         })
     }
 
-    /// Read all ready pod IPs known for a `namespace/service` from the cache.
+    /// Read all ready pod IPs known for a `namespace/service`, flattened
+    /// across every EndpointSlice attached to that service. IPs are
+    /// deduplicated to avoid double-listing if two slices overlap (rare but
+    /// permitted by the API).
     fn pod_ips_for(&self, svc_id: &str) -> Vec<String> {
-        self.endpoints
-            .read()
-            .ok()
-            .and_then(|cache| cache.get(svc_id).cloned())
-            .unwrap_or_default()
+        let Ok(cache) = self.endpoints.read() else {
+            return Vec::new();
+        };
+        let Some(slices) = cache.get(svc_id) else {
+            return Vec::new();
+        };
+        let mut out: Vec<String> = Vec::new();
+        for ips in slices.values() {
+            for ip in ips {
+                if !out.contains(ip) {
+                    out.push(ip.clone());
+                }
+            }
+        }
+        out.sort();
+        out
     }
 
     pub async fn start_service(
@@ -346,6 +362,8 @@ impl KubernetesProvider {
             .filter(|ip| !ip.is_empty())
             .collect();
 
+        let slice_name = slice.metadata.name.as_deref()?.to_string();
+
         let mut cache = match self.endpoints.write() {
             Ok(guard) => guard,
             Err(e) => {
@@ -354,32 +372,39 @@ impl KubernetesProvider {
             }
         };
 
-        // Aggregate across multiple slices for the same service: rebuild the
-        // bucket for this slice but merge with other slices we've seen.
-        let slice_key = slice.metadata.name.as_deref().unwrap_or("");
-        let bucket = cache.entry(svc_id.clone()).or_default();
-        // Strategy: store unique IPs across all slices. Slice deletes will
-        // rebuild from a full re-list, so a per-slice diff is not needed here.
-        for ip in ips {
-            if !bucket.contains(&ip) {
-                bucket.push(ip);
-            }
-        }
+        let slices = cache.entry(svc_id.clone()).or_default();
+        let total_after = if ips.is_empty() {
+            slices.remove(&slice_name);
+            slices.values().map(|v| v.len()).sum::<usize>()
+        } else {
+            let count = ips.len();
+            slices.insert(slice_name.clone(), ips);
+            count
+                + slices
+                    .iter()
+                    .filter_map(|(k, v)| {
+                        if k != &slice_name {
+                            Some(v.len())
+                        } else {
+                            None
+                        }
+                    })
+                    .sum::<usize>()
+        };
 
         debug!(
-            "EndpointSlice {} applied: {} ready endpoint(s) for {}",
-            slice_key,
-            bucket.len(),
-            svc_id
+            "EndpointSlice {} applied: {} ready endpoint(s) for {} (total across slices: {})",
+            slice_name,
+            slices.get(&slice_name).map(|v| v.len()).unwrap_or(0),
+            svc_id,
+            total_after
         );
 
         Some(svc_id)
     }
 
-    /// Drop a slice's contribution from the cache. Because we don't track
-    /// per-slice IPs, we simply clear the service's bucket — the surviving
-    /// slices will repopulate it on their next Apply (kube re-emits Apply for
-    /// every slice the service still owns when one is deleted).
+    /// Drop a slice's contribution from the cache. Surviving slices for the
+    /// same service stay intact — their attribution is keyed by slice name.
     fn remove_slice(&self, slice: &EndpointSlice) -> Option<String> {
         let namespace = slice.metadata.namespace.as_deref()?;
         let service_name = slice
@@ -387,11 +412,17 @@ impl KubernetesProvider {
             .labels
             .as_ref()
             .and_then(|l| l.get(SERVICE_NAME_LABEL))?;
+        let slice_name = slice.metadata.name.as_deref()?;
 
         let svc_id = format!("{namespace}/{service_name}");
 
-        if let Ok(mut cache) = self.endpoints.write() {
-            cache.remove(&svc_id);
+        if let Ok(mut cache) = self.endpoints.write()
+            && let Some(slices) = cache.get_mut(&svc_id)
+        {
+            slices.remove(slice_name);
+            if slices.is_empty() {
+                cache.remove(&svc_id);
+            }
         }
 
         Some(svc_id)
@@ -760,6 +791,64 @@ mod tests {
                 .read()
                 .unwrap()
                 .contains_key("default/api")
+        );
+    }
+
+    #[test]
+    fn shrinking_slice_drops_stale_ips() {
+        let provider = make_provider(true);
+        let initial = make_slice(
+            "api-abc",
+            "default",
+            "api",
+            vec![
+                (vec!["10.244.0.5"], Some(true)),
+                (vec!["10.244.0.6"], Some(true)),
+                (vec!["10.244.0.7"], Some(true)),
+            ],
+        );
+        provider.apply_slice(&initial);
+        assert_eq!(provider.pod_ips_for("default/api").len(), 3);
+
+        let shrunk = make_slice(
+            "api-abc",
+            "default",
+            "api",
+            vec![(vec!["10.244.0.5"], Some(true))],
+        );
+        provider.apply_slice(&shrunk);
+        assert_eq!(
+            provider.pod_ips_for("default/api"),
+            vec!["10.244.0.5".to_string()]
+        );
+    }
+
+    #[test]
+    fn multiple_slices_for_same_service_are_merged() {
+        let provider = make_provider(true);
+        let slice_a = make_slice(
+            "api-aaa",
+            "default",
+            "api",
+            vec![(vec!["10.244.0.5"], Some(true))],
+        );
+        let slice_b = make_slice(
+            "api-bbb",
+            "default",
+            "api",
+            vec![(vec!["10.244.0.6"], Some(true))],
+        );
+        provider.apply_slice(&slice_a);
+        provider.apply_slice(&slice_b);
+        assert_eq!(
+            provider.pod_ips_for("default/api"),
+            vec!["10.244.0.5".to_string(), "10.244.0.6".to_string()]
+        );
+
+        provider.remove_slice(&slice_a);
+        assert_eq!(
+            provider.pod_ips_for("default/api"),
+            vec!["10.244.0.6".to_string()]
         );
     }
 }


### PR DESCRIPTION
## Summary
- Second watcher on `EndpointSlice` maintains a per-service cache of ready pod IPs.
- Service entrypoints get **all** ready pod IPs as backends, so Sōzu round-robins directly between pods (bypassing kube-proxy) and inherits its L7 features (sticky sessions, weighted backends, per-pod health).
- Per-slice attribution prevents stale IPs from accumulating when a slice shrinks (e.g. scale-down 5→1).
- Falls back to `Service.spec.clusterIP` when the cache is cold or for selector-less services.

## Test plan
- [x] cargo test --bin sozune (all tests passing — 9 new on endpoints)
- [x] kubectl scale --replicas=5 → 5 backends visible within seconds
- [x] kubectl scale --replicas=1 → exactly 1 backend (no leak from prior scale-up)
- [x] Multi-slice service merges correctly across slices

