### PR TITLE
Cover SSE end-to-end with a Mercure-backed e2e suite

### DIFF
--- a/documentation/advanced/sse.md
+++ b/documentation/advanced/sse.md
@@ -1,0 +1,58 @@
+# Server-Sent Events
+
+Sōzune proxies Server-Sent Events (`text/event-stream`) transparently. There is nothing to enable — once you set the right backend timeout, the long-lived stream flows through Sōzu chunk by chunk, in real time.
+
+## The one knob you need
+
+```yaml
+labels:
+  - "sozune.enable=true"
+  - "sozune.http.events.host=events.example.com"
+  - "sozune.http.events.backendTimeout=0"
+```
+
+`backendTimeout=0` is **required** for any SSE endpoint. Without it, Sōzune cuts the connection after the default 30 s and your client reconnects on a loop without ever receiving the next event.
+
+See [Backend timeout](/documentation/middleware/backend-timeout) for the full semantics — `0` means *no timeout*, exactly what an idle SSE stream needs.
+
+## How it works
+
+When the backend responds with `Content-Type: text/event-stream`:
+
+1. Sōzu forwards the response headers immediately.
+2. Each `data: ...\n\n` chunk emitted by the backend is forwarded to the client as it arrives, without waiting for the connection to close.
+3. The connection stays open as long as either side keeps it open.
+
+End-to-end latency through Sōzune for an SSE event is typically **under 100 ms** on a local backend — the e2e test in `tests/e2e/08-sse.sh` asserts this is under one second.
+
+## Compression
+
+Do **not** enable `sozune.http.<svc>.compress=true` on an SSE endpoint. Compression buffers chunks to fill the encoder's window, which defeats real-time delivery. Sōzune does not auto-detect SSE and skip compression for you — the choice is yours, but pick one or the other.
+
+## Mercure example
+
+[Mercure](https://mercure.rocks/) is a popular SSE hub. It works behind Sōzune with the standard config:
+
+```yaml
+services:
+  mercure:
+    image: dunglas/mercure:v0.16
+    environment:
+      SERVER_NAME: ":80"
+      MERCURE_PUBLISHER_JWT_KEY: "your-publisher-secret"
+      MERCURE_SUBSCRIBER_JWT_KEY: "your-subscriber-secret"
+    labels:
+      - "sozune.enable=true"
+      - "sozune.http.mercure.host=mercure.example.com"
+      - "sozune.http.mercure.port=80"
+      - "sozune.http.mercure.tls=true"
+      - "sozune.http.mercure.backendTimeout=0"
+```
+
+This setup is exercised by the e2e suite: a publish through Sōzune to the hub reaches an active subscriber (also connected through Sōzune) in tens of milliseconds.
+
+## Limitations
+
+- **Compression** disabled by hand, as noted above.
+- **HTTP/2 and HTTP/3 SSE** work as long as the client speaks them — Sōzu serves both and forwards chunks. Polling intervals (e.g. browser auto-reconnect on `EventSource` close) are entirely client-side.
+- **No SSE-specific framing.** Sōzune does not inspect `data:` / `event:` / `id:` lines; it only shuffles bytes. Subscriber lifecycle, retry policies and topic filtering are the backend's responsibility.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -54,4 +54,5 @@ Sōzune is a reverse proxy built on [Sōzu](https://github.com/sozu-proxy/sozu).
 
 - [Health checks](/documentation/advanced/health-checks)
 - [WebSocket](/documentation/advanced/websocket)
+- [Server-Sent Events](/documentation/advanced/sse)
 - [Access logs](/documentation/advanced/access-logs)

--- a/tests/e2e/03-api.sh
+++ b/tests/e2e/03-api.sh
@@ -33,7 +33,7 @@ create_response=$(curl -s -w "\n%{http_code}" --max-time 5 \
     -H "$AUTH_HEADER" \
     -H "Content-Type: application/json" \
     -X POST "$API_URL/entrypoints" \
-    -d '{"name":"api-test","backends":["127.0.0.1:9999"],"protocol":"Http","config":{"hostnames":["apitest.localhost"],"port":9999,"path":null,"tls":false,"strip_prefix":false,"https_redirect":false,"priority":0,"auth":null,"headers":[],"backend_timeout":null,"rate_limit":null,"sticky_session":false}}' \
+    -d '{"name":"api-test","backends":[{"address":"127.0.0.1","port":9999,"weight":100}],"protocol":"Http","config":{"hostnames":["apitest.localhost"],"path":null,"tls":false,"strip_prefix":false,"https_redirect":false,"priority":0,"auth":null,"headers":[],"backend_timeout":null,"rate_limit":null,"sticky_session":false}}' \
     2>/dev/null || echo "000")
 create_status=$(echo "$create_response" | tail -1)
 create_body=$(echo "$create_response" | sed '$d')
@@ -58,7 +58,7 @@ if [[ -n "$ep_id" ]]; then
         -H "$AUTH_HEADER" \
         -H "Content-Type: application/json" \
         -X PUT "$API_URL/entrypoints/$ep_id" \
-        -d '{"name":"api-test-updated","backends":["127.0.0.1:9999"],"protocol":"Http","config":{"hostnames":["apitest.localhost"],"port":9999,"path":null,"tls":false,"strip_prefix":false,"https_redirect":false,"priority":0,"auth":null,"headers":[],"backend_timeout":null,"rate_limit":null,"sticky_session":false}}' \
+        -d '{"name":"api-test-updated","backends":[{"address":"127.0.0.1","port":9999,"weight":100}],"protocol":"Http","config":{"hostnames":["apitest.localhost"],"path":null,"tls":false,"strip_prefix":false,"https_redirect":false,"priority":0,"auth":null,"headers":[],"backend_timeout":null,"rate_limit":null,"sticky_session":false}}' \
         2>/dev/null || echo "000")
     if [[ "$update_status" == "200" ]]; then
         pass "API update entrypoint returns 200"

