### PR TITLE
Sidebar diagnostics badge and styled popover

### DIFF
--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import '../app.css';
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { clearAuth, identity, isAuthenticated } from '$lib/auth';
+  import { listDiagnostics } from '$lib/api';
 
   let { children } = $props();
 
@@ -15,6 +16,12 @@
     { href: './settings', label: 'Settings', icon: 'gear' }
   ];
 
+  /** Number of error+warn diagnostics; shown as a badge on the Diagnostics
+   *  nav entry. Polled here so any page benefits from it without each page
+   *  having to fetch it separately. */
+  let diagBadge = $state(0);
+  let diagPoll: ReturnType<typeof setInterval> | null = null;
+
   function isActive(href: string): boolean {
     const current = $page.url.pathname.replace(/\/$/, '');
     const target = href.replace(/^\.\//, '/').replace(/\/$/, '');
@@ -24,10 +31,29 @@
 
   let onLoginPage = $derived($page.url.pathname.endsWith('/login'));
 
+  async function refreshDiagBadge() {
+    try {
+      const r = await listDiagnostics();
+      const all = [...(r.global ?? []), ...r.items.flatMap((i) => i.diagnostics)];
+      diagBadge = all.filter((d) => d.severity === 'error' || d.severity === 'warn').length;
+    } catch {
+      diagBadge = 0;
+    }
+  }
+
   onMount(() => {
     if (!onLoginPage && !isAuthenticated()) {
       goto('./login');
+      return;
     }
+    if (!onLoginPage) {
+      void refreshDiagBadge();
+      diagPoll = setInterval(() => void refreshDiagBadge(), 5000);
+    }
+  });
+
+  onDestroy(() => {
+    if (diagPoll) clearInterval(diagPoll);
   });
 
   function logout() {
@@ -66,6 +92,9 @@
               {/if}
             </span>
             <span>{item.label}</span>
+            {#if item.label === 'Diagnostics' && diagBadge > 0}
+              <span class="nav-badge">{diagBadge}</span>
+            {/if}
           </a>
         {/each}
       </nav>
@@ -181,6 +210,18 @@
   .nav-icon :global(svg) {
     width: 16px;
     height: 16px;
+  }
+
+  .nav-badge {
+    margin-left: auto;
+    background: var(--warning);
+    color: #1a1a1a;
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 999px;
+    line-height: 1.4;
+    font-variant-numeric: tabular-nums;
   }
 
   .sidebar-footer {

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -60,10 +60,19 @@
     };
   }
 
-  function diagTooltip(ep: Entrypoint): string {
-    return (ep.diagnostics ?? [])
-      .map((d) => `${d.code} ${d.message}${d.hint ? `\n  → ${d.hint}` : ''}`)
-      .join('\n\n');
+  /** Entrypoint id whose diagnostic popover is currently open. Click on a
+   *  badge toggles; click anywhere else closes. */
+  let openDiagFor = $state<string | null>(null);
+
+  function toggleDiagPopover(epId: string, ev: Event) {
+    // Stop both the row's `goto` handler and the window-level closer.
+    ev.stopPropagation();
+    ev.preventDefault();
+    openDiagFor = openDiagFor === epId ? null : epId;
+  }
+
+  function closeDiagPopover() {
+    openDiagFor = null;
   }
 
   function isBackendDown(ep: Entrypoint, backend: Backend): boolean {
@@ -96,10 +105,12 @@
     }
     void load();
     poll = setInterval(() => void load(true), 5000);
+    window.addEventListener('click', closeDiagPopover);
   });
 
   onDestroy(() => {
     if (poll) clearInterval(poll);
+    window.removeEventListener('click', closeDiagPopover);
   });
 
   function timeAgo(d: Date | null): string {
@@ -274,11 +285,49 @@
                 {#if ep.config.sticky_session}<span class="chip">sticky</span>{/if}
                 {#if ep.config.compress}<span class="chip">gzip</span>{/if}
                 {#if ep.config.strip_prefix}<span class="chip">strip</span>{/if}
-                {#if diagSummary(ep).err > 0}
-                  <span class="chip chip-err" title={diagTooltip(ep)}>✗ {diagSummary(ep).err}</span>
-                {/if}
-                {#if diagSummary(ep).warn > 0}
-                  <span class="chip chip-warn" title={diagTooltip(ep)}>⚠ {diagSummary(ep).warn}</span>
+                {#if diagSummary(ep).err + diagSummary(ep).warn > 0}
+                  <span class="diag-anchor">
+                    {#if diagSummary(ep).err > 0}
+                      <button
+                        type="button"
+                        class="chip chip-err"
+                        onclick={(ev) => toggleDiagPopover(ep.id, ev)}
+                      >
+                        ✗ {diagSummary(ep).err}
+                      </button>
+                    {/if}
+                    {#if diagSummary(ep).warn > 0}
+                      <button
+                        type="button"
+                        class="chip chip-warn"
+                        onclick={(ev) => toggleDiagPopover(ep.id, ev)}
+                      >
+                        ⚠ {diagSummary(ep).warn}
+                      </button>
+                    {/if}
+                    {#if openDiagFor === ep.id}
+                      <div
+                        class="diag-popover"
+                        role="dialog"
+                        onclick={(ev) => ev.stopPropagation()}
+                      >
+                        {#each ep.diagnostics ?? [] as diag}
+                          <div class="pop-diag pop-diag-{diag.severity}">
+                            <div class="pop-head">
+                              <span class="pop-glyph">
+                                {#if diag.severity === 'error'}✗{:else if diag.severity === 'warn'}⚠{:else}ℹ{/if}
+                              </span>
+                              <span class="pop-code mono">{diag.code}</span>
+                              <span class="pop-message">{diag.message}</span>
+                            </div>
+                            {#if diag.hint}
+                              <div class="pop-hint">→ {diag.hint}</div>
+                            {/if}
+                          </div>
+                        {/each}
+                      </div>
+                    {/if}
+                  </span>
                 {/if}
               </div>
             </td>
@@ -623,12 +672,78 @@
   .chip-warn {
     background: rgba(240, 180, 41, 0.18);
     color: var(--warning);
-    cursor: help;
+    cursor: pointer;
+    border: none;
+    font-family: inherit;
   }
   .chip-err {
     background: var(--danger-bg);
     color: var(--danger);
-    cursor: help;
+    cursor: pointer;
+    border: none;
+    font-family: inherit;
+  }
+
+  .diag-anchor {
+    position: relative;
+    display: inline-flex;
+    gap: 3px;
+  }
+  .diag-popover {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 20;
+    min-width: 320px;
+    max-width: 480px;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0.5rem;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    cursor: default;
+    text-align: left;
+    white-space: normal;
+  }
+  .pop-diag {
+    border-left: 3px solid var(--border);
+    padding: 0.45rem 0.625rem;
+    background: var(--bg-2);
+    border-radius: 4px;
+  }
+  .pop-diag-error { border-left-color: var(--danger); }
+  .pop-diag-warn { border-left-color: var(--warning); }
+  .pop-diag-info { border-left-color: var(--accent); }
+  .pop-head {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+  }
+  .pop-glyph { line-height: 1; }
+  .pop-diag-error .pop-glyph { color: var(--danger); }
+  .pop-diag-warn .pop-glyph { color: var(--warning); }
+  .pop-diag-info .pop-glyph { color: var(--accent); }
+  .pop-code {
+    background: var(--bg-3);
+    color: var(--fg-1);
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 0.65rem;
+    font-weight: 600;
+  }
+  .pop-message {
+    color: var(--fg-0);
+    flex: 1;
+  }
+  .pop-hint {
+    color: var(--fg-2);
+    font-size: 0.72rem;
+    margin-top: 0.25rem;
+    margin-left: 1.3rem;
   }
 
   .global-diags {


### PR DESCRIPTION
## Summary

Two cosmetic touch-ups on top of the existing diagnostics surface:

- **Sidebar badge**: a counter showing the total of error+warn diagnostics is rendered next to the \"Diagnostics\" nav entry. Polled from `/diagnostics` every 5s, so any page benefits without each one fetching it.
- **Popover replaces native tooltip**: on the entrypoints list, the `⚠ N` / `✗ N` chips are now buttons that open a small styled popover with the full diagnostic cards (severity glyph, code, message, hint). Clicking outside closes it; the row's own `goto` handler is suppressed when the popover is targeted.

## Test plan

- [x] `bun run build` passes in `dashboard/`
- [x] manual: badge updates as containers come and go; popover opens, closes on outside click, and does not navigate to the detail page