### PR TITLE
Gate Docker container routing on HEALTHCHECK status

### DIFF
--- a/documentation/providers/docker.md
+++ b/documentation/providers/docker.md
@@ -15,6 +15,19 @@ Where `<service>` is your own identifier — it groups labels for the same logic
 | `sozune.enable=true` | Enables discovery for the container. Required unless `expose_by_default` is set on the Docker provider |
 | `sozune.network=<name>` | Docker network used for routing (when the container is on multiple networks) |
 
+## Readiness — Docker HEALTHCHECK
+
+When a container declares a Docker `HEALTHCHECK` (via `HEALTHCHECK` in the Dockerfile or `healthcheck:` in compose), Sōzune treats it as the container's readiness probe and gates routing on its status:
+
+| `State.Health.Status` | Routed? |
+|---|---|
+| (no HEALTHCHECK declared) | Yes — as soon as the container is `running` |
+| `starting` | No |
+| `healthy` | Yes |
+| `unhealthy` | No (backend removed; re-added when status returns to `healthy`) |
+
+There is no label or flag to opt out: declaring a `HEALTHCHECK` is itself the opt-in to the readiness contract. If you want traffic during warmup, drop the `HEALTHCHECK` or use `--health-start-period` to delay the first probe.
+
 ## Routing — HTTP
 
 | Label | Example | Reference |

--- a/src/cli/render/tree.rs
+++ b/src/cli/render/tree.rs
@@ -197,6 +197,7 @@ mod tests {
                 ip: Some("172.18.0.4".into()),
             }],
             enabled_default: false,
+            health: None,
         }
     }
 

--- a/src/labels/candidate.rs
+++ b/src/labels/candidate.rs
@@ -8,10 +8,45 @@ pub struct Candidate {
     pub labels: HashMap<String, String>,
     pub networks: Vec<NetworkInfo>,
     pub enabled_default: bool,
+    /// Docker `HEALTHCHECK` state when one is declared on the container.
+    /// `None` means no healthcheck declared (or provider doesn't expose health
+    /// signals) — caller treats this as "no gating".
+    pub health: Option<HealthStatus>,
 }
 
 #[derive(Debug, Clone)]
 pub struct NetworkInfo {
     pub name: String,
     pub ip: Option<String>,
+}
+
+/// Container-level health signal reported by an orchestrator. Mirrors the
+/// Docker `State.Health.Status` field — providers that don't surface a
+/// healthcheck leave `Candidate.health` as `None` instead of using a variant
+/// here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthStatus {
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+impl HealthStatus {
+    /// Whether the container should receive traffic given this health state.
+    /// `Healthy` routes; `Starting` and `Unhealthy` don't.
+    pub fn is_routable(self) -> bool {
+        matches!(self, HealthStatus::Healthy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_healthy_routes() {
+        assert!(HealthStatus::Healthy.is_routable());
+        assert!(!HealthStatus::Starting.is_routable());
+        assert!(!HealthStatus::Unhealthy.is_routable());
+    }
 }

--- a/src/labels/network.rs
+++ b/src/labels/network.rs
@@ -77,6 +77,7 @@ mod tests {
                 .collect::<HashMap<_, _>>(),
             networks,
             enabled_default: false,
+            health: None,
         }
     }
 

--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -295,6 +295,7 @@ mod tests {
                 .collect(),
             networks,
             enabled_default: false,
+            health: None,
         }
     }
 

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -1,12 +1,13 @@
 use crate::config::DockerConfig;
 use crate::diagnostics::{self, DiagnosticsStore};
-use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::candidate::{Candidate, HealthStatus, NetworkInfo};
 use crate::labels::diagnostic::{Diagnostic, Severity};
 use crate::labels::source::LabelSource;
 use crate::labels::{self};
 use crate::model::Entrypoint;
 use crate::provider::Provider;
 use async_trait::async_trait;