--- a/tests/e2e/08-sse.sh
+++ b/tests/e2e/08-sse.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Server-Sent Events: a long-lived stream propagates events from backend to
+# client through Sozune chunk-by-chunk, not buffered until the connection
+# closes. Uses a Mercure hub (anonymous publish allowed) as the SSE source.
+# Sourced by run-all.sh.
+
+log "[08] SSE: subscriber endpoint reachable"
+
+# Mercure responds with the keepalive comment ":\n" almost immediately on
+# subscribe. We give it a generous 5s and assert the connection completes
+# (curl exit 28 is the expected timeout, exit 0 means EOF — both fine).
+sse_probe=$(curl -s -N --max-time 3 -H "Host: $HOST_SSE" \
+    "http://127.0.0.1:$HTTP_PORT/.well-known/mercure?topic=probe" 2>&1 | head -c 64 || true)
+
+if [[ "$sse_probe" == *":"* ]]; then
+    pass "SSE keepalive received from Mercure through Sozune"
+else
+    fail "no SSE keepalive received (got: '$sse_probe')"
+    return 0
+fi
+
+log "[08] SSE: published event reaches subscriber in real time"
+
+# Subscribe in background, capture wall-clock timestamps for every line.
+sub_out="$(mktemp)"
+trap "rm -f $sub_out" RETURN
+
+(
+    curl -s -N --max-time 8 -H "Host: $HOST_SSE" \
+        "http://127.0.0.1:$HTTP_PORT/.well-known/mercure?topic=e2e-sse-test" 2>/dev/null \
+    | while IFS= read -r line; do
+        printf '%s.%03d %s\n' "$(date +%s)" "$(($(date +%N) / 1000000))" "$line"
+    done
+) > "$sub_out" &
+sub_pid=$!
+
+# Give the subscriber time to connect (first keepalive sets up the stream).
+sleep 1.5
+
+publish_ts=$(($(date +%s) * 1000 + $(date +%N) / 1000000))
+
+# Mercure's `anonymous` directive only allows anonymous SUBSCRIBE; publish
+# always requires a publisher JWT. This token is signed with the same
+# `MERCURE_PUBLISHER_JWT_KEY` configured on the svc-sse container in
+# run-all.sh and grants publish on every topic.
+SSE_PUBLISHER_JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdfX0.a8cjcSRUAcHdnGNMKifA4BK5epRXxQI0UBp2XpNrBdw"
+
+publish_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 \
+    -H "Host: $HOST_SSE" \
+    -H "Authorization: Bearer $SSE_PUBLISHER_JWT" \
+    -d "topic=e2e-sse-test&data=hello-from-sozune-e2e" \
+    "http://127.0.0.1:$HTTP_PORT/.well-known/mercure")
+
+if [[ "$publish_status" != "200" ]]; then
+    fail "publish failed (HTTP $publish_status)"
+    kill "$sub_pid" 2>/dev/null || true
+    wait "$sub_pid" 2>/dev/null || true
+    return 0
+fi
+
+# Wait long enough for the event to flow back, then stop the subscriber.
+sleep 2
+kill "$sub_pid" 2>/dev/null || true
+wait "$sub_pid" 2>/dev/null || true
+
+if grep -q "data: hello-from-sozune-e2e" "$sub_out"; then
+    pass "published event delivered to subscriber through Sozune"
+else
+    fail "subscriber never received the event. Stream contents:"
+    cat "$sub_out"
+    return 0
+fi
+
+# Find the timestamp of the data line and assert it arrived within 1s of
+# publish — proves Sozune doesn't buffer the chunk until connection close.
+data_line=$(grep "data: hello-from-sozune-e2e" "$sub_out" | head -1)
+data_ts_str=$(echo "$data_line" | awk '{print $1}')
+# Convert "1777672623.131" → 1777672623131 (ms)
+data_ts=$(echo "$data_ts_str" | awk -F. '{printf "%d", $1 * 1000 + $2}')
+delta_ms=$((data_ts - publish_ts))
+
+if [[ "$delta_ms" -lt 1000 ]]; then
+    pass "event streamed in real time (${delta_ms} ms after publish)"
+else
+    fail "event delivery was buffered: ${delta_ms} ms after publish (expected < 1000)"
+fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -41,6 +41,7 @@ HOST_MIXED_SUFFIX="mixed-test.localhost"
 HOST_HOSTREGEX_SUFFIX="hostregex-test.localhost"
 HOST_TLS="tls.func-test.localhost"
 HOST_WS="ws.func-test.localhost"
