### PR TITLE
Move port and weight onto Backend (breaking)

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -78,7 +78,6 @@ export type Protocol = 'Http' | 'Tcp' | 'Udp';
 
 export interface EntrypointConfig {
   hostnames: string[];
-  port: number;
   tls: boolean;
   strip_prefix: boolean;
   https_redirect?: boolean;
@@ -90,14 +89,24 @@ export interface EntrypointConfig {
   [key: string]: unknown;
 }
 
+export interface Backend {
+  address: string;
+  port: number;
+  weight: number;
+}
+
+/** Backend identifier as serialized in `unhealthy_backends`: `address:port`. */
+export function backendKey(b: Backend): string {
+  return `${b.address}:${b.port}`;
+}
+
 export interface Entrypoint {
   id: string;
   name: string;
   protocol: Protocol;
-  backends: string[];
+  backends: Backend[];
   config: EntrypointConfig;
   source?: string | null;
-  backend_weights?: Record<string, number>;
   /** Backend addresses (`host:port`) currently marked down by the health checker. */
   unhealthy_backends?: string[];
 }

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
-  import { listEntrypoints, type Entrypoint } from '$lib/api';
+  import { listEntrypoints, backendKey, type Backend, type Entrypoint } from '$lib/api';
   import { isAuthenticated } from '$lib/auth';
 
   let entrypoints = $state<Entrypoint[]>([]);
@@ -22,7 +22,7 @@
         ep.name.toLowerCase().includes(q) ||
         ep.id.toLowerCase().includes(q) ||
         ep.config.hostnames.some((h) => h.toLowerCase().includes(q)) ||
-        ep.backends.some((b) => b.toLowerCase().includes(q))
+        ep.backends.some((b) => backendKey(b).toLowerCase().includes(q))
       );
     })
   );
@@ -36,8 +36,8 @@
     tls: entrypoints.filter((e) => e.config.tls).length
   });
 