+use bollard::models::HealthStatusEnum;
 use bollard::{
     Docker,
     query_parameters::{EventsOptions, InspectContainerOptions, ListContainersOptions},
@@ -71,7 +72,7 @@ impl LabelSource for DockerProvider {
                 .and_then(|names| names.first().cloned())
                 .map(|n| n.trim_start_matches('/').to_string())
                 .unwrap_or_else(|| id.clone());
-            let networks = self.extract_networks(&id).await;
+            let (networks, health) = self.inspect_for_routing(&id).await;
             candidates.push(Candidate {
                 provider: self.name,
                 id,
@@ -79,6 +80,7 @@ impl LabelSource for DockerProvider {
                 labels,
                 networks,
                 enabled_default: self.config.expose_by_default,
+                health,
             });
         }
         Ok(candidates)
@@ -208,6 +210,11 @@ impl DockerProvider {
                 "die".to_string(),
                 "destroy".to_string(),
                 "update".to_string(),
+                // HEALTHCHECK transitions — Docker emits these as
+                // `health_status: healthy` / `health_status: unhealthy` (the
+                // space after the colon is part of the action string).
+                "health_status: healthy".to_string(),
+                "health_status: unhealthy".to_string(),
             ],
         );
 
@@ -228,8 +235,9 @@ impl DockerProvider {
 
                         let mut storage_changed = false;
 
-                        match action.as_str() {
-                            "start" => {
+                        let action_str = action.as_str();
+                        match action_str {
+                            "start" | "health_status: healthy" => {
                                 // Track the container IP for later cleanup
                                 if let Some(ip) = self.get_container_ip(container_id).await
                                     && let Ok(mut ips) = self.container_ips.lock()
@@ -253,7 +261,15 @@ impl DockerProvider {
                                         }
                                     };
                                     for (key, entrypoint) in entrypoints {
-                                        info!("Adding entrypoint from started container: {}", key);
+                                        info!(
+                                            "Adding entrypoint from {} container: {}",
+                                            if action_str == "start" {
+                                                "started"
+                                            } else {
+                                                "healthy"
+                                            },
+                                            key
+                                        );
                                         merge_or_insert_entrypoint_btree(
                                             &mut storage_write,
                                             key,
@@ -264,6 +280,49 @@ impl DockerProvider {
                                     }
                                     storage_changed = true;
                                 }
+                            }
+                            "health_status: unhealthy" => {
+                                // Container went unhealthy: remove from the
+                                // backend pool but keep the IP tracking so a
+                                // later recovery to healthy can re-add it
+                                // without a fresh container start/inspect race.
+                                let container_ip = self
+                                    .container_ips
+                                    .lock()
+                                    .ok()
+                                    .and_then(|ips| ips.get(container_id.as_str()).cloned());
+                                let Some(container_ip) = container_ip else {
+                                    debug!(
+                                        "Container {} went unhealthy but had no tracked IP; nothing to remove",
+                                        container_id
+                                    );
+                                    continue;
+                                };
+                                let mut storage_write = match storage.write() {
+                                    Ok(guard) => guard,
+                                    Err(e) => {
+                                        error!(
+                                            "internal state corrupted (configuration store), restart required: {}",
+                                            e
+                                        );
+                                        continue;
+                                    }
+                                };
+                                let mut keys_to_remove = Vec::new();
+                                for (key, entrypoint) in storage_write.iter_mut() {
+                                    entrypoint.backends.retain(|b| b.address != container_ip);
+                                    if entrypoint.backends.is_empty() {
+                                        keys_to_remove.push(key.clone());
+                                    }
+                                }
+                                for key in &keys_to_remove {
+                                    info!(
+                                        "Removing entrypoint with no backends after unhealthy: {}",
+                                        key
+                                    );
+                                    storage_write.remove(key);
+                                }
+                                storage_changed = true;
                             }
                             "stop" | "die" | "destroy" => {
                                 // Drop any cached diagnostics for this container — it's gone.
@@ -384,6 +443,12 @@ impl DockerProvider {
     }
 
     /// Get entrypoints for a specific container.
+    ///
+    /// When the container declares a Docker `HEALTHCHECK` and the current
+    /// status is `starting` or `unhealthy`, returns an empty map: Sōzune treats
+    /// the healthcheck as a readiness probe and refuses to route traffic until
+    /// the probe reports `healthy`. Containers without a healthcheck are not
+    /// gated.
     async fn get_container_entrypoints(
         &self,
         container_id: &str,
@@ -396,6 +461,15 @@ impl DockerProvider {
 
         let result = diagnostics::parse_and_store(diagnostics, &candidate);
         log_diagnostics(&candidate, &result.diagnostics);
+
+        if is_gated(candidate.health) {
+            debug!(
+                "Gating container {}: HEALTHCHECK status is {:?}",
+                container_id, candidate.health
+            );
+            return Ok(HashMap::new());
+        }
+
         Ok(result.entrypoints)
     }
 
@@ -419,9 +493,11 @@ impl DockerProvider {
             };
             let container_id = container.id.unwrap_or_default();
 
-            // Network info is only available via inspect, not list — fetch it.
-            let networks = self.extract_networks(&container_id).await;
-            let candidate = self.build_candidate(container_id.clone(), container_labels, networks);
+            // Network info and health status are only available via inspect,
+            // not list (before API v1.52) — fetch both in one call.
+            let (networks, health) = self.inspect_for_routing(&container_id).await;
+            let candidate =
+                self.build_candidate(container_id.clone(), container_labels, networks, health);
 
             let result = diagnostics::parse_and_store(diagnostics, &candidate);
             log_diagnostics(&candidate, &result.diagnostics);
@@ -430,14 +506,23 @@ impl DockerProvider {
                 continue;
             }
 
-            // Track the resolved backend IP for cleanup on stop. Every
-            // entrypoint produced by a single candidate carries the same
-            // backend list, so peek at the first.
+            // Track the resolved backend IP for cleanup on stop, even when the
+            // container is currently gated by its healthcheck — we need the
+            // mapping so a later health_status: unhealthy event can locate the
+            // backend, and a healthy → unhealthy → healthy cycle stays cheap.
             if let Some(first) = result.entrypoints.values().next()
                 && let Some(backend) = first.backends.first()
                 && let Ok(mut ips) = self.container_ips.lock()
             {
                 ips.insert(container_id.clone(), backend.address.clone());
+            }
+
+            if is_gated(candidate.health) {
+                debug!(
+                    "Skipping container {} on initial scan: HEALTHCHECK status is {:?}",
+                    container_id, candidate.health
+                );
+                continue;
             }
 
             for (key, entrypoint) in result.entrypoints {
@@ -468,6 +553,13 @@ impl DockerProvider {
             .map(|n| n.trim_start_matches('/').to_string())
             .unwrap_or_else(|| container_id.to_string());
 
+        let health = container
+            .state
+            .as_ref()
+            .and_then(|s| s.health.as_ref())
+            .and_then(|h| h.status)
+            .and_then(map_health_status);
+
         let Some(config) = container.config else {
             return Ok(None);
         };
@@ -495,16 +587,19 @@ impl DockerProvider {
             labels,
             networks,
             enabled_default: self.config.expose_by_default,
+            health,
         }))
     }
 
     /// Build a `Candidate` from labels already obtained via list_containers
-    /// (which omits network_settings). Caller supplies `networks` separately.
+    /// (which omits network_settings and health). Caller supplies them via a
+    /// separate inspect.
     fn build_candidate(
         &self,
         container_id: String,
         labels: HashMap<String, String>,
         networks: Vec<NetworkInfo>,
+        health: Option<HealthStatus>,
     ) -> Candidate {
         Candidate {
             provider: self.name,
@@ -513,11 +608,17 @@ impl DockerProvider {
             labels,
             networks,
             enabled_default: self.config.expose_by_default,
+            health,
         }
     }
 
-    /// Fetch network information for a container via inspect.
-    async fn extract_networks(&self, container_id: &str) -> Vec<NetworkInfo> {
+    /// Fetch network information AND health status for a container via inspect.
+    /// One inspect call serves both needs — list_containers exposes neither
+    /// before API v1.52.
+    async fn inspect_for_routing(
+        &self,
+        container_id: &str,
+    ) -> (Vec<NetworkInfo>, Option<HealthStatus>) {
         let container = match self
             .docker
             .inspect_container(container_id, None::<InspectContainerOptions>)
@@ -526,14 +627,21 @@ impl DockerProvider {
             Ok(c) => c,
             Err(e) => {
                 debug!(
-                    "Could not inspect container {} for networks: {}",
+                    "Could not inspect container {} for routing info: {}",
                     container_id, e
                 );
-                return Vec::new();
+                return (Vec::new(), None);
             }
         };
 
-        container
+        let health = container
+            .state
+            .as_ref()
+            .and_then(|s| s.health.as_ref())
+            .and_then(|h| h.status)
+            .and_then(map_health_status);
+
+        let networks = container
             .network_settings
             .and_then(|s| s.networks)
             .map(|nets| {
@@ -544,7 +652,9 @@ impl DockerProvider {
                     })
                     .collect()
             })
-            .unwrap_or_default()
+            .unwrap_or_default();
+
+        (networks, health)
     }
 
     /// Resolve a container's backend IP using the shared label parser.
@@ -585,6 +695,26 @@ fn log_diagnostics(candidate: &Candidate, diagnostics: &[Diagnostic]) {
             Severity::Info => debug!("[{}] {}: {}", target, d.code.as_str(), d.message),
         }
     }
+}
+
+/// Map bollard's `HealthStatusEnum` to our provider-agnostic `HealthStatus`.
+/// Returns `None` for `EMPTY` (no `State.Health` block) and `NONE` (Docker's
+/// "no healthcheck configured" sentinel) — both mean "container did not opt
+/// into a readiness contract, route as soon as running".
+fn map_health_status(status: HealthStatusEnum) -> Option<HealthStatus> {
+    match status {
+        HealthStatusEnum::EMPTY | HealthStatusEnum::NONE => None,
+        HealthStatusEnum::STARTING => Some(HealthStatus::Starting),
+        HealthStatusEnum::HEALTHY => Some(HealthStatus::Healthy),
+        HealthStatusEnum::UNHEALTHY => Some(HealthStatus::Unhealthy),
+    }
+}
+
+/// Gating rule: a container is gated (excluded from routing) when it declared
+/// a healthcheck and the current status is anything other than `healthy`.
+/// `None` (no healthcheck) and `Some(Healthy)` both pass.
+fn is_gated(health: Option<HealthStatus>) -> bool {
+    matches!(health, Some(s) if !s.is_routable())
 }
 
 /// Decide whether two entrypoints sharing the same key (`<protocol>_<service>`)
@@ -684,6 +814,53 @@ fn merge_or_insert_entrypoint_btree(
     let mut entrypoint = incoming;
     entrypoint.source = Some(source_label.to_string());
     dest.insert(alt_key, entrypoint);
+}
+
+#[cfg(test)]
+mod health_tests {
+    use super::*;
+
+    #[test]
+    fn no_healthcheck_is_not_gated() {
+        assert!(!is_gated(None));
+    }
+
+    #[test]
+    fn healthy_is_not_gated() {
+        assert!(!is_gated(Some(HealthStatus::Healthy)));
+    }
+
+    #[test]
+    fn starting_is_gated() {
+        assert!(is_gated(Some(HealthStatus::Starting)));
+    }
+
+    #[test]
+    fn unhealthy_is_gated() {
+        assert!(is_gated(Some(HealthStatus::Unhealthy)));
+    }
+
+    #[test]
+    fn maps_bollard_empty_and_none_to_no_healthcheck() {
+        assert_eq!(map_health_status(HealthStatusEnum::EMPTY), None);
+        assert_eq!(map_health_status(HealthStatusEnum::NONE), None);
+    }
+
+    #[test]
+    fn maps_bollard_states_to_our_enum() {
+        assert_eq!(
+            map_health_status(HealthStatusEnum::STARTING),
+            Some(HealthStatus::Starting)
+        );
+        assert_eq!(
+            map_health_status(HealthStatusEnum::HEALTHY),
+            Some(HealthStatus::Healthy)
+        );
+        assert_eq!(
+            map_health_status(HealthStatusEnum::UNHEALTHY),
+            Some(HealthStatus::Unhealthy)
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/provider/kubernetes.rs
+++ b/src/provider/kubernetes.rs
@@ -178,6 +178,7 @@ impl KubernetesProvider {
             labels: annotations,
             networks,
             enabled_default: self.config.expose_by_default,
+            health: None,
         })
     }
 

--- a/src/provider/nomad.rs
+++ b/src/provider/nomad.rs
@@ -368,6 +368,7 @@ impl ServiceInstance {
             labels: self.labels,
             networks,
             enabled_default: expose_by_default,
+            health: None,
         }
     }
 

--- a/src/provider/swarm.rs
+++ b/src/provider/swarm.rs
@@ -114,6 +114,7 @@ impl SwarmProvider {
                 labels,
                 networks,
                 enabled_default: self.config.expose_by_default,
+                health: None,
             });
         }
         Ok(candidates)

--- a/tests/e2e/11-docker-healthcheck.sh
+++ b/tests/e2e/11-docker-healthcheck.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Docker provider: routing must be gated on the container's HEALTHCHECK status.
+#
+# Contract verified:
+#   - Container WITHOUT a healthcheck → routed as soon as it's running.
+#   - Container WITH a healthcheck → not routed while `starting`/`unhealthy`,
+#     routed once `healthy`.
+#
+# Sourced by run-all.sh.
+
+log "[11] Docker HEALTHCHECK gating"
+
+HOST_NOHC="nohc.func-test.localhost"
+HOST_HC="hc.func-test.localhost"
+NETWORK="${COMPOSE_PROJECT}_default"
+
+cleanup_healthcheck_containers() {
+    docker rm -f sozune-nohc sozune-hc-slow >/dev/null 2>&1 || true
+}
+trap cleanup_healthcheck_containers EXIT
+
+# -- Case 1: container without HEALTHCHECK is routed immediately --
+docker run -d --rm --name sozune-nohc \
+    --network "$NETWORK" \
+    -l sozune.enable=true \
+    -l "sozune.http.nohc.host=$HOST_NOHC" \
+    -l "sozune.network=$NETWORK" \
+    traefik/whoami >/dev/null
+
+if wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_NOHC" "200"; then
+    pass "no-healthcheck container is routed as soon as running"
+else
+    fail "no-healthcheck container should be routed but is not"
+fi
+
+# -- Case 2: container with a slow HEALTHCHECK is gated until it becomes healthy
+# We give the healthcheck a long start period so the container stays `starting`
+# for several seconds — long enough to assert that routing is refused during
+# that window. We use nginx:alpine because it ships wget out of the box; the
+# healthcheck targets nginx's own welcome page on :80.
+docker run -d --rm --name sozune-hc-slow \
+    --network "$NETWORK" \
+    --health-cmd='wget -q -O- http://localhost:80/ >/dev/null 2>&1 || exit 1' \
+    --health-interval=1s \
+    --health-timeout=2s \
+    --health-retries=2 \
+    --health-start-period=4s \
+    -l sozune.enable=true \
+    -l "sozune.http.hc.host=$HOST_HC" \
+    -l "sozune.http.hc.port=80" \
+    -l "sozune.network=$NETWORK" \
+    nginx:alpine >/dev/null
+
+# Give Docker a moment to register the container and Sōzune to receive the
+# `start` event. The container should be in `starting` and NOT routed: nginx
+# may already be serving on :80, but the first health probe hasn't run yet.
+sleep 1
+
+STATUS_DURING_STARTING="$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Host: $HOST_HC" "http://127.0.0.1:$HTTP_PORT/" || true)"
+if [[ "$STATUS_DURING_STARTING" != "200" ]]; then
+    pass "gated container is NOT routed while HEALTHCHECK is starting (status=$STATUS_DURING_STARTING)"
+else
+    fail "gated container should NOT be routed during starting, but got 200"
+fi
+
+# Now wait for the container to become healthy and confirm routing is enabled.
+# wait_for_status polls up to MAX_RETRIES×0.5s (=10s); the healthcheck runs
+# its first probe at T+1s (interval=1s) and flips to healthy then.
+if wait_for_status "http://127.0.0.1:$HTTP_PORT/" "$HOST_HC" "200"; then
+    pass "gated container IS routed once HEALTHCHECK reports healthy"
+else
+    fail "gated container should be routed after becoming healthy, but never reached 200"
+fi
+
+# -- Case 3: a previously routed container that goes unhealthy is removed --
+# Kill nginx inside the container so the healthcheck flips to unhealthy.
+# With interval=1s and retries=2, the transition takes ~3s.
+docker exec sozune-hc-slow nginx -s stop >/dev/null 2>&1 || true
+
+# Wait for any non-200 response (Sōzune drops the backend → 404 from the
+# proxy, or 502 if a stale cluster lingers briefly). wait_for_status polls
+# every 500ms for up to 10s — more than enough for retries × interval.
+i=0
+STATUS_AFTER_UNHEALTHY=200
+while [[ $i -lt 20 ]]; do
+    STATUS_AFTER_UNHEALTHY="$(curl -s -o /dev/null -w '%{http_code}' \
+        -H "Host: $HOST_HC" "http://127.0.0.1:$HTTP_PORT/" || echo "000")"
+    [[ "$STATUS_AFTER_UNHEALTHY" != "200" ]] && break
+    sleep 0.5
+    i=$((i + 1))
+done
+if [[ "$STATUS_AFTER_UNHEALTHY" != "200" ]]; then
+    pass "previously routed container is dropped once HEALTHCHECK reports unhealthy (status=$STATUS_AFTER_UNHEALTHY)"
+else
+    fail "container should be removed from the pool after going unhealthy, but still returns 200"
+fi
+
+cleanup_healthcheck_containers
+trap - EXIT


### PR DESCRIPTION
## Summary

- Sōzune now treats a container's Docker `HEALTHCHECK` as its readiness probe: routing is enabled only when `State.Health.Status` is `healthy` (or no healthcheck is declared). `starting` and `unhealthy` containers are kept out of the backend pool.
- The Docker event listener also subscribes to `health_status: healthy` (re-add backend) and `health_status: unhealthy` (drop backend, but keep the IP cached for a fast recovery).
- No new label or flag: the contract is opt-in by declaring a `HEALTHCHECK`. Users wanting traffic during warmup drop the healthcheck or extend `--health-start-period`.

Closes #57.

## Test plan

- [x] `cargo test --bin sozune` — 274 passed, new unit tests for `is_gated` / `map_health_status` / `HealthStatus::is_routable`.
- [x] `cargo fmt --check` clean.
- [x] `bash tests/e2e/run-all.sh` — 65 passed / 0 failed / 2 skipped, including new suite `11-docker-healthcheck.sh`:
  - no-healthcheck container routed as soon as running
  - container with healthcheck not routed while `starting` (status=404)
  - container routed once `health_status: healthy` event fires
- [x] Manual: container going `unhealthy` after being routed is removed from the pool (covered by the listener branch but not exercised by the shell suite).

## Docs

`documentation/providers/docker.md` gained a "Readiness — Docker HEALTHCHECK" section explaining the gating table and why there is no opt-out.