+HOST_SSE="sse.func-test.localhost"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/e2e/run-all.sh
+++ b/tests/e2e/run-all.sh
@@ -197,6 +197,22 @@ services:
       - "sozune.http.svcws.port=8080"
       - "sozune.network=${COMPOSE_PROJECT}_default"
 
+  svc-sse:
+    image: dunglas/mercure:v0.16
+    environment:
+      SERVER_NAME: ":80"
+      MERCURE_PUBLISHER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      MERCURE_SUBSCRIBER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      MERCURE_EXTRA_DIRECTIVES: |
+        cors_origins *
+        anonymous
+    labels:
+      - "sozune.enable=true"
+      - "sozune.http.svcsse.host=$HOST_SSE"
+      - "sozune.http.svcsse.port=80"
+      - "sozune.http.svcsse.backendTimeout=0"
+      - "sozune.network=${COMPOSE_PROJECT}_default"
+
   svc-tcpecho:
     image: alpine/socat
     command: ["TCP-LISTEN:9000,fork,reuseaddr", "EXEC:cat"]


### PR DESCRIPTION
## Summary

Adds an end-to-end test that proves Sozune passes Server-Sent Events through in real time, using Mercure as the SSE source. Documents the pattern for users.

### What changes

- New `tests/e2e/08-sse.sh` suite with 3 assertions:
  - SSE keepalive comment reaches the subscriber through Sozune
  - A published event is delivered to a connected subscriber
  - Delivery happens within 1 s of publish (asserted at ~56 ms locally), proving Sozu does not buffer chunks until connection close
- New `svc-sse` backend in `tests/e2e/run-all.sh` running `dunglas/mercure:v0.16` with `backendTimeout=0`
- New `documentation/advanced/sse.md` explaining the one knob users actually need (`backendTimeout=0`), the compression caveat, and a Mercure example
- Index entry under Advanced
- Drive-by: `tests/e2e/03-api.sh` updated to send the new Backend JSON shape — the script was broken since the per-backend port refactor merged on main but caught here because `cargo test` runs the unit tests, not the shell e2e suite

## Test plan
- [x] `bash tests/e2e/run-all.sh` → 49 PASS, 0 FAIL, 2 SKIP (the 2 skips are pre-existing — method-based routing and response caching)
- [x] SSE specifically: 3 PASS including the streaming-time assertion
- [x] `cargo fmt --check`