### PR TITLE
Surface runtime collision (W018) and global ACME (W015) lints

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -126,9 +126,8 @@ export interface Entrypoint {
 
 export interface DiagnosticsResponse {
   total: number;
-  /** Diagnostics not attached to any single candidate (e.g. ACME-without-TLS).
-   *  Optional: older API responses may omit this field. */
-  global?: Diagnostic[];
+  /** Diagnostics not attached to any single candidate (e.g. ACME-without-TLS). */
+  global: Diagnostic[];
   items: { candidate_id: string; diagnostics: Diagnostic[] }[];
 }
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
-  import { listEntrypoints, backendKey, type Backend, type Entrypoint } from '$lib/api';
+  import {
+    listEntrypoints,
+    listDiagnostics,
+    backendKey,
+    type Backend,
+    type Diagnostic,
+    type Entrypoint
+  } from '$lib/api';
   import { isAuthenticated } from '$lib/auth';
 
   let entrypoints = $state<Entrypoint[]>([]);
+  let globalDiagnostics = $state<Diagnostic[]>([]);
   let error = $state<string | null>(null);
   let loading = $state(true);
   let lastRefresh = $state<Date | null>(null);
@@ -69,7 +77,9 @@
   async function load(silent = false) {
     if (!silent) loading = true;
     try {
-      entrypoints = await listEntrypoints();
+      const [eps, diags] = await Promise.all([listEntrypoints(), listDiagnostics()]);
+      entrypoints = eps;
+      globalDiagnostics = diags.global ?? [];
       error = null;
       lastRefresh = new Date();
     } catch (e) {
@@ -155,6 +165,23 @@
     </div>
   </div>
 </section>
+
+{#if globalDiagnostics.length > 0}
+  <section class="global-diags">
+    {#each globalDiagnostics as diag}
+      <div class="global-diag global-diag-{diag.severity}">
+        <span class="global-diag-glyph">
+          {#if diag.severity === 'error'}✗{:else if diag.severity === 'warn'}⚠{:else}ℹ{/if}
+        </span>
+        <span class="global-diag-code mono">{diag.code}</span>
+        <span class="global-diag-message">{diag.message}</span>
+        {#if diag.hint}
+          <span class="global-diag-hint">→ {diag.hint}</span>
+        {/if}
+      </div>
+    {/each}
+  </section>
+{/if}
 
 <section class="toolbar">
   <div class="search">
@@ -602,6 +629,64 @@
     background: var(--danger-bg);
     color: var(--danger);
     cursor: help;
+  }
+
+  .global-diags {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .global-diag {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.625rem 0.875rem;
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: var(--radius);
+    background: var(--bg-1);
+    font-size: 0.825rem;
+    flex-wrap: wrap;
+  }
+  .global-diag-error {
+    border-left-color: var(--danger);
+  }
+  .global-diag-warn {
+    border-left-color: var(--warning);
+  }
+  .global-diag-info {
+    border-left-color: var(--accent);
+  }
+  .global-diag-glyph {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+  .global-diag-error .global-diag-glyph {
+    color: var(--danger);
+  }
+  .global-diag-warn .global-diag-glyph {
+    color: var(--warning);
+  }
+  .global-diag-info .global-diag-glyph {
+    color: var(--accent);
+  }
+  .global-diag-code {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 1px 7px;
+    border-radius: 3px;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+  .global-diag-message {
+    color: var(--fg-0);
+  }
+  .global-diag-hint {
+    color: var(--fg-2);
+    font-size: 0.78rem;
+    width: 100%;
+    margin-left: 1.55rem;
   }
 
   .source {

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -24,6 +24,7 @@ pub struct AppState {
     pub users: Vec<ApiUser>,
     pub unhealthy_backends: Arc<RwLock<HashSet<String>>>,
     pub diagnostics: crate::diagnostics::DiagnosticsStore,
+    pub acme_enabled: bool,
 }
 
 /// Build the JSON payload for an entrypoint, augmenting it with the
@@ -160,6 +161,7 @@ pub async fn serve(
     reload_tx: mpsc::Sender<()>,
     unhealthy_backends: Arc<RwLock<HashSet<String>>>,
     diagnostics: crate::diagnostics::DiagnosticsStore,
+    acme_enabled: bool,
 ) -> anyhow::Result<()> {
     if config.users.is_empty() {
         anyhow::bail!(
@@ -173,6 +175,7 @@ pub async fn serve(
         users: config.users.clone(),
         unhealthy_backends,
         diagnostics,
+        acme_enabled,
     };
 
     let protected = Router::new()
@@ -299,12 +302,28 @@ async fn list_entrypoints(State(state): State<AppState>) -> (StatusCode, Json<se
             HashSet::new()
         }
     };
-    let diagnostics = read_diagnostics(&state);
+    let mut diagnostics = read_diagnostics(&state);
+    merge_collision_lints(&storage, &mut diagnostics);
     let list: Vec<serde_json::Value> = storage
         .values()
         .map(|ep| entrypoint_payload(ep, &unhealthy, &diagnostics))
         .collect();
     (StatusCode::OK, Json(serde_json::json!(list)))
+}
+
+/// Compute W018 route-collision diagnostics on the live storage and append
+/// them to the diagnostics map under the entrypoint id so they show up next to
+/// the per-candidate diagnostics. Idempotent — duplicate codes are not
+/// deduplicated, callers should treat the map as additive.
+fn merge_collision_lints(
+    storage: &BTreeMap<String, Entrypoint>,
+    diagnostics: &mut HashMap<String, Vec<crate::labels::diagnostic::Diagnostic>>,
+) {
+    let pairs: Vec<(&str, &Entrypoint)> =
+        storage.iter().map(|(id, ep)| (id.as_str(), ep)).collect();
+    for (ep_id, diag) in crate::labels::lint::lint_collection(&pairs) {
+        diagnostics.entry(ep_id).or_default().push(diag);
+    }
 }
 
 fn read_diagnostics(
@@ -322,11 +341,21 @@ fn read_diagnostics(
     }
 }
 
-/// `GET /diagnostics` — flat snapshot of all diagnostics by candidate id.
+/// `GET /diagnostics` — snapshot of every per-entrypoint diagnostic plus
+/// recomputed global lints (e.g. ACME-without-TLS) and runtime collision
+/// lints (W018) that are not stored at parse time.
 async fn list_diagnostics(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
-    let snapshot = crate::diagnostics::snapshot(&state.diagnostics);
-    let total: usize = snapshot.iter().map(|(_, v)| v.len()).sum();
-    let by_candidate: Vec<serde_json::Value> = snapshot
+    let mut grouped: HashMap<String, Vec<crate::labels::diagnostic::Diagnostic>> =
+        crate::diagnostics::snapshot(&state.diagnostics)
+            .into_iter()
+            .collect();
+
+    if let Ok(storage) = state.storage.read() {
+        merge_collision_lints(&storage, &mut grouped);
+    }
+
+    let mut total: usize = grouped.values().map(|v| v.len()).sum();
+    let mut by_candidate: Vec<serde_json::Value> = grouped
         .into_iter()
         .map(|(id, diags)| {
             serde_json::json!({
@@ -335,13 +364,47 @@ async fn list_diagnostics(State(state): State<AppState>) -> (StatusCode, Json<se
             })
         })
         .collect();
+    // Stable order so the dashboard doesn't shuffle on every poll.
+    by_candidate.sort_by(|a, b| {
+        a["candidate_id"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["candidate_id"].as_str().unwrap_or(""))
+    });
+
+    let global = global_lints(&state);
+    total += global.len();
+
     (
         StatusCode::OK,
         Json(serde_json::json!({
             "total": total,
+            "global": global,
             "items": by_candidate,
         })),
     )
+}
+
+/// Recompute lints that span the full entrypoint set (not attached to a
+/// single candidate). Today: only `W015 ACME enabled but no entrypoint
+/// declares tls=true`.
+fn global_lints(state: &AppState) -> Vec<crate::labels::diagnostic::Diagnostic> {
+    let storage = match state.storage.read() {
+        Ok(g) => g,
+        Err(e) => {
+            error!(
+                "internal state corrupted (configuration store), restart required: {}",
+                e
+            );
+            return Vec::new();
+        }
+    };
+    let eps: Vec<&Entrypoint> = storage.values().collect();
+    let mut out = Vec::new();
+    if let Some(d) = crate::labels::lint::lint_acme_without_tls(state.acme_enabled, &eps) {
+        out.push(d);
+    }
+    out
 }
 
 async fn get_entrypoint(
@@ -372,7 +435,8 @@ async fn get_entrypoint(
         }
     };
 
-    let diagnostics = read_diagnostics(&state);
+    let mut diagnostics = read_diagnostics(&state);
+    merge_collision_lints(&storage, &mut diagnostics);
 
     match storage.get(&id) {
         Some(entrypoint) => (
@@ -590,6 +654,7 @@ mod tests {
             users,
             unhealthy_backends: Arc::new(RwLock::new(HashSet::new())),
             diagnostics: crate::diagnostics::new_store(),
+            acme_enabled: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let api_config = config.api.clone();
     let unhealthy_api = Arc::clone(&unhealthy_backends);
     let diagnostics_api = Arc::clone(&diagnostics_store);
+    let acme_enabled_api = acme_enabled;
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
@@ -174,6 +175,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 reload_tx_api,
                 unhealthy_api,
                 diagnostics_api,
+                acme_enabled_api,
             )
             .await?;
         }


### PR DESCRIPTION
## Summary

Cross-cutting lints (route collisions and ACME-without-TLS) are computed by the CLI \`sozune validate\` command but were not surfaced at runtime. This PR adds them on top of the per-entrypoint diagnostics surface introduced in #46.

### Backend
- \`AppState\` carries \`acme_enabled: bool\` so the API can recompute \`W015 ACME-without-TLS\` from the live storage.
- New \`merge_collision_lints\` helper attaches \`W018\` to each entrypoint that shares its \`(host, path)\` with another. Computed on the fly inside \`/entrypoints\`, \`/entrypoints/{id}\` and \`/diagnostics\`.
- \`/diagnostics\` response gains a top-level \`global: []\` field.

### Dashboard
- New banner above the entrypoints table when global diagnostics exist (e.g. \`W015\`).

## Test plan

- [x] cargo test (226 passed)
- [x] bash tests/e2e/run-all.sh (50/50 passed)
- [x] manual: create two Docker containers with the same host+path, observe \`W018\` on both in /diagnostics