-  function isBackendDown(ep: Entrypoint, backend: string): boolean {
-    return (ep.unhealthy_backends ?? []).includes(`${backend}:${ep.config.port}`);
+  function isBackendDown(ep: Entrypoint, backend: Backend): boolean {
+    return (ep.unhealthy_backends ?? []).includes(backendKey(backend));
   }
 
   function downCount(ep: Entrypoint): number {

--- a/dashboard/src/routes/entrypoints/[id]/+page.svelte
+++ b/dashboard/src/routes/entrypoints/[id]/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { getEntrypoint, type Entrypoint } from '$lib/api';
+  import { getEntrypoint, backendKey, type Backend, type Entrypoint } from '$lib/api';
   import { isAuthenticated } from '$lib/auth';
 
   let entrypoint = $state<Entrypoint | null>(null);
@@ -13,8 +13,8 @@
 
   const id = $derived($page.params.id ?? '');
 
-  function isBackendDown(ep: Entrypoint, backend: string): boolean {
-    return (ep.unhealthy_backends ?? []).includes(`${backend}:${ep.config.port}`);
+  function isBackendDown(ep: Entrypoint, backend: Backend): boolean {
+    return (ep.unhealthy_backends ?? []).includes(backendKey(backend));
   }
 
   async function load(silent = false) {
@@ -94,8 +94,6 @@
       <dl>
         <dt>Protocol</dt>
         <dd><span class="badge badge-{entrypoint.protocol.toLowerCase()}">{entrypoint.protocol.toUpperCase()}</span></dd>
-        <dt>Port</dt>
-        <dd class="mono">{entrypoint.config.port}</dd>
         <dt>Priority</dt>
         <dd class="mono">{entrypoint.config.priority}</dd>
         <dt>Source</dt>
@@ -169,8 +167,8 @@
         <tbody>
           {#each entrypoint.backends as backend}
             <tr>
-              <td class="mono">{backend}</td>
-              <td class="mono">{entrypoint.backend_weights?.[backend] ?? 1}</td>
+              <td class="mono">{backendKey(backend)}</td>
+              <td class="mono">{backend.weight}</td>
               <td>
                 {#if isBackendDown(entrypoint, backend)}
                   <span class="status-pill down">down</span>

--- a/documentation/configuration/api.md
+++ b/documentation/configuration/api.md
@@ -86,11 +86,12 @@ curl -X POST http://localhost:3035/entrypoints \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-api",
-    "backends": ["10.0.0.5:8080"],
+    "backends": [
+      { "address": "10.0.0.5", "port": 8080, "weight": 100 }
+    ],
     "protocol": "Http",
     "config": {
       "hostnames": ["api.example.com"],
-      "port": 8080,
       "tls": true,
       "https_redirect": true
     }

--- a/documentation/routing/load-balancing.md
+++ b/documentation/routing/load-balancing.md
@@ -35,29 +35,29 @@ The Compose service name (`app-instance-1`, `app-instance-2`) is irrelevant — 
 POST /entrypoints
 {
   "name": "app",
-  "backends": ["10.0.0.5:8080", "10.0.0.6:8080"],
+  "backends": [
+    { "address": "10.0.0.5", "port": 8080, "weight": 100 },
+    { "address": "10.0.0.6", "port": 8080, "weight": 100 }
+  ],
   "protocol": "Http",
-  "config": { "hostnames": ["app.example.com"], "port": 8080, ... }
+  "config": { "hostnames": ["app.example.com"] }
 }
 ```
 
 ## Weighted load balancing
 
-Weights are exposed only through the [REST API](/documentation/configuration/api), via the `backend_weights` map:
+Weights live on each backend via the `weight` field (default `100`). Higher weight = more traffic.
 
 ```json
 {
   "name": "app",
-  "backends": ["10.0.0.5:8080", "10.0.0.6:8080"],
-  "backend_weights": {
-    "10.0.0.5:8080": 80,
-    "10.0.0.6:8080": 20
-  },
+  "backends": [
+    { "address": "10.0.0.5", "port": 8080, "weight": 80 },
+    { "address": "10.0.0.6", "port": 8080, "weight": 20 }
+  ],
   ...
 }
 ```
-
-Backends without an explicit weight default to `100`. Higher weights receive proportionally more traffic.
 
 There is currently no Docker label to set per-backend weights.
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,6 +1,6 @@
 use crate::api::auth::{AuthOutcome, Identity, check};
 use crate::config::{ApiConfig, ApiUser, Role};
-use crate::model::{Entrypoint, EntrypointConfig, Protocol};
+use crate::model::{Backend, Entrypoint, EntrypointConfig, Protocol};
 use axum::extract::{Path, Request, State};
 use axum::http::StatusCode;
 use axum::http::{HeaderValue, Method, header};
@@ -32,7 +32,7 @@ fn entrypoint_payload(entrypoint: &Entrypoint, unhealthy: &HashSet<String>) -> s
     let unhealthy_for_ep: Vec<String> = entrypoint
         .backends
         .iter()
-        .map(|b| format!("{}:{}", b, entrypoint.config.port))
+        .map(|b| b.to_string())
         .filter(|key| unhealthy.contains(key))
         .collect();
 
@@ -49,10 +49,9 @@ fn entrypoint_payload(entrypoint: &Entrypoint, unhealthy: &HashSet<String>) -> s
 #[derive(Deserialize)]
 pub struct CreateEntrypointRequest {
     pub name: String,
-    pub backends: Vec<String>,
+    pub backends: Vec<Backend>,
     pub protocol: Protocol,
     pub config: EntrypointConfig,
-    pub backend_weights: Option<std::collections::HashMap<String, u32>>,
 }
 
 /// Authenticate the request with HTTP Basic, then attach the resolved
@@ -323,7 +322,6 @@ async fn create_entrypoint(
         protocol: payload.protocol,
         config: payload.config,
         source: Some("api".to_string()),
-        backend_weights: payload.backend_weights.unwrap_or_default(),
     };
 
     {
@@ -391,7 +389,6 @@ async fn update_entrypoint(
             protocol: payload.protocol,
             config: payload.config,
             source: Some("api".to_string()),
-            backend_weights: payload.backend_weights.unwrap_or_default(),
         };
         storage.insert(id.clone(), entrypoint);
     }
@@ -537,11 +534,12 @@ mod tests {
     fn sample_entrypoint_json() -> serde_json::Value {
         serde_json::json!({
             "name": "web",
-            "backends": ["127.0.0.1:3000"],
+            "backends": [
+                { "address": "127.0.0.1", "port": 3000, "weight": 100 }
+            ],
             "protocol": "Http",
             "config": {
                 "hostnames": ["example.com"],
-                "port": 80,
                 "path": null,
                 "tls": false,
                 "strip_prefix": false,
@@ -757,11 +755,10 @@ mod tests {
                 Entrypoint {
                     id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
                     name: "docker-service".to_string(),
-                    backends: vec!["172.17.0.2:8080".to_string()],
+                    backends: vec![Backend::new("172.17.0.2", 8080)],
                     protocol: Protocol::Http,
                     config: EntrypointConfig {
                         hostnames: vec!["docker.local".to_string()],
-                        port: 80,
                         path: None,
                         tls: false,
                         strip_prefix: false,
@@ -781,7 +778,6 @@ mod tests {
                         entrypoint: None,
                     },
                     source: Some("docker".to_string()),
-                    backend_weights: std::collections::HashMap::new(),
                 },
             );
         }

--- a/src/cli/render/tree.rs
+++ b/src/cli/render/tree.rs
@@ -129,11 +129,13 @@ fn format_route(ep: &Entrypoint) -> String {
     };
     let host = ep.config.hostnames.first().cloned().unwrap_or_default();
     let path_str = ep.config.path.as_ref().map(format_path).unwrap_or_default();
-    let backends = ep.backends.join(", ");
-    format!(
-        "{}://{}:{}{}  →  {}",
-        scheme, host, ep.config.port, path_str, backends
-    )
+    let backends = ep
+        .backends
+        .iter()
+        .map(|b| b.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{}://{}{}  →  {}", scheme, host, path_str, backends)
 }
 
 fn format_path(p: &PathConfig) -> String {
@@ -220,8 +222,8 @@ mod tests {
         let out = render(&report, Severity::Warn);
         assert!(out.contains("docker"));
         assert!(out.contains("✓ my-api"));
-        assert!(out.contains("http://example.com:8080"));
-        assert!(out.contains("172.18.0.4"));
+        assert!(out.contains("http://example.com"));
+        assert!(out.contains("172.18.0.4:8080"));
         assert!(out.contains("1 routed · 0 degraded · 0 skipped"));
     }
 

--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -5,7 +5,7 @@ use crate::labels::catalog;
 use crate::labels::diagnostic::{Diagnostic, DiagnosticCode, ParseResult};
 use crate::labels::fields::{auth, core, headers, host, path, ratelimit, redirect};
 use crate::labels::network;
-use crate::model::{Entrypoint, EntrypointConfig, Protocol};
+use crate::model::{Backend, Entrypoint, EntrypointConfig, Protocol};
 
 const SUPPORTED_PROTOCOLS: &[&str] = &["http", "tcp", "udp"];
 
@@ -178,13 +178,11 @@ fn build_entrypoint(
 
     Some(Entrypoint {
         id: format!("{protocol}_{service_name}"),
-        backends: vec![backend_ip.to_string()],
+        backends: vec![Backend::new(backend_ip, port)],
         name: service_name.to_string(),
         protocol: protocol_enum,
-        backend_weights: HashMap::new(),
         config: EntrypointConfig {
             hostnames,
-            port,
             path,
             tls,
             strip_prefix,
@@ -238,13 +236,11 @@ fn build_tcp_entrypoint(
 
     Some(Entrypoint {
         id: format!("tcp_{service_name}"),
-        backends: vec![backend_ip.to_string()],
+        backends: vec![Backend::new(backend_ip, port)],
         name: service_name.to_string(),
         protocol: Protocol::Tcp,
-        backend_weights: HashMap::new(),
         config: EntrypointConfig {
             hostnames: Vec::new(),
-            port,
             path: None,
             tls: false,
             strip_prefix: false,
@@ -359,9 +355,8 @@ mod tests {
         assert_eq!(r.entrypoints.len(), 1);
         assert!(!r.has_errors());
         let ep = r.entrypoints.get("http_web").unwrap();
-        assert_eq!(ep.config.port, 8080);
+        assert_eq!(ep.backends, vec![Backend::new("172.18.0.4", 8080)]);
         assert_eq!(ep.config.hostnames, vec!["example.com"]);
-        assert_eq!(ep.backends, vec!["172.18.0.4"]);
     }
 
     #[test]
@@ -377,7 +372,7 @@ mod tests {
         let r = parse(&c);
         assert_eq!(r.entrypoints.len(), 1);
         assert!(has_code(&r, DiagnosticCode::W001InvalidPort));
-        assert_eq!(r.entrypoints.get("http_web").unwrap().config.port, 80);
+        assert_eq!(r.entrypoints.get("http_web").unwrap().backends[0].port, 80);
     }
 
     #[test]
@@ -424,7 +419,7 @@ mod tests {
         assert!(has_code(&r, DiagnosticCode::W010NoIpFellBackToLocalhost));
         assert_eq!(
             r.entrypoints.get("http_web").unwrap().backends,
-            vec!["127.0.0.1"]
+            vec![Backend::new("127.0.0.1", 80)]
         );
     }
 
@@ -443,11 +438,14 @@ mod tests {
         );
         let r = parse(&c);
         assert_eq!(r.entrypoints.len(), 3);
-        assert_eq!(r.entrypoints.get("http_api").unwrap().config.port, 9000);
+        assert_eq!(
+            r.entrypoints.get("http_api").unwrap().backends[0].port,
+            9000
+        );
         let tcp = r.entrypoints.get("tcp_db").unwrap();
         assert!(matches!(tcp.protocol, Protocol::Tcp));
         assert_eq!(tcp.config.entrypoint.as_deref(), Some("postgres"));
-        assert_eq!(tcp.config.port, 5432);
+        assert_eq!(tcp.backends[0].port, 5432);
     }
 
     #[test]
@@ -476,8 +474,7 @@ mod tests {
         let ep = r.entrypoints.get("tcp_echo").unwrap();
         assert!(matches!(ep.protocol, Protocol::Tcp));
         assert_eq!(ep.config.entrypoint.as_deref(), Some("tcpecho"));
-        assert_eq!(ep.config.port, 9000);
-        assert_eq!(ep.backends, vec!["172.18.0.4"]);
+        assert_eq!(ep.backends, vec![Backend::new("172.18.0.4", 9000)]);
         assert!(ep.config.hostnames.is_empty());
     }
 
@@ -494,7 +491,7 @@ mod tests {
         let r = parse(&c);
         assert_eq!(
             r.entrypoints.get("http_web").unwrap().backends,
-            vec!["10.0.0.5"]
+            vec![Backend::new("10.0.0.5", 80)]
         );
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -11,7 +11,7 @@ use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
 use tracing::info;
 
-use crate::model::EntrypointConfig;
+use crate::model::{Backend, EntrypointConfig};
 use rate_limit::RateLimiter;
 
 /// Shared state for the middleware server
@@ -86,7 +86,7 @@ pub fn needs_middleware(config: &EntrypointConfig) -> bool {
 /// Build middleware route from entrypoint config
 pub fn build_middleware_route(
     config: &EntrypointConfig,
-    backends: &[String],
+    backends: &[Backend],
 ) -> Arc<MiddlewareRoute> {
     let rate_limiter = config
         .rate_limit
@@ -94,7 +94,10 @@ pub fn build_middleware_route(
         .map(|rl| RateLimiter::new(rl.average, rl.burst));
 
     Arc::new(MiddlewareRoute {
-        backends: backends.iter().map(|b| (b.clone(), config.port)).collect(),
+        backends: backends
+            .iter()
+            .map(|b| (b.address.clone(), b.port))
+            .collect(),
         backend_counter: AtomicUsize::new(0),
         backend_timeout: config.backend_timeout,
         rate_limiter,

--- a/src/model/entrypoint.rs
+++ b/src/model/entrypoint.rs
@@ -1,17 +1,49 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct Entrypoint {
     pub id: String,
-    pub backends: Vec<String>,
+    pub backends: Vec<Backend>,
     pub name: String,
     pub protocol: Protocol,
     pub config: EntrypointConfig,
     #[serde(default)]
     pub source: Option<String>,
-    #[serde(default)]
-    pub backend_weights: HashMap<String, u32>,
+}
+
+/// One backend instance: an address (IP or hostname), the port it listens
+/// on, and an optional load-balancing weight (defaults to 100).
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Backend {
+    pub address: String,
+    pub port: u16,
+    #[serde(default = "default_weight")]
+    pub weight: u32,
+}
+
+fn default_weight() -> u32 {
+    100
+}
+
+impl Backend {
+    pub fn new(address: impl Into<String>, port: u16) -> Self {
+        Self {
+            address: address.into(),
+            port,
+            weight: default_weight(),
+        }
+    }
+
+    pub fn with_weight(mut self, weight: u32) -> Self {
+        self.weight = weight;
+        self
+    }
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.address, self.port)
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -24,7 +56,6 @@ pub enum Protocol {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct EntrypointConfig {
     pub hostnames: Vec<String>,
-    pub port: u16,
     pub path: Option<PathConfig>,
     pub tls: bool,
     pub strip_prefix: bool,

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -281,7 +281,7 @@ impl DockerProvider {
                                 let mut keys_to_remove = Vec::new();
                                 for (key, entrypoint) in storage_write.iter_mut() {
                                     // Remove this container's IP from backends
-                                    entrypoint.backends.retain(|ip| ip != &container_ip);
+                                    entrypoint.backends.retain(|b| b.address != container_ip);
 
                                     // If no backends left, mark for removal
                                     if entrypoint.backends.is_empty() {
@@ -319,7 +319,7 @@ impl DockerProvider {
                                     // Remove old entries for this container
                                     let mut keys_to_remove = Vec::new();
                                     for (key, entrypoint) in storage_write.iter_mut() {
-                                        entrypoint.backends.retain(|ip| ip != &container_ip);
+                                        entrypoint.backends.retain(|b| b.address != container_ip);
                                         if entrypoint.backends.is_empty() {
                                             keys_to_remove.push(key.clone());
                                         }
@@ -420,21 +420,20 @@ impl DockerProvider {
             // entrypoint produced by a single candidate carries the same
             // backend list, so peek at the first.
             if let Some(first) = result.entrypoints.values().next()
-                && let Some(ip) = first.backends.first()
+                && let Some(backend) = first.backends.first()
                 && let Ok(mut ips) = self.container_ips.lock()
             {
-                ips.insert(container_id.clone(), ip.clone());
+                ips.insert(container_id.clone(), backend.address.clone());
             }
 
             for (key, entrypoint) in result.entrypoints {
-                let backend_ip = entrypoint.backends.first().cloned().unwrap_or_default();
+                let Some(backend) = entrypoint.backends.first().cloned() else {
+                    continue;
+                };
                 if let Some(existing) = entrypoints.get_mut(&key) {
-                    if !existing.backends.contains(&backend_ip) {
-                        existing.backends.push(backend_ip.clone());
-                        info!(
-                            "Added backend {} to existing entrypoint {}",
-                            backend_ip, key
-                        );
+                    if !existing.backends.contains(&backend) {
+                        info!("Added backend {} to existing entrypoint {}", backend, key);
+                        existing.backends.push(backend);
                     }
                 } else {
                     entrypoints.insert(key.clone(), entrypoint);

--- a/src/provider/http.rs
+++ b/src/provider/http.rs
@@ -76,7 +76,6 @@ impl HttpProvider {
                                 storage_read.get(id).is_none_or(|existing| {
                                     existing.backends != ep.backends
                                         || existing.config.hostnames != ep.config.hostnames
-                                        || existing.config.port != ep.config.port
                                 })
                             })
                     };
@@ -117,19 +116,17 @@ impl HttpProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{EntrypointConfig, Protocol};
+    use crate::model::{Backend, EntrypointConfig, Protocol};
     use axum::{Router, routing::get};
-    use std::collections::HashMap;
 
     fn sample_entrypoints_json() -> String {
         serde_json::to_string(&vec![Entrypoint {
             id: "web".to_string(),
             name: "web".to_string(),
-            backends: vec!["127.0.0.1:3000".to_string()],
+            backends: vec![Backend::new("127.0.0.1", 3000)],
             protocol: Protocol::Http,
             config: EntrypointConfig {
                 hostnames: vec!["example.com".to_string()],
-                port: 80,
                 path: None,
                 tls: false,
                 strip_prefix: false,
@@ -149,7 +146,6 @@ mod tests {
                 entrypoint: None,
             },
             source: None,
-            backend_weights: HashMap::new(),
         }])
         .unwrap()
     }

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -3,7 +3,7 @@ use crate::labels::candidate::{Candidate, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
 use crate::labels::source::LabelSource;
 use crate::labels::{self};
-use crate::model::Entrypoint;
+use crate::model::{Backend, Entrypoint};
 use crate::provider::Provider;
 use anyhow::Context;
 use async_trait::async_trait;
@@ -497,8 +497,19 @@ impl KubernetesProvider {
 
             for (key, mut entrypoint) in result.entrypoints {
                 entrypoint.source = Some(self.name.to_string());
+                // Replace the parser's single-pod placeholder with one
+                // Backend per ready pod IP, all targeting the same port the
+                // parser resolved from the labels.
                 if !pod_ips.is_empty() {
-                    entrypoint.backends = pod_ips.clone();
+                    let port = entrypoint
+                        .backends
+                        .first()
+                        .map(|b| b.port)
+                        .unwrap_or_default();
+                    entrypoint.backends = pod_ips
+                        .iter()
+                        .map(|ip| Backend::new(ip.clone(), port))
+                        .collect();
                 }
                 let backends = entrypoint.backends.len();
                 let existing_changed = match storage_write.get(&key) {

--- a/src/provider/nomad.rs
+++ b/src/provider/nomad.rs
@@ -31,10 +31,12 @@ impl Provider for NomadProvider {
             let result = labels::parse(&candidate);
             log_diagnostics(&candidate, &result.diagnostics);
             for (key, mut entrypoint) in result.entrypoints {
-                let backend_ip = entrypoint.backends.first().cloned().unwrap_or_default();
+                let Some(backend) = entrypoint.backends.first().cloned() else {
+                    continue;
+                };
                 if let Some(existing) = entrypoints.get_mut(&key) {
-                    if !existing.backends.contains(&backend_ip) {
-                        existing.backends.push(backend_ip);
+                    if !existing.backends.contains(&backend) {
+                        existing.backends.push(backend);
                     }
                 } else {
                     entrypoint.source = Some(PROVIDER_NAME.to_string());

--- a/src/provider/swarm.rs
+++ b/src/provider/swarm.rs
@@ -241,7 +241,6 @@ impl SwarmProvider {
                     storage_read.get(id).is_none_or(|existing| {
                         existing.backends != ep.backends
                             || existing.config.hostnames != ep.config.hostnames
-                            || existing.config.port != ep.config.port
                     })
                 })
         };
@@ -372,7 +371,6 @@ impl SwarmProvider {
                         storage_read.get(id).is_none_or(|existing| {
                             existing.backends != ep.backends
                                 || existing.config.hostnames != ep.config.hostnames
-                                || existing.config.port != ep.config.port
                         })
                     })
             };
@@ -417,10 +415,12 @@ impl Provider for SwarmProvider {
             log_diagnostics(&candidate, &result.diagnostics);
 
             for (key, entrypoint) in result.entrypoints {
-                let backend_ip = entrypoint.backends.first().cloned().unwrap_or_default();
+                let Some(backend) = entrypoint.backends.first().cloned() else {
+                    continue;
+                };
                 if let Some(existing) = entrypoints.get_mut(&key) {
-                    if !backend_ip.is_empty() && !existing.backends.contains(&backend_ip) {
-                        existing.backends.push(backend_ip);
+                    if !existing.backends.contains(&backend) {
+                        existing.backends.push(backend);
                     }
                 } else {
                     entrypoints.insert(key, entrypoint);

--- a/src/proxy/health.rs
+++ b/src/proxy/health.rs
@@ -83,8 +83,8 @@ impl HealthChecker {
         let mut backends = HashMap::new();
         for entrypoint in storage.values() {
             for backend in &entrypoint.backends {
-                let key = format!("{}:{}", backend, entrypoint.config.port);
-                backends.insert(key, format!("{}:{}", backend, entrypoint.config.port));
+                let key = backend.to_string();
+                backends.insert(key.clone(), key);
             }
         }
         backends

--- a/src/proxy/sozu.rs
+++ b/src/proxy/sozu.rs
@@ -1,7 +1,7 @@
 use crate::acme::CertCommand;
 use crate::config::ProxyConfig;
 use crate::middleware::{self, MiddlewareState};
-use crate::model::{Entrypoint, PathConfig, PathRuleType, Protocol};
+use crate::model::{Backend, Entrypoint, PathConfig, PathRuleType, Protocol};
 use sozu_command_lib::{
     channel::Channel,
     config::ListenerBuilder,
@@ -880,15 +880,9 @@ fn configure_http_entrypoint(
             entrypoint.name,
             entrypoint.backends
         );
-        for (backend_index, backend_host) in entrypoint.backends.iter().enumerate() {
-            let backend_port = entrypoint.config.port;
-            let address = parse_backend_address(backend_host, backend_port)?;
-
-            let weight = entrypoint
-                .backend_weights
-                .get(backend_host)
-                .copied()
-                .unwrap_or(100) as i32;
+        for (backend_index, backend_entry) in entrypoint.backends.iter().enumerate() {
+            let address = parse_backend_address(backend_entry)?;
+            let weight = backend_entry.weight as i32;
 
             let backend = AddBackend {
                 cluster_id: cluster_id.to_string(),
@@ -899,10 +893,7 @@ fn configure_http_entrypoint(
                 backup: None,
             };
 
-            debug!(
-                "Adding backend {}: {}:{}",
-                backend.backend_id, backend_host, backend_port
-            );
+            debug!("Adding backend {}: {}", backend.backend_id, backend_entry);
             if let Err(e) = send_to_worker(
                 command_channel,
                 format!("add-backend-http-{}-{}", cluster_id, backend_index),
@@ -917,10 +908,7 @@ fn configure_http_entrypoint(
             // HTTPS backend only if TLS is enabled
             if entrypoint.config.tls {
                 let backend_id = backend.backend_id.clone();
-                info!(
-                    "Adding HTTPS backend {} -> {}:{}",
-                    backend_id, backend_host, backend_port
-                );
+                info!("Adding HTTPS backend {} -> {}", backend_id, backend_entry);
                 match send_to_worker(
                     command_channel_https,
                     format!("add-backend-https-{}-{}", cluster_id, backend_index),
@@ -1013,22 +1001,18 @@ fn configure_tcp_entrypoint(
         );
     }
 
-    for (idx, backend_host) in entrypoint.backends.iter().enumerate() {
-        let address = match parse_backend_address(backend_host, entrypoint.config.port) {
+    for (idx, backend_entry) in entrypoint.backends.iter().enumerate() {
+        let address = match parse_backend_address(backend_entry) {
             Ok(addr) => addr,
             Err(e) => {
                 error!(
-                    "Invalid TCP backend address {}:{} for {}: {}",
-                    backend_host, entrypoint.config.port, cluster_id, e
+                    "Invalid TCP backend address {} for {}: {}",
+                    backend_entry, cluster_id, e
                 );
                 continue;
             }
         };
-        let weight = entrypoint
-            .backend_weights
-            .get(backend_host)
-            .copied()
-            .unwrap_or(100) as i32;
+        let weight = backend_entry.weight as i32;
         let backend = AddBackend {
             cluster_id: cluster_id.to_string(),
             backend_id: format!("{}-backend-{}", cluster_id, idx),
@@ -1266,13 +1250,13 @@ fn remove_backends(
     cluster_id: &str,
     entrypoint: &Entrypoint,
 ) {
-    for (i, backend_host) in entrypoint.backends.iter().enumerate() {
-        let address = match parse_backend_address(backend_host, entrypoint.config.port) {
+    for (i, backend_entry) in entrypoint.backends.iter().enumerate() {
+        let address = match parse_backend_address(backend_entry) {
             Ok(addr) => addr,
             Err(e) => {
                 debug!(
-                    "Failed to parse backend address {}:{} for removal: {}",
-                    backend_host, entrypoint.config.port, e
+                    "Failed to parse backend address {} for removal: {}",
+                    backend_entry, e
                 );
                 continue;
             }
@@ -1441,8 +1425,8 @@ fn remove_tcp_entrypoint(
     let listener_port = listener.port;
     let channel = &mut listener.channel;
 
-    for (idx, backend_host) in entrypoint.backends.iter().enumerate() {
-        let address = match parse_backend_address(backend_host, entrypoint.config.port) {
+    for (idx, backend_entry) in entrypoint.backends.iter().enumerate() {
+        let address = match parse_backend_address(backend_entry) {
             Ok(addr) => addr,
             Err(_) => continue,
         };
@@ -1482,8 +1466,8 @@ fn remove_tcp_entrypoint(
     }
 }
 
-fn parse_backend_address(host: &str, port: u16) -> anyhow::Result<SocketAddress> {
-    let addr: std::net::SocketAddr = format!("{}:{}", host, port).parse()?;
+fn parse_backend_address(backend: &Backend) -> anyhow::Result<SocketAddress> {
+    let addr: std::net::SocketAddr = format!("{}:{}", backend.address, backend.port).parse()?;
 
     match addr {
         std::net::SocketAddr::V4(addr_v4) => {
@@ -1508,20 +1492,19 @@ mod tests {
 
     #[test]
     fn test_parse_backend_address_ipv4() {
-        let result = parse_backend_address("192.168.1.100", 8080);
+        let result = parse_backend_address(&Backend::new("192.168.1.100", 8080));
         assert!(result.is_ok(), "Failed to parse IPv4 address: {:?}", result);
-        // No need to test exact format, just that it parses
     }
 
     #[test]
     fn test_parse_backend_address_localhost() {
-        let result = parse_backend_address("127.0.0.1", 3000);
+        let result = parse_backend_address(&Backend::new("127.0.0.1", 3000));
         assert!(result.is_ok(), "Failed to parse localhost: {:?}", result);
     }
 
     #[test]
     fn test_parse_backend_address_hostname() {
-        let result = parse_backend_address("localhost", 80);
+        let result = parse_backend_address(&Backend::new("localhost", 80));
         // Localhost may not resolve in all test environments
         // Just verify we get a consistent result
         match result {
@@ -1537,13 +1520,14 @@ mod tests {
 
     #[test]
     fn test_parse_backend_address_invalid() {
-        let result = parse_backend_address("invalid-host-name-that-does-not-exist", 80);
+        let result =
+            parse_backend_address(&Backend::new("invalid-host-name-that-does-not-exist", 80));
         assert!(result.is_err());
     }
 
     #[test]
     fn test_parse_backend_address_invalid_port() {
-        let result = parse_backend_address("127.0.0.1", 0);
+        let result = parse_backend_address(&Backend::new("127.0.0.1", 0));
         assert!(result.is_ok()); // Port 0 is technically valid
     }
 }

--- a/tests/e2e/nomad/01-discovery.sh
+++ b/tests/e2e/nomad/01-discovery.sh
@@ -10,20 +10,15 @@ else
     return 0
 fi
 
-log "[01] Round-robin across allocations"
-# In Nomad `-dev` mode every allocation runs on 127.0.0.1 with a different
-# dynamically-assigned port. Sozune's current Entrypoint model carries a
-# single port per route, so multi-allocation routing on the same host only
-# reaches one backend reliably. Skip the round-robin assertion in dev mode;
-# a multi-host Nomad cluster (each allocation on its own IP) routes correctly.
-distinct=$(count_distinct_hostnames "$HOST_WHOAMI" 12)
-if [[ "$distinct" -ge 1 ]]; then
-    pass "service routed via Sozune ($distinct distinct backend(s) over 12 reqs)"
-    if [[ "$distinct" -lt 3 ]]; then
-        skip "round-robin across 3 allocations not asserted in -dev mode (single-host port-per-alloc limitation)"
-    fi
+log "[01] Round-robin hits all 3 allocations"
+# Each allocation in Nomad `-dev` runs on 127.0.0.1 with its own dynamic port.
+# Now that Sozune carries a port per backend, the three allocations each show
+# up as distinct routing targets even on a single host.
+distinct=$(wait_for_distinct_backends "$HOST_WHOAMI" 3 30 || true)
+if [[ "$distinct" -ge 3 ]]; then
+    pass "round-robin hits $distinct distinct allocations"
 else
-    fail "no successful backend response over 12 requests"
+    fail "expected >=3 distinct allocations after 30s, got $distinct"
 fi
 
 log "[01] Sozune-Id header is present (proves Sōzu, not host network, served the request)"

--- a/tests/e2e/nomad/02-scaling.sh
+++ b/tests/e2e/nomad/02-scaling.sh
@@ -8,22 +8,22 @@ if ! wait_for_deployment_done; then
     return 0
 fi
 
-log "[02] Scale to 5 — Nomad converges, Sozune stays routable"
+log "[02] Scale to 5 — backend list grows"
 nomad job scale -detach "$JOB_NAME" web 5 >/dev/null
 
 if ! wait_for_service_instances 5; then
     fail "Nomad did not converge to 5 service instances in time"
     return 0
 fi
-# Service stays reachable through the whole scale-up. We don't assert
-# distinct backends here (see -dev mode caveat in 01-discovery.sh).
-if wait_for_status "$HOST_WHOAMI" "200"; then
-    pass "after scale to 5, service still routable"
+
+distinct=$(wait_for_distinct_backends "$HOST_WHOAMI" 5 30 || true)
+if [[ "$distinct" -ge 5 ]]; then
+    pass "after scale to 5, $distinct distinct allocations served traffic"
 else
-    fail "service became unroutable during scale-up"
+    fail "expected >=5 backends after scale-up, got $distinct"
 fi
 
-log "[02] Scale to 1 — Sozune sees the smaller pool"
+log "[02] Scale to 1 — backend list shrinks"
 wait_for_deployment_done || true
 nomad job scale -detach "$JOB_NAME" web 1 >/dev/null
 
@@ -31,13 +31,13 @@ if ! wait_for_service_instances 1; then
     fail "Nomad did not converge to 1 service instance in time"
     return 0
 fi
-# Sozune needs a beat after Nomad converges; the blocking-query watcher
-# wakes up on the services-list change but allocations may take a few seconds
-# to actually drain.
+# Sozune's blocking-query watcher wakes up on the services-list change but
+# allocations may take a few seconds to actually drain.
 sleep 5
 
-if wait_for_status "$HOST_WHOAMI" "200"; then
-    pass "after scale to 1, single backend still routable"
+distinct=$(count_distinct_hostnames "$HOST_WHOAMI" 12)
+if [[ "$distinct" -le 1 ]]; then
+    pass "after scale to 1, only $distinct distinct backend(s) served traffic"
 else
-    fail "service unroutable after scale-down"
+    fail "expected <=1 backend after scale-down, got $distinct (stale allocations?)"
 fi


### PR DESCRIPTION
## Summary

**BREAKING change** to the entrypoint shape. Each backend now carries its own port and weight, instead of sharing a single port at the entrypoint level.

### Before

\`\`\`json
{
  \"backends\": [\"10.0.0.5\", \"10.0.0.6\"],
  \"config\": { \"hostnames\": [\"...\"], \"port\": 8080, ... },
  \"backend_weights\": { \"10.0.0.5\": 100, \"10.0.0.6\": 200 }
}
\`\`\`

### After

\`\`\`json
{
  \"backends\": [
    { \"address\": \"10.0.0.5\", \"port\": 8080, \"weight\": 100 },
    { \"address\": \"10.0.0.6\", \"port\": 8080, \"weight\": 200 }
  ],
  \"config\": { \"hostnames\": [\"...\"], ... }
}
\`\`\`

\`config.port\` is gone (it now lives on each backend). \`backend_weights\` is gone (each backend has its own \`weight\` field, default 100).

## Why

On hosts where multiple allocations of the same service share an IP but bind different dynamic ports (Nomad \`-dev\`, multi-port Pods, anything with port mapping), the old shape silently merged them into a single backend through the \`Vec<String>\` dedup. The Nomad e2e suite was forced to skip the round-robin assertion in dev mode for that reason.

## Behaviour change

- All providers (Docker, Podman, Swarm, Kubernetes, Nomad, HTTP, file) produce the new shape.
- Sōzu picks each backend's own port when registering it as a worker backend.
- Health checks probe \`address:port\` per backend, no longer a single per-cluster port.
- The Nomad e2e suite no longer skips round-robin: \`round-robin hits 3 distinct allocations\` against a single dev agent.
- Dashboard updated: backend table shows address + weight per row, the standalone Port row is gone.

## Test plan

- [x] cargo test --bin sozune (177 tests passing)
- [x] cargo fmt --check
- [x] tests/e2e/nomad/run-nomad.sh (6 PASS, 0 FAIL, 0 SKIP — round-robin and scale up/down asserted on a single -dev agent)
- [x] Dashboard rebuilt against the new JSON shape (\`bun run build\`, no type errors).