### PR TITLE
Surface diagnostics in API and dashboard

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -126,6 +126,9 @@ export interface Entrypoint {
 
 export interface DiagnosticsResponse {
   total: number;
+  /** Diagnostics not attached to any single candidate (e.g. ACME-without-TLS).
+   *  Optional: older API responses may omit this field. */
+  global?: Diagnostic[];
   items: { candidate_id: string; diagnostics: Diagnostic[] }[];
 }
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -100,6 +100,17 @@ export function backendKey(b: Backend): string {
   return `${b.address}:${b.port}`;
 }
 
+export type Severity = 'error' | 'warn' | 'info';
+
+export interface Diagnostic {
+  code: string;
+  severity: Severity;
+  message: string;
+  label?: string;
+  value?: string;
+  hint?: string;
+}
+
 export interface Entrypoint {
   id: string;
   name: string;
@@ -109,10 +120,21 @@ export interface Entrypoint {
   source?: string | null;
   /** Backend addresses (`host:port`) currently marked down by the health checker. */
   unhealthy_backends?: string[];
+  /** Diagnostics produced for this entrypoint by the label parser. */
+  diagnostics?: Diagnostic[];
+}
+
+export interface DiagnosticsResponse {
+  total: number;
+  items: { candidate_id: string; diagnostics: Diagnostic[] }[];
 }
 
 export function listEntrypoints(): Promise<Entrypoint[]> {
   return request<Entrypoint[]>('/entrypoints');
+}
+
+export function listDiagnostics(): Promise<DiagnosticsResponse> {
+  return request<DiagnosticsResponse>('/diagnostics');
 }
 
 export function getEntrypoint(id: string): Promise<Entrypoint> {

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 
   const nav = [
     { href: './', label: 'Entrypoints', icon: 'grid' },
+    { href: './diagnostics', label: 'Diagnostics', icon: 'warning' },
     { href: './certificates', label: 'Certificates', icon: 'lock' },
     { href: './health', label: 'Health', icon: 'pulse' },
     { href: './settings', label: 'Settings', icon: 'gear' }
@@ -60,6 +61,8 @@
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 8h3l2-5 3 10 2-5h4"/></svg>
               {:else if item.icon === 'gear'}
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="2.5"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M3.05 12.95l1.4-1.4M11.55 4.45l1.4-1.4"/></svg>
+              {:else if item.icon === 'warning'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2L1.5 13.5h13L8 2z"/><path d="M8 6.5v3.5"/><circle cx="8" cy="11.5" r="0.5" fill="currentColor"/></svg>
               {/if}
             </span>
             <span>{item.label}</span>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -33,8 +33,30 @@
     tcp: entrypoints.filter((e) => e.protocol === 'Tcp').length,
     backends: entrypoints.reduce((n, e) => n + e.backends.length, 0),
     backendsDown: entrypoints.reduce((n, e) => n + (e.unhealthy_backends?.length ?? 0), 0),
-    tls: entrypoints.filter((e) => e.config.tls).length
+    tls: entrypoints.filter((e) => e.config.tls).length,
+    warnings: entrypoints.reduce(
+      (n, e) => n + (e.diagnostics?.filter((d) => d.severity === 'warn').length ?? 0),
+      0
+    ),
+    errors: entrypoints.reduce(
+      (n, e) => n + (e.diagnostics?.filter((d) => d.severity === 'error').length ?? 0),
+      0
+    )
   });
+
+  function diagSummary(ep: Entrypoint): { warn: number; err: number } {
+    const diags = ep.diagnostics ?? [];
+    return {
+      warn: diags.filter((d) => d.severity === 'warn').length,
+      err: diags.filter((d) => d.severity === 'error').length
+    };
+  }
+
+  function diagTooltip(ep: Entrypoint): string {
+    return (ep.diagnostics ?? [])
+      .map((d) => `${d.code} ${d.message}${d.hint ? `\n  → ${d.hint}` : ''}`)
+      .join('\n\n');
+  }
 
   function isBackendDown(ep: Entrypoint, backend: Backend): boolean {
     return (ep.unhealthy_backends ?? []).includes(backendKey(backend));
@@ -117,11 +139,20 @@
     <div class="stat-sub">{stats.total ? Math.round((stats.tls / stats.total) * 100) : 0}% of routes</div>
   </div>
   <div class="stat-card">
-    <div class="stat-label">Status</div>
-    <div class="stat-value healthy">
-      <span class="dot"></span> live
+    <div class="stat-label">Diagnostics</div>
+    <div class="stat-value">
+      {stats.warnings + stats.errors}
     </div>
-    <div class="stat-sub">polling every 5s</div>
+    <div class="stat-sub">
+      {#if stats.errors > 0}
+        <span class="stat-down">{stats.errors} error{stats.errors === 1 ? '' : 's'}</span>
+        {#if stats.warnings > 0}· {stats.warnings} warning{stats.warnings === 1 ? '' : 's'}{/if}
+      {:else if stats.warnings > 0}
+        {stats.warnings} warning{stats.warnings === 1 ? '' : 's'}
+      {:else}
+        no issues
+      {/if}
+    </div>
   </div>
 </section>
 
@@ -216,6 +247,12 @@
                 {#if ep.config.sticky_session}<span class="chip">sticky</span>{/if}
                 {#if ep.config.compress}<span class="chip">gzip</span>{/if}
                 {#if ep.config.strip_prefix}<span class="chip">strip</span>{/if}
+                {#if diagSummary(ep).err > 0}
+                  <span class="chip chip-err" title={diagTooltip(ep)}>✗ {diagSummary(ep).err}</span>
+                {/if}
+                {#if diagSummary(ep).warn > 0}
+                  <span class="chip chip-warn" title={diagTooltip(ep)}>⚠ {diagSummary(ep).warn}</span>
+                {/if}
               </div>
             </td>
             <td>
@@ -555,6 +592,16 @@
     font-size: 0.68rem;
     font-family: var(--font-mono);
     font-weight: 500;
+  }
+  .chip-warn {
+    background: rgba(240, 180, 41, 0.18);
+    color: var(--warning);
+    cursor: help;
+  }
+  .chip-err {
+    background: var(--danger-bg);
+    color: var(--danger);
+    cursor: help;
   }
 
   .source {

--- a/dashboard/src/routes/diagnostics/+page.svelte
+++ b/dashboard/src/routes/diagnostics/+page.svelte
@@ -1,0 +1,388 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { listDiagnostics, type Diagnostic, type DiagnosticsResponse } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth';
+
+  let data = $state<DiagnosticsResponse | null>(null);
+  let error = $state<string | null>(null);
+  let loading = $state(true);
+  let lastRefresh = $state<Date | null>(null);
+  let severityFilter = $state<'all' | 'error' | 'warn' | 'info'>('all');
+
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  const stats = $derived.by(() => {
+    if (!data) return { total: 0, error: 0, warn: 0, info: 0 };
+    const all = [...data.global, ...data.items.flatMap((i) => i.diagnostics)];
+    return {
+      total: all.length,
+      error: all.filter((d) => d.severity === 'error').length,
+      warn: all.filter((d) => d.severity === 'warn').length,
+      info: all.filter((d) => d.severity === 'info').length
+    };
+  });
+
+  function passes(d: Diagnostic): boolean {
+    return severityFilter === 'all' || d.severity === severityFilter;
+  }
+
+  const filteredItems = $derived(
+    (data?.items ?? [])
+      .map((i) => ({ ...i, diagnostics: i.diagnostics.filter(passes) }))
+      .filter((i) => i.diagnostics.length > 0)
+  );
+
+  const filteredGlobal = $derived((data?.global ?? []).filter(passes));
+
+  async function load(silent = false) {
+    if (!silent) loading = true;
+    try {
+      data = await listDiagnostics();
+      error = null;
+      lastRefresh = new Date();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    if (!isAuthenticated()) {
+      goto('./login');
+      return;
+    }
+    void load();
+    poll = setInterval(() => void load(true), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) clearInterval(poll);
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) return '';
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) return 'just now';
+    if (s < 60) return `${s}s ago`;
+    return `${Math.floor(s / 60)}m ago`;
+  }
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Diagnostics</h1>
+    <p class="subtitle">Issues detected by the label parser and the config lints</p>
+  </div>
+  <div class="header-actions">
+    {#if lastRefresh}
+      <span class="refresh-meta">updated {timeAgo(lastRefresh)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={() => load()} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">Total</div>
+    <div class="stat-value">{stats.total}</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Errors</div>
+    <div class="stat-value sev-error">{stats.error}</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Warnings</div>
+    <div class="stat-value sev-warn">{stats.warn}</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Info</div>
+    <div class="stat-value sev-info">{stats.info}</div>
+  </div>
+</section>
+
+<section class="toolbar">
+  <div class="filters">
+    {#each ['all', 'error', 'warn', 'info'] as sev}
+      <button
+        class="filter-chip"
+        class:active={severityFilter === sev}
+        onclick={() => (severityFilter = sev as typeof severityFilter)}
+      >
+        {sev}
+      </button>
+    {/each}
+  </div>
+</section>
+
+{#if error}
+  <div class="alert">
+    <strong>error</strong> {error}
+  </div>
+{/if}
+
+{#if loading && !data}
+  <div class="empty">loading…</div>
+{:else if stats.total === 0}
+  <div class="empty">no diagnostics — every entrypoint parsed cleanly</div>
+{:else}
+  {#if filteredGlobal.length > 0}
+    <section class="group">
+      <h2 class="group-title">Global</h2>
+      <div class="diag-list">
+        {#each filteredGlobal as diag}
+          {@render diagCard(diag)}
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  {#each filteredItems as item}
+    <section class="group">
+      <h2 class="group-title">
+        <span class="group-id mono">{item.candidate_id}</span>
+        <span class="group-count">{item.diagnostics.length}</span>
+      </h2>
+      <div class="diag-list">
+        {#each item.diagnostics as diag}
+          {@render diagCard(diag)}
+        {/each}
+      </div>
+    </section>
+  {/each}
+{/if}
+
+{#snippet diagCard(diag: Diagnostic)}
+  <div class="diag diag-{diag.severity}">
+    <div class="diag-head">
+      <span class="diag-glyph">
+        {#if diag.severity === 'error'}✗{:else if diag.severity === 'warn'}⚠{:else}ℹ{/if}
+      </span>
+      <span class="diag-code mono">{diag.code}</span>
+      <span class="diag-message">{diag.message}</span>
+    </div>
+    {#if diag.label || diag.value}
+      <div class="diag-meta mono">
+        {#if diag.label}<span>{diag.label}</span>{/if}
+        {#if diag.value}<span class="diag-value">= {diag.value}</span>{/if}
+      </div>
+    {/if}
+    {#if diag.hint}
+      <div class="diag-hint">→ {diag.hint}</div>
+    {/if}
+  </div>
+{/snippet}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    background: var(--bg-2);
+    color: var(--fg-1);
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-top: 0.25rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+  .sev-error { color: var(--danger); }
+  .sev-warn { color: var(--warning); }
+  .sev-info { color: var(--accent); }
+
+  .toolbar {
+    margin-bottom: 1rem;
+  }
+  .filters {
+    display: inline-flex;
+    gap: 4px;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 3px;
+  }
+  .filter-chip {
+    padding: 0.35rem 0.85rem;
+    background: transparent;
+    border: none;
+    color: var(--fg-2);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+  .filter-chip:hover {
+    color: var(--fg-0);
+  }
+  .filter-chip.active {
+    background: var(--bg-3);
+    color: var(--fg-0);
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+  }
+
+  .empty {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    text-align: center;
+    color: var(--fg-3);
+    font-size: 0.85rem;
+  }
+
+  .group {
+    margin-bottom: 1.5rem;
+  }
+  .group-title {
+    font-size: 0.825rem;
+    font-weight: 500;
+    color: var(--fg-2);
+    margin: 0 0 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .group-id {
+    color: var(--fg-1);
+    word-break: break-all;
+  }
+  .group-count {
+    background: var(--bg-3);
+    color: var(--fg-2);
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 1px 7px;
+    border-radius: 999px;
+  }
+
+  .diag-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .diag {
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: var(--radius);
+    padding: 0.625rem 0.875rem;
+    background: var(--bg-1);
+  }
+  .diag-error { border-left-color: var(--danger); }
+  .diag-warn { border-left-color: var(--warning); }
+  .diag-info { border-left-color: var(--accent); }
+  .diag-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.825rem;
+  }
+  .diag-glyph {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+  .diag-error .diag-glyph { color: var(--danger); }
+  .diag-warn .diag-glyph { color: var(--warning); }
+  .diag-info .diag-glyph { color: var(--accent); }
+  .diag-code {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 1px 7px;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+  .diag-message {
+    color: var(--fg-0);
+    flex: 1;
+  }
+  .diag-meta {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+    margin-top: 0.35rem;
+    margin-left: 1.45rem;
+    display: flex;
+    gap: 0.4rem;
+  }
+  .diag-value { color: var(--fg-2); }
+  .diag-hint {
+    color: var(--fg-2);
+    font-size: 0.78rem;
+    margin-top: 0.35rem;
+    margin-left: 1.45rem;
+  }
+</style>

--- a/dashboard/src/routes/entrypoints/[id]/+page.svelte
+++ b/dashboard/src/routes/entrypoints/[id]/+page.svelte
@@ -183,6 +183,37 @@
     {/if}
   </section>
 
+  {#if (entrypoint.diagnostics ?? []).length > 0}
+    <section class="card">
+      <h2>
+        Diagnostics
+        <span class="diag-count">{(entrypoint.diagnostics ?? []).length}</span>
+      </h2>
+      <ul class="diag-list">
+        {#each entrypoint.diagnostics ?? [] as diag}
+          <li class="diag diag-{diag.severity}">
+            <div class="diag-head">
+              <span class="diag-glyph">
+                {#if diag.severity === 'error'}✗{:else if diag.severity === 'warn'}⚠{:else}ℹ{/if}
+              </span>
+              <span class="diag-code mono">{diag.code}</span>
+              <span class="diag-message">{diag.message}</span>
+            </div>
+            {#if diag.label || diag.value}
+              <div class="diag-meta mono">
+                {#if diag.label}<span>{diag.label}</span>{/if}
+                {#if diag.value}<span class="diag-value">= {diag.value}</span>{/if}
+              </div>
+            {/if}
+            {#if diag.hint}
+              <div class="diag-hint">→ {diag.hint}</div>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
   {#if entrypoint.config.headers && Object.keys(entrypoint.config.headers).length > 0}
     <section class="card">
       <h2>Custom headers</h2>
@@ -466,5 +497,89 @@
     .feature-grid {
       grid-template-columns: 1fr;
     }
+  }
+
+  .diag-count {
+    display: inline-block;
+    background: var(--bg-3);
+    color: var(--fg-2);
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 1px 7px;
+    border-radius: 999px;
+    margin-left: 0.5rem;
+    vertical-align: middle;
+  }
+  .diag-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .diag {
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: var(--radius);
+    padding: 0.625rem 0.875rem;
+    background: var(--bg-2);
+  }
+  .diag-error {
+    border-left-color: var(--danger);
+  }
+  .diag-warn {
+    border-left-color: var(--warning);
+  }
+  .diag-info {
+    border-left-color: var(--accent);
+  }
+  .diag-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.825rem;
+  }
+  .diag-glyph {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+  .diag-error .diag-glyph {
+    color: var(--danger);
+  }
+  .diag-warn .diag-glyph {
+    color: var(--warning);
+  }
+  .diag-info .diag-glyph {
+    color: var(--accent);
+  }
+  .diag-code {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 1px 7px;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+  .diag-message {
+    color: var(--fg-0);
+    flex: 1;
+  }
+  .diag-meta {
+    color: var(--fg-3);
+    font-size: 0.72rem;
+    margin-top: 0.35rem;
+    margin-left: 1.45rem;
+    display: flex;
+    gap: 0.4rem;
+  }
+  .diag-value {
+    color: var(--fg-2);
+  }
+  .diag-hint {
+    color: var(--fg-2);
+    font-size: 0.78rem;
+    margin-top: 0.35rem;
+    margin-left: 1.45rem;
   }
 </style>

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -9,7 +9,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Deserialize;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -23,12 +23,22 @@ pub struct AppState {
     pub reload_tx: mpsc::Sender<()>,
     pub users: Vec<ApiUser>,
     pub unhealthy_backends: Arc<RwLock<HashSet<String>>>,
+    pub diagnostics: crate::diagnostics::DiagnosticsStore,
 }
 
 /// Build the JSON payload for an entrypoint, augmenting it with the
 /// `unhealthy_backends` list (subset of `backends` that the health checker
-/// has marked down). Empty when every backend is reachable.
-fn entrypoint_payload(entrypoint: &Entrypoint, unhealthy: &HashSet<String>) -> serde_json::Value {
+/// has marked down) and the `diagnostics` produced for this entrypoint by the
+/// label parser (empty when none).
+///
+/// Diagnostics are looked up by `entrypoint.id` first (the cluster_id used at
+/// runtime), then by `entrypoint.source` which is set to the candidate id by
+/// most providers. The first non-empty match wins.
+fn entrypoint_payload(
+    entrypoint: &Entrypoint,
+    unhealthy: &HashSet<String>,
+    diagnostics: &HashMap<String, Vec<crate::labels::diagnostic::Diagnostic>>,
+) -> serde_json::Value {
     let unhealthy_for_ep: Vec<String> = entrypoint
         .backends
         .iter()
@@ -36,12 +46,24 @@ fn entrypoint_payload(entrypoint: &Entrypoint, unhealthy: &HashSet<String>) -> s
         .filter(|key| unhealthy.contains(key))
         .collect();
 
+    let diags_for_ep: Vec<crate::labels::diagnostic::Diagnostic> = diagnostics
+        .get(&entrypoint.id)
+        .or_else(|| {
+            entrypoint
+                .source
+                .as_ref()
+                .and_then(|s| diagnostics.get(s.as_str()))
+        })
+        .cloned()
+        .unwrap_or_default();
+
     let mut value = serde_json::json!(entrypoint);
     if let Some(obj) = value.as_object_mut() {
         obj.insert(
             "unhealthy_backends".to_string(),
             serde_json::json!(unhealthy_for_ep),
         );
+        obj.insert("diagnostics".to_string(), serde_json::json!(diags_for_ep));
     }
     value
 }
@@ -137,6 +159,7 @@ pub async fn serve(
     storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     reload_tx: mpsc::Sender<()>,
     unhealthy_backends: Arc<RwLock<HashSet<String>>>,
+    diagnostics: crate::diagnostics::DiagnosticsStore,
 ) -> anyhow::Result<()> {
     if config.users.is_empty() {
         anyhow::bail!(
@@ -149,6 +172,7 @@ pub async fn serve(
         reload_tx,
         users: config.users.clone(),
         unhealthy_backends,
+        diagnostics,
     };
 
     let protected = Router::new()
@@ -162,6 +186,7 @@ pub async fn serve(
                 .put(update_entrypoint)
                 .delete(delete_entrypoint),
         )
+        .route("/diagnostics", get(list_diagnostics))
         .route_layer(axum_middleware::from_fn(require_admin));
 
     let me_route = Router::new().route("/me", get(me));
@@ -274,11 +299,49 @@ async fn list_entrypoints(State(state): State<AppState>) -> (StatusCode, Json<se
             HashSet::new()
         }
     };
+    let diagnostics = read_diagnostics(&state);
     let list: Vec<serde_json::Value> = storage
         .values()
-        .map(|ep| entrypoint_payload(ep, &unhealthy))
+        .map(|ep| entrypoint_payload(ep, &unhealthy, &diagnostics))
         .collect();
     (StatusCode::OK, Json(serde_json::json!(list)))
+}
+
+fn read_diagnostics(
+    state: &AppState,
+) -> HashMap<String, Vec<crate::labels::diagnostic::Diagnostic>> {
+    match state.diagnostics.read() {
+        Ok(guard) => guard.clone(),
+        Err(e) => {
+            error!(
+                "internal state corrupted (diagnostics store), restart required: {}",
+                e
+            );
+            HashMap::new()
+        }
+    }
+}
+
+/// `GET /diagnostics` — flat snapshot of all diagnostics by candidate id.
+async fn list_diagnostics(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
+    let snapshot = crate::diagnostics::snapshot(&state.diagnostics);
+    let total: usize = snapshot.iter().map(|(_, v)| v.len()).sum();
+    let by_candidate: Vec<serde_json::Value> = snapshot
+        .into_iter()
+        .map(|(id, diags)| {
+            serde_json::json!({
+                "candidate_id": id,
+                "diagnostics": diags,
+            })
+        })
+        .collect();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "total": total,
+            "items": by_candidate,
+        })),
+    )
 }
 
 async fn get_entrypoint(
@@ -309,10 +372,12 @@ async fn get_entrypoint(
         }
     };
 
+    let diagnostics = read_diagnostics(&state);
+
     match storage.get(&id) {
         Some(entrypoint) => (
             StatusCode::OK,
-            Json(entrypoint_payload(entrypoint, &unhealthy)),
+            Json(entrypoint_payload(entrypoint, &unhealthy, &diagnostics)),
         ),
         None => (
             StatusCode::NOT_FOUND,
@@ -524,6 +589,7 @@ mod tests {
             reload_tx,
             users,
             unhealthy_backends: Arc::new(RwLock::new(HashSet::new())),
+            diagnostics: crate::diagnostics::new_store(),
         }
     }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,119 @@
+//! Shared diagnostics store, populated by providers at parse time and read by
+//! the API (`/entrypoints` and `/diagnostics` endpoints).
+//!
+//! Keyed by candidate id (the same id the candidate was parsed from), so that
+//! callers can look up "what did the parser say about this container?". An
+//! entrypoint id (cluster_id) may not match the candidate id 1:1 — a single
+//! candidate can produce multiple entrypoints.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::labels::candidate::Candidate;
+use crate::labels::diagnostic::{Diagnostic, ParseResult};
+
+pub type DiagnosticsStore = Arc<RwLock<HashMap<String, Vec<Diagnostic>>>>;
+
+pub fn new_store() -> DiagnosticsStore {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Replace the diagnostics for a single candidate.
+///
+/// Empty `diags` removes the entry rather than storing an empty vec — callers
+/// reading the map can then assume "key present" ⟺ "has at least one diag".
+pub fn set(store: &DiagnosticsStore, candidate_id: &str, diags: Vec<Diagnostic>) {
+    let mut guard = match store.write() {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!(
+                "internal state corrupted (diagnostics store), restart required: {}",
+                e
+            );
+            return;
+        }
+    };
+    if diags.is_empty() {
+        guard.remove(candidate_id);
+    } else {
+        guard.insert(candidate_id.to_string(), diags);
+    }
+}
+
+/// Drop the diagnostics for a candidate that no longer exists.
+pub fn remove(store: &DiagnosticsStore, candidate_id: &str) {
+    let mut guard = match store.write() {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!(
+                "internal state corrupted (diagnostics store), restart required: {}",
+                e
+            );
+            return;
+        }
+    };
+    guard.remove(candidate_id);
+}
+
+/// Parse a candidate and write the resulting diagnostics into the store keyed
+/// by `candidate.id`. Returns the parse result so callers can use the
+/// entrypoints. Empty diagnostics remove any existing entry.
+///
+/// Use this in providers as a drop-in replacement for `labels::parse(&c)`
+/// when you want diagnostics to surface in the API.
+pub fn parse_and_store(store: &DiagnosticsStore, candidate: &Candidate) -> ParseResult {
+    let result = crate::labels::parse(candidate);
+    set(store, &candidate.id, result.diagnostics.clone());
+    result
+}
+
+/// Snapshot of all current diagnostics. Returns a flat list with the candidate
+/// id attached to each diagnostic for cross-referencing.
+pub fn snapshot(store: &DiagnosticsStore) -> Vec<(String, Vec<Diagnostic>)> {
+    match store.read() {
+        Ok(g) => g.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+        Err(e) => {
+            tracing::error!(
+                "internal state corrupted (diagnostics store), restart required: {}",
+                e
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::labels::diagnostic::DiagnosticCode;
+
+    fn diag() -> Diagnostic {
+        Diagnostic::new(DiagnosticCode::W001InvalidPort, "test")
+    }
+
+    #[test]
+    fn set_then_snapshot_returns_inserted() {
+        let s = new_store();
+        set(&s, "c1", vec![diag()]);
+        let snap = snapshot(&s);
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].0, "c1");
+        assert_eq!(snap[0].1.len(), 1);
+    }
+
+    #[test]
+    fn set_with_empty_removes_entry() {
+        let s = new_store();
+        set(&s, "c1", vec![diag()]);
+        set(&s, "c1", vec![]);
+        assert!(snapshot(&s).is_empty());
+    }
+
+    #[test]
+    fn remove_drops_entry() {
+        let s = new_store();
+        set(&s, "c1", vec![diag()]);
+        remove(&s, "c1");
+        assert!(snapshot(&s).is_empty());
+    }
+}

--- a/src/labels/diagnostic.rs
+++ b/src/labels/diagnostic.rs
@@ -1,7 +1,9 @@
 use crate::model::Entrypoint;
+use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
     Warn,
@@ -80,6 +82,12 @@ impl DiagnosticCode {
     }
 }
 
+impl Serialize for DiagnosticCode {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
     pub code: DiagnosticCode,
@@ -87,6 +95,36 @@ pub struct Diagnostic {
     pub value: Option<String>,
     pub message: String,
     pub hint: Option<String>,
+}
+
+impl Serialize for Diagnostic {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut len = 3; // code, severity, message
+        if self.label.is_some() {
+            len += 1;
+        }
+        if self.value.is_some() {
+            len += 1;
+        }
+        if self.hint.is_some() {
+            len += 1;
+        }
+        let mut m = s.serialize_map(Some(len))?;
+        m.serialize_entry("code", self.code.as_str())?;
+        m.serialize_entry("severity", &self.severity())?;
+        m.serialize_entry("message", &self.message)?;
+        if let Some(label) = &self.label {
+            m.serialize_entry("label", label)?;
+        }
+        if let Some(value) = &self.value {
+            m.serialize_entry("value", value)?;
+        }
+        if let Some(hint) = &self.hint {
+            m.serialize_entry("hint", hint)?;
+        }
+        m.end()
+    }
 }
 
 impl Diagnostic {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod cli;
 mod config;
 mod config_load;
 mod dashboard;
+mod diagnostics;
 mod labels;
 mod middleware;
 mod model;
@@ -93,6 +94,9 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let storage = Arc::new(RwLock::new(std::collections::BTreeMap::new()));
     let storage_proxy = Arc::clone(&storage);
 
+    // Diagnostics store, populated by providers at parse time and read by the API.
+    let diagnostics_store = diagnostics::new_store();
+
     // Create bounded channels to prevent memory exhaustion
     let (reload_tx, reload_rx) = mpsc::channel(64);
     let (cert_tx, cert_rx) = mpsc::channel(64);
@@ -136,6 +140,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
         let storage_providers = Arc::clone(&storage);
         let reload_tx_providers = reload_tx.clone();
         let acme_notify_providers = Arc::clone(&acme_notify);
+        let diagnostics_providers = Arc::clone(&diagnostics_store);
         let config = config.clone();
 
         async move {
@@ -144,6 +149,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 storage_providers,
                 reload_tx_providers,
                 acme_notify_providers,
+                diagnostics_providers,
             )
             .await
         }
@@ -158,10 +164,18 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let reload_tx_api = reload_tx.clone();
     let api_config = config.api.clone();
     let unhealthy_api = Arc::clone(&unhealthy_backends);
+    let diagnostics_api = Arc::clone(&diagnostics_store);
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
-            api::server::serve(api_config, storage_server, reload_tx_api, unhealthy_api).await?;
+            api::server::serve(
+                api_config,
+                storage_server,
+                reload_tx_api,
+                unhealthy_api,
+                diagnostics_api,
+            )
+            .await?;
         }
 
         Ok::<(), anyhow::Error>(())

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -1,4 +1,5 @@
 use crate::config::DockerConfig;
+use crate::diagnostics::{self, DiagnosticsStore};
 use crate::labels::candidate::{Candidate, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
 use crate::labels::source::LabelSource;
@@ -28,8 +29,11 @@ pub struct DockerProvider {
 #[async_trait]
 impl Provider for DockerProvider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        // Throwaway store: trait callers (CLI, validate) don't share the
+        // runtime store; diagnostics get logged either way.
+        let throwaway = diagnostics::new_store();
         let hashmap = self
-            .get_entrypoints_from_containers()
+            .get_entrypoints_from_containers(&throwaway)
             .await
             .map_err(anyhow::Error::new)?;
         Ok(hashmap.into_iter().collect())
@@ -115,12 +119,13 @@ impl DockerProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<tokio::sync::Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         info!("Starting Docker service");
 
         // Initial scan of existing containers
         info!("Performing initial scan of running containers");
-        match self.get_entrypoints_from_containers().await {
+        match self.get_entrypoints_from_containers(&diagnostics).await {
             Ok(initial_entrypoints) => {
                 if !initial_entrypoints.is_empty() {
                     let storage_changed = {
@@ -180,7 +185,7 @@ impl DockerProvider {
         }
 
         // Start event listener
-        self.start_event_listener(storage, reload_tx, acme_notify)
+        self.start_event_listener(storage, reload_tx, acme_notify, diagnostics)
             .await
     }
 
@@ -190,6 +195,7 @@ impl DockerProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<tokio::sync::Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         info!("Starting Docker event listener");
 
@@ -232,8 +238,9 @@ impl DockerProvider {
                                     ips.insert(container_id.to_string(), ip);
                                 }
 
-                                if let Ok(entrypoints) =
-                                    self.get_container_entrypoints(container_id).await
+                                if let Ok(entrypoints) = self
+                                    .get_container_entrypoints(container_id, &diagnostics)
+                                    .await
                                     && !entrypoints.is_empty()
                                 {
                                     let mut storage_write = match storage.write() {
@@ -265,6 +272,8 @@ impl DockerProvider {
                                 }
                             }
                             "stop" | "die" | "destroy" => {
+                                // Drop any cached diagnostics for this container — it's gone.
+                                diagnostics::remove(&diagnostics, container_id);
                                 // Use tracked IP (stopped containers lose their network IP)
                                 let container_ip = self.container_ips.lock().ok()
                                             .and_then(|mut ips| ips.remove(container_id.as_str()))
@@ -307,8 +316,9 @@ impl DockerProvider {
                             }
                             "update" => {
                                 // For updates, remove old and add new
-                                if let Ok(entrypoints) =
-                                    self.get_container_entrypoints(container_id).await
+                                if let Ok(entrypoints) = self
+                                    .get_container_entrypoints(container_id, &diagnostics)
+                                    .await
                                 {
                                     let container_ip = self
                                         .get_container_ip(container_id)
@@ -387,19 +397,21 @@ impl DockerProvider {
     async fn get_container_entrypoints(
         &self,
         container_id: &str,
+        diagnostics: &DiagnosticsStore,
     ) -> Result<HashMap<String, Entrypoint>, bollard::errors::Error> {
         let candidate = match self.inspect_to_candidate(container_id).await? {
             Some(c) => c,
             None => return Ok(HashMap::new()),
         };
 
-        let result = labels::parse(&candidate);
+        let result = diagnostics::parse_and_store(diagnostics, &candidate);
         log_diagnostics(&candidate, &result.diagnostics);
         Ok(result.entrypoints)
     }
 
     pub async fn get_entrypoints_from_containers(
         &self,
+        diagnostics: &DiagnosticsStore,
     ) -> Result<HashMap<String, Entrypoint>, bollard::errors::Error> {
         let mut entrypoints: HashMap<String, Entrypoint> = HashMap::new();
 
@@ -421,7 +433,7 @@ impl DockerProvider {
             let networks = self.extract_networks(&container_id).await;
             let candidate = self.build_candidate(container_id.clone(), container_labels, networks);
 
-            let result = labels::parse(&candidate);
+            let result = diagnostics::parse_and_store(diagnostics, &candidate);
             log_diagnostics(&candidate, &result.diagnostics);
 
             if result.entrypoints.is_empty() {

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -1,4 +1,5 @@
 use crate::config::AppConfig;
+use crate::diagnostics::DiagnosticsStore;
 use crate::model::Entrypoint;
 use crate::provider::{
     Provider, config::ConfigProvider, docker::DockerProvider, http::HttpProvider,
@@ -16,6 +17,7 @@ pub async fn start_services(
     storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     reload_tx: mpsc::Sender<()>,
     acme_notify: Arc<Notify>,
+    diagnostics: DiagnosticsStore,
 ) -> anyhow::Result<()> {
     info!("Loading initial entrypoints and starting provider services");
 
@@ -88,10 +90,16 @@ pub async fn start_services(
         let storage_docker = Arc::clone(&storage);
         let reload_tx_docker = reload_tx.clone();
         let acme_notify_docker = Arc::clone(&acme_notify);
+        let diagnostics_docker = Arc::clone(&diagnostics);
 
         tokio::spawn(async move {
             if let Err(e) = docker_provider
-                .start_service(storage_docker, reload_tx_docker, acme_notify_docker)
+                .start_service(
+                    storage_docker,
+                    reload_tx_docker,
+                    acme_notify_docker,
+                    diagnostics_docker,
+                )
                 .await
             {
                 error!("Docker service failed: {}", e);
@@ -109,10 +117,16 @@ pub async fn start_services(
         let storage_podman = Arc::clone(&storage);
         let reload_tx_podman = reload_tx.clone();
         let acme_notify_podman = Arc::clone(&acme_notify);
+        let diagnostics_podman = Arc::clone(&diagnostics);
 
         tokio::spawn(async move {
             if let Err(e) = podman_provider
-                .start_service(storage_podman, reload_tx_podman, acme_notify_podman)
+                .start_service(
+                    storage_podman,
+                    reload_tx_podman,
+                    acme_notify_podman,
+                    diagnostics_podman,
+                )
                 .await
             {
                 error!("Podman service failed: {}", e);
@@ -131,10 +145,16 @@ pub async fn start_services(
         let storage_swarm = Arc::clone(&storage);
         let reload_tx_swarm = reload_tx.clone();
         let acme_notify_swarm = Arc::clone(&acme_notify);
+        let diagnostics_swarm = Arc::clone(&diagnostics);
 
         tokio::spawn(async move {
             if let Err(e) = swarm_provider
-                .start_service(storage_swarm, reload_tx_swarm, acme_notify_swarm)
+                .start_service(
+                    storage_swarm,
+                    reload_tx_swarm,
+                    acme_notify_swarm,
+                    diagnostics_swarm,
+                )
                 .await
             {
                 error!("Swarm service failed: {}", e);
@@ -154,6 +174,7 @@ pub async fn start_services(
         let storage_kubernetes = Arc::clone(&storage);
         let reload_tx_kubernetes = reload_tx.clone();
         let acme_notify_kubernetes = Arc::clone(&acme_notify);
+        let diagnostics_kubernetes = Arc::clone(&diagnostics);
 
         tokio::spawn(async move {
             if let Err(e) = kubernetes_provider
@@ -161,6 +182,7 @@ pub async fn start_services(
                     storage_kubernetes,
                     reload_tx_kubernetes,
                     acme_notify_kubernetes,
+                    diagnostics_kubernetes,
                 )
                 .await
             {
@@ -179,10 +201,16 @@ pub async fn start_services(
         let storage_nomad = Arc::clone(&storage);
         let reload_tx_nomad = reload_tx.clone();
         let acme_notify_nomad = Arc::clone(&acme_notify);
+        let diagnostics_nomad = Arc::clone(&diagnostics);
 
         tokio::spawn(async move {
             if let Err(e) = nomad_provider
-                .start_polling(storage_nomad, reload_tx_nomad, acme_notify_nomad)
+                .start_polling(
+                    storage_nomad,
+                    reload_tx_nomad,
+                    acme_notify_nomad,
+                    diagnostics_nomad,
+                )
                 .await
             {
                 error!("Nomad provider failed: {}", e);

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -1,8 +1,8 @@
 use crate::config::KubernetesConfig;
+use crate::diagnostics::{self, DiagnosticsStore};
 use crate::labels::candidate::{Candidate, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
 use crate::labels::source::LabelSource;
-use crate::labels::{self};
 use crate::model::{Backend, Entrypoint, EntrypointConfig, PathConfig, PathRuleType, Protocol};
 use crate::provider::Provider;
 use anyhow::Context;
@@ -44,10 +44,13 @@ pub struct KubernetesProvider {
 #[async_trait]
 impl Provider for KubernetesProvider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        // Trait callers don't share the runtime store; use a throwaway so
+        // diagnostics are at least logged.
+        let throwaway = diagnostics::new_store();
         let candidates = self.collect().await?;
         let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
         for candidate in candidates {
-            let result = labels::parse(&candidate);
+            let result = diagnostics::parse_and_store(&throwaway, &candidate);
             log_diagnostics(&candidate, &result.diagnostics);
             for (key, entrypoint) in result.entrypoints {
                 entrypoints.insert(key, entrypoint);
@@ -206,6 +209,7 @@ impl KubernetesProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         info!(
             "Starting Kubernetes provider (namespace={}, ingress_class={}, expose_by_default={})",
@@ -244,9 +248,16 @@ impl KubernetesProvider {
         let svc_reload = reload_tx.clone();
         let svc_acme = Arc::clone(&acme_notify);
         let svc_client = client.clone();
+        let svc_diagnostics = Arc::clone(&diagnostics);
         let svc_handle = tokio::spawn(async move {
             if let Err(e) = svc_provider
-                .watch_services(svc_client, svc_storage, svc_reload, svc_acme)
+                .watch_services(
+                    svc_client,
+                    svc_storage,
+                    svc_reload,
+                    svc_acme,
+                    svc_diagnostics,
+                )
                 .await
             {
                 error!("Kubernetes Service watcher failed: {}", e);
@@ -258,9 +269,10 @@ impl KubernetesProvider {
         let ep_reload = reload_tx.clone();
         let ep_acme = Arc::clone(&acme_notify);
         let ep_client = client.clone();
+        let ep_diagnostics = Arc::clone(&diagnostics);
         let ep_handle = tokio::spawn(async move {
             if let Err(e) = ep_provider
-                .watch_endpoint_slices(ep_client, ep_storage, ep_reload, ep_acme)
+                .watch_endpoint_slices(ep_client, ep_storage, ep_reload, ep_acme, ep_diagnostics)
                 .await
             {
                 error!("Kubernetes EndpointSlice watcher failed: {}", e);
@@ -272,9 +284,16 @@ impl KubernetesProvider {
         let ing_reload = reload_tx.clone();
         let ing_acme = Arc::clone(&acme_notify);
         let ing_client = client.clone();
+        let ing_diagnostics = Arc::clone(&diagnostics);
         let ing_handle = tokio::spawn(async move {
             if let Err(e) = ing_provider
-                .watch_ingresses(ing_client, ing_storage, ing_reload, ing_acme)
+                .watch_ingresses(
+                    ing_client,
+                    ing_storage,
+                    ing_reload,
+                    ing_acme,
+                    ing_diagnostics,
+                )
                 .await
             {
                 error!("Kubernetes Ingress watcher failed: {}", e);
@@ -292,6 +311,7 @@ impl KubernetesProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         let services: Api<Service> = self.scoped_api(&client);
         let stream = watcher::watcher(services, watcher::Config::default());
@@ -302,11 +322,12 @@ impl KubernetesProvider {
         while let Some(event) = stream.next().await {
             match event {
                 Ok(Event::Apply(svc)) | Ok(Event::InitApply(svc)) => {
-                    self.upsert_service(&svc, &storage, &reload_tx, &acme_notify)
+                    self.upsert_service(&svc, &storage, &reload_tx, &acme_notify, &diagnostics)
                         .await;
                 }
                 Ok(Event::Delete(svc)) => {
-                    self.remove_service(&svc, &storage, &reload_tx).await;
+                    self.remove_service(&svc, &storage, &reload_tx, &diagnostics)
+                        .await;
                 }
                 Ok(Event::Init) => {
                     debug!("Service watcher restart: reinitialising");
@@ -331,6 +352,7 @@ impl KubernetesProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         let slices: Api<EndpointSlice> = self.scoped_api(&client);
         let stream = watcher::watcher(slices, watcher::Config::default());
@@ -342,14 +364,28 @@ impl KubernetesProvider {
             match event {
                 Ok(Event::Apply(slice)) | Ok(Event::InitApply(slice)) => {
                     if let Some(svc_id) = self.apply_slice(&slice) {
-                        self.refresh_service(&client, &svc_id, &storage, &reload_tx, &acme_notify)
-                            .await;
+                        self.refresh_service(
+                            &client,
+                            &svc_id,
+                            &storage,
+                            &reload_tx,
+                            &acme_notify,
+                            &diagnostics,
+                        )
+                        .await;
                     }
                 }
                 Ok(Event::Delete(slice)) => {
                     if let Some(svc_id) = self.remove_slice(&slice) {
-                        self.refresh_service(&client, &svc_id, &storage, &reload_tx, &acme_notify)
-                            .await;
+                        self.refresh_service(
+                            &client,
+                            &svc_id,
+                            &storage,
+                            &reload_tx,
+                            &acme_notify,
+                            &diagnostics,
+                        )
+                        .await;
                     }
                 }
                 Ok(Event::Init) | Ok(Event::InitDone) => {}
@@ -462,6 +498,7 @@ impl KubernetesProvider {
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
         acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
     ) {
         let Some((namespace, name)) = svc_id.split_once('/') else {
             return;
@@ -469,7 +506,7 @@ impl KubernetesProvider {
         let api: Api<Service> = Api::namespaced(client.clone(), namespace);
         match api.get(name).await {
             Ok(svc) => {
-                self.upsert_service(&svc, storage, reload_tx, acme_notify)
+                self.upsert_service(&svc, storage, reload_tx, acme_notify, diagnostics)
                     .await;
             }
             Err(kube::Error::Api(err)) if err.code == 404 => {
@@ -493,6 +530,7 @@ impl KubernetesProvider {
             storage,
             reload_tx,
             acme_notify,
+            diagnostics,
         )
         .await;
     }
@@ -508,6 +546,7 @@ impl KubernetesProvider {
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
         acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
     ) {
         let api: Api<Ingress> = Api::namespaced(client.clone(), namespace);
         let list = match api.list(&ListParams::default()).await {
@@ -525,7 +564,7 @@ impl KubernetesProvider {
             if !ingress_references_service(&ing, svc_name) {
                 continue;
             }
-            self.apply_ingress(&ing, storage, reload_tx, acme_notify)
+            self.apply_ingress(&ing, storage, reload_tx, acme_notify, diagnostics)
                 .await;
         }
     }
@@ -536,12 +575,13 @@ impl KubernetesProvider {
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
         acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
     ) {
         let Some(candidate) = self.service_to_candidate(svc) else {
             return;
         };
 
-        let result = labels::parse(&candidate);
+        let result = diagnostics::parse_and_store(diagnostics, &candidate);
         log_diagnostics(&candidate, &result.diagnostics);
 
         if result.entrypoints.is_empty() {
@@ -614,12 +654,16 @@ impl KubernetesProvider {
         svc: &Service,
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
+        diagnostics: &DiagnosticsStore,
     ) {
         let Some(candidate) = self.service_to_candidate(svc) else {
             return;
         };
 
-        let result = labels::parse(&candidate);
+        // Service is gone — drop its diagnostics. We still need to know which
+        // entrypoint keys it produced, so re-parse without writing to the store.
+        let result = crate::labels::parse(&candidate);
+        diagnostics::remove(diagnostics, &candidate.id);
         if result.entrypoints.is_empty() {
             return;
         }
@@ -662,6 +706,7 @@ impl KubernetesProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         let ingresses: Api<Ingress> = self.scoped_api(&client);
         let stream = watcher::watcher(ingresses, watcher::Config::default());
@@ -675,11 +720,12 @@ impl KubernetesProvider {
         while let Some(event) = stream.next().await {
             match event {
                 Ok(Event::Apply(ing)) | Ok(Event::InitApply(ing)) => {
-                    self.apply_ingress(&ing, &storage, &reload_tx, &acme_notify)
+                    self.apply_ingress(&ing, &storage, &reload_tx, &acme_notify, &diagnostics)
                         .await;
                 }
                 Ok(Event::Delete(ing)) => {
-                    self.remove_ingress(&ing, &storage, &reload_tx).await;
+                    self.remove_ingress(&ing, &storage, &reload_tx, &diagnostics)
+                        .await;
                 }
                 Ok(Event::Init) | Ok(Event::InitDone) => {}
                 Err(e) => {
@@ -699,6 +745,7 @@ impl KubernetesProvider {
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
         acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
     ) {
         let Some(ing_id) = ingress_id(ing) else {
             return;
@@ -713,7 +760,8 @@ impl KubernetesProvider {
             .map(|c| c == self.config.ingress_class)
             .unwrap_or(false);
         if !class_match {
-            self.remove_ingress(ing, storage, reload_tx).await;
+            self.remove_ingress(ing, storage, reload_tx, diagnostics)
+                .await;
             return;
         }
 
@@ -794,6 +842,9 @@ impl KubernetesProvider {
         ing: &Ingress,
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
+        // Threaded for symmetry with apply_ingress; Ingress entries don't
+        // produce diagnostic entries (they don't go through `labels::parse`).
+        _diagnostics: &DiagnosticsStore,
     ) {
         let Some(ing_id) = ingress_id(ing) else {
             return;

--- a/src/provider/nomad.rs
+++ b/src/provider/nomad.rs
@@ -1,8 +1,8 @@
 use crate::config::NomadConfig;
+use crate::diagnostics::{self, DiagnosticsStore};
 use crate::labels::candidate::{Candidate, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
 use crate::labels::source::LabelSource;
-use crate::labels::{self};
 use crate::model::Entrypoint;
 use crate::provider::Provider;
 use anyhow::Context;
@@ -25,10 +25,27 @@ pub struct NomadProvider {
 #[async_trait]
 impl Provider for NomadProvider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        // Trait callers don't share the runtime store; use a throwaway so
+        // diagnostics are at least logged.
+        let throwaway = diagnostics::new_store();
+        self.provide_into(&throwaway).await
+    }
+
+    fn name(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+}
+
+impl NomadProvider {
+    /// Same as `provide()` but writes diagnostics into the supplied store.
+    async fn provide_into(
+        &self,
+        diagnostics: &DiagnosticsStore,
+    ) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
         let candidates = self.collect().await?;
         let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
         for candidate in candidates {
-            let result = labels::parse(&candidate);
+            let result = diagnostics::parse_and_store(diagnostics, &candidate);
             log_diagnostics(&candidate, &result.diagnostics);
             for (key, mut entrypoint) in result.entrypoints {
                 let Some(backend) = entrypoint.backends.first().cloned() else {
@@ -45,10 +62,6 @@ impl Provider for NomadProvider {
             }
         }
         Ok(entrypoints)
-    }
-
-    fn name(&self) -> &'static str {
-        PROVIDER_NAME
     }
 }
 
@@ -170,8 +183,9 @@ impl NomadProvider {
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
         acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
     ) {
-        let new_entrypoints = match self.provide().await {
+        let new_entrypoints = match self.provide_into(diagnostics).await {
             Ok(map) => map,
             Err(e) => {
                 warn!("Nomad poll failed: {e}");
@@ -241,6 +255,7 @@ impl NomadProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         info!(
             "Starting Nomad provider against {} (namespace={}, expose_by_default={}, blocking-wait={}s)",
@@ -255,7 +270,8 @@ impl NomadProvider {
         );
 
         // Initial pull (`index = None` → immediate response).
-        self.poll_once(&storage, &reload_tx, &acme_notify).await;
+        self.poll_once(&storage, &reload_tx, &acme_notify, &diagnostics)
+            .await;
         let mut last_index = self
             .list_services(None)
             .await
@@ -269,7 +285,8 @@ impl NomadProvider {
                 Ok((_, new_index)) => {
                     if new_index != last_index {
                         last_index = new_index;
-                        self.poll_once(&storage, &reload_tx, &acme_notify).await;
+                        self.poll_once(&storage, &reload_tx, &acme_notify, &diagnostics)
+                            .await;
                     }
                     // Same index = wait timed out with no change. Loop right
                     // back into another blocking call — no sleep needed.

--- a/src/provider/podman.rs
+++ b/src/provider/podman.rs
@@ -1,4 +1,5 @@
 use crate::config::{DockerConfig, PodmanConfig};
+use crate::diagnostics::DiagnosticsStore;
 use crate::labels::candidate::Candidate;
 use crate::labels::source::LabelSource;
 use crate::model::Entrypoint;
@@ -30,9 +31,10 @@ impl PodmanProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<tokio::sync::Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         self.inner
-            .start_service(storage, reload_tx, acme_notify)
+            .start_service(storage, reload_tx, acme_notify, diagnostics)
             .await
     }
 }

--- a/src/provider/swarm.rs
+++ b/src/provider/swarm.rs
@@ -1,8 +1,8 @@
 use crate::config::SwarmConfig;
+use crate::diagnostics::{self, DiagnosticsStore};
 use crate::labels::candidate::{Candidate, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
 use crate::labels::source::LabelSource;
-use crate::labels::{self};
 use crate::model::Entrypoint;
 use crate::provider::Provider;
 use async_trait::async_trait;
@@ -157,6 +157,7 @@ impl SwarmProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         if let Err(e) = self.verify_swarm_manager().await {
             error!("Swarm provider disabled: {}", e);
@@ -167,7 +168,7 @@ impl SwarmProvider {
         // before kicking off the loops, so storage is populated by the time
         // start_services() returns.
         if let Err(e) = self
-            .sync_once(&storage, &reload_tx, &acme_notify, true)
+            .sync_once(&storage, &reload_tx, &acme_notify, &diagnostics, true)
             .await
         {
             warn!("Swarm provider initial sync failed: {}", e);
@@ -178,9 +179,10 @@ impl SwarmProvider {
             let storage = Arc::clone(&storage);
             let reload_tx = reload_tx.clone();
             let acme_notify = Arc::clone(&acme_notify);
+            let diagnostics = Arc::clone(&diagnostics);
             tokio::spawn(async move {
                 if let Err(e) = provider
-                    .start_polling(storage, reload_tx, acme_notify)
+                    .start_polling(storage, reload_tx, acme_notify, diagnostics)
                     .await
                 {
                     error!("Swarm polling loop failed: {}", e);
@@ -193,9 +195,10 @@ impl SwarmProvider {
             let storage = Arc::clone(&storage);
             let reload_tx = reload_tx.clone();
             let acme_notify = Arc::clone(&acme_notify);
+            let diagnostics = Arc::clone(&diagnostics);
             tokio::spawn(async move {
                 if let Err(e) = provider
-                    .start_event_listener(storage, reload_tx, acme_notify)
+                    .start_event_listener(storage, reload_tx, acme_notify, diagnostics)
                     .await
                 {
                     error!("Swarm event listener failed: {}", e);
@@ -215,9 +218,10 @@ impl SwarmProvider {
         storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: &mpsc::Sender<()>,
         acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
         log_when_idle: bool,
     ) -> anyhow::Result<bool> {
-        let new_entrypoints = self.provide().await?;
+        let new_entrypoints = self.provide_into(diagnostics).await?;
 
         let needs_update = {
             let storage_read = match storage.read() {
@@ -293,6 +297,7 @@ impl SwarmProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         info!("Starting Swarm event listener");
 
@@ -312,7 +317,7 @@ impl SwarmProvider {
                         if let Some(action) = &event.action {
                             debug!("Swarm event: {} (actor={:?})", action, event.actor);
                             if let Err(e) = self
-                                .sync_once(&storage, &reload_tx, &acme_notify, false)
+                                .sync_once(&storage, &reload_tx, &acme_notify, &diagnostics, false)
                                 .await
                             {
                                 warn!("Swarm sync after event failed: {}", e);
@@ -339,6 +344,7 @@ impl SwarmProvider {
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         reload_tx: mpsc::Sender<()>,
         acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
     ) -> anyhow::Result<()> {
         info!(
             "Starting Swarm provider polling on {} every {}s",
@@ -350,7 +356,7 @@ impl SwarmProvider {
         loop {
             interval.tick().await;
 
-            let new_entrypoints = match self.provide().await {
+            let new_entrypoints = match self.provide_into(&diagnostics).await {
                 Ok(eps) => eps,
                 Err(e) => {
                     warn!("Swarm provider poll failed: {}", e);
@@ -425,11 +431,28 @@ impl SwarmProvider {
 #[async_trait]
 impl Provider for SwarmProvider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        // Trait callers don't share the runtime store; use a throwaway so
+        // diagnostics are at least logged.
+        let throwaway = diagnostics::new_store();
+        self.provide_into(&throwaway).await
+    }
+
+    fn name(&self) -> &'static str {
+        SOURCE
+    }
+}
+
+impl SwarmProvider {
+    /// Same as `provide()` but writes diagnostics into the supplied store.
+    async fn provide_into(
+        &self,
+        diagnostics: &DiagnosticsStore,
+    ) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
         let candidates = self.build_candidates().await.map_err(anyhow::Error::new)?;
         let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
 
         for candidate in candidates {
-            let result = labels::parse(&candidate);
+            let result = diagnostics::parse_and_store(diagnostics, &candidate);
             log_diagnostics(&candidate, &result.diagnostics);
 
             for (key, entrypoint) in result.entrypoints {
@@ -447,10 +470,6 @@ impl Provider for SwarmProvider {
         }
 
         Ok(entrypoints)
-    }
-
-    fn name(&self) -> &'static str {
-        SOURCE
     }
 }
 


### PR DESCRIPTION
## Summary

Make the diagnostics produced by the label parser visible at runtime, both via the API and the dashboard.

### Backend
- New `src/diagnostics.rs`: shared `Arc<RwLock<HashMap<candidate_id, Vec<Diagnostic>>>>` populated by every provider at parse time.
- `Diagnostic` is now `Serialize` (custom impl includes the derived severity).
- `GET /entrypoints` enriched with a per-entrypoint \`diagnostics: []\` field.
- New `GET /diagnostics` endpoint: snapshot of every diagnostic by candidate id.
- Five providers (Docker / Podman / Swarm / Kubernetes / Nomad) updated to call `diagnostics::parse_and_store` instead of `labels::parse`.

### Dashboard
- Per-entrypoint diagnostic badges (\`⚠ N\`, \`✗ N\`) on the entrypoints list, with a native tooltip listing the codes / messages / hints.
- New stat-card \"Diagnostics\" on the entrypoints page (counts warnings + errors).
- New \`/diagnostics\` page: full diagnostic table grouped by candidate id, with severity filter and stat-cards.
- New sidebar entry \"Diagnostics\" with a warning glyph.
- Detail page (`/entrypoints/[id]`) now shows a \"Diagnostics\" section when the entrypoint has any.

## Scope

This PR is the per-entrypoint surface only. Cross-cutting lints (route collisions, ACME-without-TLS) are in a separate follow-up PR (`feat/runtime-collision-lints`) so this one stays small enough to review.

## Test plan

- [x] cargo test (226 passed)
- [x] bash tests/e2e/run-all.sh (50/50 passed)
- [x] manual: dashboard shows badges and the new page