### PR TITLE
Collapse functions with too many arguments via context structs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,15 +122,17 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let handle = tokio::runtime::Handle::current();
     let proxy_task = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         proxy::backend::init_proxy(
-            storage_proxy,
+            proxy::backend::ProxyInputs {
+                storage: storage_proxy,
+                shutdown_rx,
+                reload_rx,
+                cert_rx,
+                acme_challenge_port,
+                middleware_state: middleware_state_proxy,
+                middleware_port,
+                handle,
+            },
             &proxy_config,
-            shutdown_rx,
-            reload_rx,
-            cert_rx,
-            acme_challenge_port,
-            middleware_state_proxy,
-            middleware_port,
-            handle,
         )
     });
 

--- a/src/provider/kubernetes/mod.rs
+++ b/src/provider/kubernetes/mod.rs
@@ -36,6 +36,17 @@ type EndpointsCache = Arc<RwLock<HashMap<String, HashMap<String, Vec<String>>>>>
 /// touching what other Ingresses or annotated Services produced.
 type IngressOwnership = Arc<RwLock<HashMap<String, HashSet<String>>>>;
 
+/// References to the four shared values every watcher needs: the storage,
+/// the reload channel, the ACME notifier, and the diagnostics store. Borrowed
+/// so the same context can be threaded through nested helpers without forcing
+/// an `Arc::clone` at every call site.
+struct WatchCtx<'a> {
+    storage: &'a Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+    reload_tx: &'a mpsc::Sender<()>,
+    acme_notify: &'a Arc<Notify>,
+    diagnostics: &'a DiagnosticsStore,
+}
+
 pub struct KubernetesProvider {
     config: KubernetesConfig,
     name: &'static str,
@@ -322,15 +333,20 @@ impl KubernetesProvider {
 
         info!("Kubernetes Service watcher started");
 
+        let ctx = WatchCtx {
+            storage: &storage,
+            reload_tx: &reload_tx,
+            acme_notify: &acme_notify,
+            diagnostics: &diagnostics,
+        };
+
         while let Some(event) = stream.next().await {
             match event {
                 Ok(Event::Apply(svc)) | Ok(Event::InitApply(svc)) => {
-                    self.upsert_service(&svc, &storage, &reload_tx, &acme_notify, &diagnostics)
-                        .await;
+                    self.upsert_service(&svc, &ctx).await;
                 }
                 Ok(Event::Delete(svc)) => {
-                    self.remove_service(&svc, &storage, &reload_tx, &diagnostics)
-                        .await;
+                    self.remove_service(&svc, &ctx).await;
                 }
                 Ok(Event::Init) => {
                     debug!("Service watcher restart: reinitialising");
@@ -363,32 +379,23 @@ impl KubernetesProvider {
 
         info!("Kubernetes EndpointSlice watcher started");
 
+        let ctx = WatchCtx {
+            storage: &storage,
+            reload_tx: &reload_tx,
+            acme_notify: &acme_notify,
+            diagnostics: &diagnostics,
+        };
+
         while let Some(event) = stream.next().await {
             match event {
                 Ok(Event::Apply(slice)) | Ok(Event::InitApply(slice)) => {
                     if let Some(svc_id) = self.apply_slice(&slice) {
-                        self.refresh_service(
-                            &client,
-                            &svc_id,
-                            &storage,
-                            &reload_tx,
-                            &acme_notify,
-                            &diagnostics,
-                        )
-                        .await;
+                        self.refresh_service(&client, &svc_id, &ctx).await;
                     }
                 }
                 Ok(Event::Delete(slice)) => {
                     if let Some(svc_id) = self.remove_slice(&slice) {
-                        self.refresh_service(
-                            &client,
-                            &svc_id,
-                            &storage,
-                            &reload_tx,
-                            &acme_notify,
-                            &diagnostics,
-                        )
-                        .await;
+                        self.refresh_service(&client, &svc_id, &ctx).await;
                     }
                 }
                 Ok(Event::Init) | Ok(Event::InitDone) => {}
@@ -494,23 +501,14 @@ impl KubernetesProvider {
 
     /// Re-fetch a Service and re-run the upsert path so its entrypoint picks
     /// up the freshest backend list from the endpoints cache.
-    async fn refresh_service(
-        &self,
-        client: &Client,
-        svc_id: &str,
-        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        reload_tx: &mpsc::Sender<()>,
-        acme_notify: &Arc<Notify>,
-        diagnostics: &DiagnosticsStore,
-    ) {
+    async fn refresh_service(&self, client: &Client, svc_id: &str, ctx: &WatchCtx<'_>) {
         let Some((namespace, name)) = svc_id.split_once('/') else {
             return;
         };
         let api: Api<Service> = Api::namespaced(client.clone(), namespace);
         match api.get(name).await {
             Ok(svc) => {
-                self.upsert_service(&svc, storage, reload_tx, acme_notify, diagnostics)
-                    .await;
+                self.upsert_service(&svc, ctx).await;
             }
             Err(kube::Error::Api(err)) if err.code == 404 => {
                 debug!(
@@ -526,16 +524,8 @@ impl KubernetesProvider {
             }
         }
 
-        self.refresh_ingresses_for_service(
-            client,
-            namespace,
-            name,
-            storage,
-            reload_tx,
-            acme_notify,
-            diagnostics,
-        )
-        .await;
+        self.refresh_ingresses_for_service(client, namespace, name, ctx)
+            .await;
     }
 
     /// Re-apply every Ingress in `namespace` whose backend references `svc_name`.
@@ -546,10 +536,7 @@ impl KubernetesProvider {
         client: &Client,
         namespace: &str,
         svc_name: &str,
-        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        reload_tx: &mpsc::Sender<()>,
-        acme_notify: &Arc<Notify>,
-        diagnostics: &DiagnosticsStore,
+        ctx: &WatchCtx<'_>,
     ) {
         let api: Api<Ingress> = Api::namespaced(client.clone(), namespace);
         let list = match api.list(&ListParams::default()).await {
@@ -567,24 +554,16 @@ impl KubernetesProvider {
             if !ingress_references_service(&ing, svc_name) {
                 continue;
             }
-            self.apply_ingress(&ing, storage, reload_tx, acme_notify, diagnostics)
-                .await;
+            self.apply_ingress(&ing, ctx).await;
         }
     }
 
-    async fn upsert_service(
-        &self,
-        svc: &Service,
-        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        reload_tx: &mpsc::Sender<()>,
-        acme_notify: &Arc<Notify>,
-        diagnostics: &DiagnosticsStore,
-    ) {
+    async fn upsert_service(&self, svc: &Service, ctx: &WatchCtx<'_>) {
         let Some(candidate) = self.service_to_candidate(svc) else {
             return;
         };
 
-        let result = diagnostics::parse_and_store(diagnostics, &candidate);
+        let result = diagnostics::parse_and_store(ctx.diagnostics, &candidate);
         log_diagnostics(&candidate, &result.diagnostics);
 
         if result.entrypoints.is_empty() {
@@ -598,7 +577,7 @@ impl KubernetesProvider {
 
         let mut storage_changed = false;
         {
-            let mut storage_write = match storage.write() {
+            let mut storage_write = match ctx.storage.write() {
                 Ok(guard) => guard,
                 Err(e) => {
                     error!(
@@ -642,23 +621,17 @@ impl KubernetesProvider {
         }
 
         if storage_changed {
-            if let Err(e) = reload_tx.send(()).await {
+            if let Err(e) = ctx.reload_tx.send(()).await {
                 error!(
                     "could not apply configuration update; will retry on next change: {}",
                     e
                 );
             }
-            acme_notify.notify_one();
+            ctx.acme_notify.notify_one();
         }
     }
 
-    async fn remove_service(
-        &self,
-        svc: &Service,
-        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        reload_tx: &mpsc::Sender<()>,
-        diagnostics: &DiagnosticsStore,
-    ) {
+    async fn remove_service(&self, svc: &Service, ctx: &WatchCtx<'_>) {
         let Some(candidate) = self.service_to_candidate(svc) else {
             return;
         };
@@ -666,14 +639,14 @@ impl KubernetesProvider {
         // Service is gone — drop its diagnostics. We still need to know which
         // entrypoint keys it produced, so re-parse without writing to the store.
         let result = crate::labels::parse(&candidate);
-        diagnostics::remove(diagnostics, &candidate.id);
+        diagnostics::remove(ctx.diagnostics, &candidate.id);
         if result.entrypoints.is_empty() {
             return;
         }
 
         let mut storage_changed = false;
         {
-            let mut storage_write = match storage.write() {
+            let mut storage_write = match ctx.storage.write() {
                 Ok(guard) => guard,
                 Err(e) => {
                     error!(
@@ -695,7 +668,7 @@ impl KubernetesProvider {
             }
         }
 
-        if storage_changed && let Err(e) = reload_tx.send(()).await {
+        if storage_changed && let Err(e) = ctx.reload_tx.send(()).await {
             error!(
                 "could not apply configuration update; will retry on next change: {}",
                 e
@@ -720,15 +693,20 @@ impl KubernetesProvider {
             self.config.ingress_class
         );
 
+        let ctx = WatchCtx {
+            storage: &storage,
+            reload_tx: &reload_tx,
+            acme_notify: &acme_notify,
+            diagnostics: &diagnostics,
+        };
+
         while let Some(event) = stream.next().await {
             match event {
                 Ok(Event::Apply(ing)) | Ok(Event::InitApply(ing)) => {
-                    self.apply_ingress(&ing, &storage, &reload_tx, &acme_notify, &diagnostics)
-                        .await;
+                    self.apply_ingress(&ing, &ctx).await;
                 }
                 Ok(Event::Delete(ing)) => {
-                    self.remove_ingress(&ing, &storage, &reload_tx, &diagnostics)
-                        .await;
+                    self.remove_ingress(&ing, &ctx).await;
                 }
                 Ok(Event::Init) | Ok(Event::InitDone) => {}
                 Err(e) => {
@@ -742,14 +720,7 @@ impl KubernetesProvider {
         Ok(())
     }
 
-    async fn apply_ingress(
-        &self,
-        ing: &Ingress,
-        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        reload_tx: &mpsc::Sender<()>,
-        acme_notify: &Arc<Notify>,
-        diagnostics: &DiagnosticsStore,
-    ) {
+    async fn apply_ingress(&self, ing: &Ingress, ctx: &WatchCtx<'_>) {
         let Some(ing_id) = ingress_id(ing) else {
             return;
         };
@@ -763,8 +734,7 @@ impl KubernetesProvider {
             .map(|c| c == self.config.ingress_class)
             .unwrap_or(false);
         if !class_match {
-            self.remove_ingress(ing, storage, reload_tx, diagnostics)
-                .await;
+            self.remove_ingress(ing, ctx).await;
             return;
         }
 
@@ -781,7 +751,7 @@ impl KubernetesProvider {
         let mut storage_changed = false;
         let mut tls_added = false;
         {
-            let mut storage_write = match storage.write() {
+            let mut storage_write = match ctx.storage.write() {
                 Ok(guard) => guard,
                 Err(e) => {
                     error!(
@@ -828,27 +798,19 @@ impl KubernetesProvider {
         }
 
         if storage_changed {
-            if let Err(e) = reload_tx.send(()).await {
+            if let Err(e) = ctx.reload_tx.send(()).await {
                 error!(
                     "could not apply configuration update; will retry on next change: {}",
                     e
                 );
             }
             if tls_added {
-                acme_notify.notify_one();
+                ctx.acme_notify.notify_one();
             }
         }
     }
 
-    async fn remove_ingress(
-        &self,
-        ing: &Ingress,
-        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-        reload_tx: &mpsc::Sender<()>,
-        // Threaded for symmetry with apply_ingress; Ingress entries don't
-        // produce diagnostic entries (they don't go through `labels::parse`).
-        _diagnostics: &DiagnosticsStore,
-    ) {
+    async fn remove_ingress(&self, ing: &Ingress, ctx: &WatchCtx<'_>) {
         let Some(ing_id) = ingress_id(ing) else {
             return;
         };
@@ -870,7 +832,7 @@ impl KubernetesProvider {
 
         let mut storage_changed = false;
         {
-            let mut storage_write = match storage.write() {
+            let mut storage_write = match ctx.storage.write() {
                 Ok(guard) => guard,
                 Err(e) => {
                     error!(
@@ -888,7 +850,7 @@ impl KubernetesProvider {
             }
         }
 
-        if storage_changed && let Err(e) = reload_tx.send(()).await {
+        if storage_changed && let Err(e) = ctx.reload_tx.send(()).await {
             error!(
                 "could not apply configuration update; will retry on next change: {}",
                 e
@@ -922,6 +884,13 @@ impl KubernetesProvider {
             })
             .unwrap_or_default();
 
+        let ctx = IngressParseCtx {
+            provider: self,
+            ing_id: &ing_id,
+            namespace,
+            tls_hosts: &tls_hosts,
+        };
+
         let mut entries: Vec<(String, Entrypoint)> = Vec::new();
 
         if let Some(rules) = spec.rules.as_ref() {
@@ -931,15 +900,9 @@ impl KubernetesProvider {
                     continue;
                 };
                 for (path_idx, path) in http.paths.iter().enumerate() {
-                    if let Some(entry) = self.path_to_entrypoint(
-                        &ing_id,
-                        namespace,
-                        rule_idx,
-                        path_idx,
-                        host.as_deref(),
-                        path,
-                        &tls_hosts,
-                    ) {
+                    if let Some(entry) =
+                        ctx.path_to_entrypoint(rule_idx, path_idx, host.as_deref(), path)
+                    {
                         entries.push(entry);
                     }
                 }
@@ -947,27 +910,36 @@ impl KubernetesProvider {
         }
 
         if let Some(default) = spec.default_backend.as_ref()
-            && let Some(entry) = self
-                .backend_to_entrypoint(&ing_id, namespace, "default", None, None, default, false)
+            && let Some(entry) = ctx.backend_to_entrypoint("default", None, None, default, false)
         {
             entries.push(entry);
         }
 
         entries
     }
+}
 
+/// Identity + pre-computed state carried through every helper that parses one
+/// Ingress into entrypoints. Lifted out of `path_to_entrypoint` /
+/// `backend_to_entrypoint` so they're not dragging the same 4 contextual
+/// values through their signatures.
+struct IngressParseCtx<'a> {
+    provider: &'a KubernetesProvider,
+    ing_id: &'a str,
+    namespace: &'a str,
+    tls_hosts: &'a HashSet<String>,
+}
+
+impl IngressParseCtx<'_> {
     fn path_to_entrypoint(
         &self,
-        ing_id: &str,
-        namespace: &str,
         rule_idx: usize,
         path_idx: usize,
         host: Option<&str>,
         path: &HTTPIngressPath,
-        tls_hosts: &HashSet<String>,
     ) -> Option<(String, Entrypoint)> {
         let suffix = format!("r{rule_idx}p{path_idx}");
-        let tls = host.map(|h| tls_hosts.contains(h)).unwrap_or(false);
+        let tls = host.map(|h| self.tls_hosts.contains(h)).unwrap_or(false);
 
         let path_config = match path.path.as_deref() {
             Some(p) if !p.is_empty() => Some(PathConfig {
@@ -982,21 +954,11 @@ impl KubernetesProvider {
             _ => None,
         };
 
-        self.backend_to_entrypoint(
-            ing_id,
-            namespace,
-            &suffix,
-            host,
-            path_config,
-            &path.backend,
-            tls,
-        )
+        self.backend_to_entrypoint(&suffix, host, path_config, &path.backend, tls)
     }
 
     fn backend_to_entrypoint(
         &self,
-        ing_id: &str,
-        namespace: &str,
         suffix: &str,
         host: Option<&str>,
         path: Option<PathConfig>,
@@ -1008,13 +970,13 @@ impl KubernetesProvider {
             Some(p) => p.number.unwrap_or(80) as u16,
             None => 80,
         };
-        let svc_id = format!("{namespace}/{}", svc_ref.name);
+        let svc_id = format!("{}/{}", self.namespace, svc_ref.name);
 
-        let pod_ips = self.pod_ips_for(&svc_id);
+        let pod_ips = self.provider.pod_ips_for(&svc_id);
         let backends: Vec<Backend> = if pod_ips.is_empty() {
             warn!(
                 "Ingress {} references service {} but no ready endpoints are known yet",
-                ing_id, svc_id
+                self.ing_id, svc_id
             );
             Vec::new()
         } else {
@@ -1024,7 +986,7 @@ impl KubernetesProvider {
                 .collect()
         };
 
-        let key = format!("ingress_{}_{}", sanitise(ing_id), suffix);
+        let key = format!("ingress_{}_{}", sanitise(self.ing_id), suffix);
         let hostnames = host.map(|h| vec![h.to_string()]).unwrap_or_default();
 
         let entrypoint = Entrypoint {
@@ -1055,7 +1017,7 @@ impl KubernetesProvider {
                 entrypoint: None,
                 methods: Vec::new(),
             },
-            source: Some(self.name.to_string()),
+            source: Some(self.provider.name.to_string()),
         };
 
         Some((key, entrypoint))

--- a/src/proxy/backend.rs
+++ b/src/proxy/backend.rs
@@ -7,26 +7,21 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
 
-pub fn init_proxy(
-    storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-    config: &ProxyConfig,
-    shutdown_rx: tokio::sync::oneshot::Receiver<()>,
-    reload_rx: mpsc::Receiver<()>,
-    cert_rx: mpsc::Receiver<CertCommand>,
-    acme_challenge_port: Option<u16>,
-    middleware_state: MiddlewareState,
-    middleware_port: u16,
-    handle: tokio::runtime::Handle,
-) -> anyhow::Result<()> {
-    proxy::sozu::start_sozu_proxy(
-        storage,
-        config,
-        shutdown_rx,
-        reload_rx,
-        cert_rx,
-        acme_challenge_port,
-        middleware_state,
-        middleware_port,
-        handle,
-    )
+/// Bundle of channels and state the proxy needs to wire up. Grouped here so
+/// every caller and forward (main.rs → init_proxy → start_sozu_proxy) only
+/// has to pass one value instead of nine — the inner fields are deliberately
+/// public so the sozu reload thread can take direct ownership of each.
+pub struct ProxyInputs {
+    pub storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+    pub shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    pub reload_rx: mpsc::Receiver<()>,
+    pub cert_rx: mpsc::Receiver<CertCommand>,
+    pub acme_challenge_port: Option<u16>,
+    pub middleware_state: MiddlewareState,
+    pub middleware_port: u16,
+    pub handle: tokio::runtime::Handle,
+}
+
+pub fn init_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Result<()> {
+    proxy::sozu::start_sozu_proxy(inputs, config)
 }

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -3,10 +3,10 @@ mod addr;
 mod builders;
 mod channel;
 
-use crate::acme::CertCommand;
 use crate::config::ProxyConfig;
 use crate::middleware::{self, MiddlewareState};
 use crate::model::{Entrypoint, Protocol};
+use crate::proxy::backend::ProxyInputs;
 use acme::{add_certificate, register_acme_challenge_cluster};
 use addr::parse_backend_address;
 use builders::{
@@ -53,6 +53,21 @@ struct TcpListenerChannel {
 /// TCP workers keyed by listener name (matches `proxy.tcp[].name`).
 /// One worker = one listener.
 type TcpChannels = HashMap<String, TcpListenerChannel>;
+
+/// Bundle of every Sōzu worker channel a reload needs to talk to, plus the
+/// ports they're bound on. Grouped together because every function in the
+/// reload path already has to pass all of them — this turns a 6-parameter
+/// drag into one `&mut Channels`.
+struct Channels {
+    http: Channel<WorkerRequest, WorkerResponse>,
+    https: Channel<WorkerRequest, WorkerResponse>,
+    tcp: TcpChannels,
+    http_port: u16,
+    https_port: u16,
+    /// Loopback port serving the ACME HTTP-01 challenge responder, when
+    /// ACME is enabled. `None` disables every ACME-specific code path.
+    acme_challenge_port: Option<u16>,
+}
 
 fn snapshot_from_storage(storage: &BTreeMap<String, Entrypoint>) -> RoutingSnapshot {
     storage
@@ -127,17 +142,18 @@ fn spawn_tcp_workers(
     Ok((channels, handles))
 }
 
-pub fn start_sozu_proxy(
-    storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-    config: &ProxyConfig,
-    shutdown_rx: tokio::sync::oneshot::Receiver<()>,
-    mut reload_rx: mpsc::Receiver<()>,
-    mut cert_rx: mpsc::Receiver<CertCommand>,
-    acme_challenge_port: Option<u16>,
-    middleware_state: MiddlewareState,
-    middleware_port: u16,
-    handle: tokio::runtime::Handle,
-) -> anyhow::Result<()> {
+pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Result<()> {
+    let ProxyInputs {
+        storage,
+        shutdown_rx,
+        mut reload_rx,
+        mut cert_rx,
+        acme_challenge_port,
+        middleware_state,
+        middleware_port,
+        handle,
+    } = inputs;
+
     info!("Starting Sōzu HTTP and HTTPS workers");
 
     // Copy values needed for threads
@@ -227,6 +243,19 @@ pub fn start_sozu_proxy(
     let cluster_setup_delay_ms = config.cluster_setup_delay_ms;
     let reload_debounce = Duration::from_millis(config.reload_debounce_ms);
 
+    // Now that every worker is up and the static ACME cluster has been
+    // registered, fold the three command channels into a single `Channels`
+    // and hand it to the reload thread by value. Splitting them again here
+    // would just push the 6-parameter mess further down.
+    let mut channels = Channels {
+        http: command_channel,
+        https: command_channel_https,
+        tcp: tcp_channels,
+        http_port,
+        https_port,
+        acme_challenge_port,
+    };
+
     let reload_handle = thread::spawn(move || {
         handle.block_on(async {
             let mut shutdown_rx = shutdown_rx;
@@ -263,7 +292,7 @@ pub fn start_sozu_proxy(
                         Some(cmd) => {
                             info!("Adding certificate for {}", cmd.hostname);
                             if let Err(e) = add_certificate(
-                                &mut command_channel_https,
+                                &mut channels.https,
                                 https_port,
                                 &cmd.cert_pem,
                                 &cmd.chain,
@@ -315,7 +344,7 @@ pub fn start_sozu_proxy(
                                 Some(cmd) => {
                                     info!("Adding certificate for {}", cmd.hostname);
                                     if let Err(e) = add_certificate(
-                                        &mut command_channel_https,
+                                        &mut channels.https,
                                         https_port,
                                         &cmd.cert_pem,
                                         &cmd.chain,
@@ -344,13 +373,8 @@ pub fn start_sozu_proxy(
 
                 previous_snapshot = handle_reload(
                     &storage_reload,
-                    &mut command_channel,
-                    &mut command_channel_https,
-                    &mut tcp_channels,
-                    http_port,
-                    https_port,
+                    &mut channels,
                     cluster_setup_delay_ms,
-                    acme_challenge_port,
                     &previous_snapshot,
                     &middleware_state,
                     middleware_port,
@@ -386,13 +410,8 @@ pub fn start_sozu_proxy(
 
 fn handle_reload(
     storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-    command_channel: &mut Channel<WorkerRequest, WorkerResponse>,
-    command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
-    tcp_channels: &mut TcpChannels,
-    http_port: u16,
-    https_port: u16,
+    channels: &mut Channels,
     cluster_setup_delay_ms: u64,
-    acme_challenge_port: Option<u16>,
     previous_snapshot: &RoutingSnapshot,
     middleware_state: &MiddlewareState,
     middleware_port: u16,
@@ -411,30 +430,16 @@ fn handle_reload(
 
     let current_snapshot = snapshot_from_storage(&storage_read);
 
-    apply_routing_diff(
-        previous_snapshot,
-        &current_snapshot,
-        command_channel,
-        command_channel_https,
-        tcp_channels,
-        http_port,
-        https_port,
-        acme_challenge_port,
-    );
+    apply_routing_diff(previous_snapshot, &current_snapshot, channels);
 
     // Update middleware route table
     update_middleware_routes(&storage_read, middleware_state);
 
     match configure_sozu_routing(
-        command_channel,
-        command_channel_https,
-        tcp_channels,
+        channels,
         &storage_read,
         previous_snapshot,
-        http_port,
-        https_port,
         cluster_setup_delay_ms,
-        acme_challenge_port,
         middleware_port,
     ) {
         Ok(()) => info!("Configuration reloaded successfully"),
@@ -482,15 +487,10 @@ fn update_middleware_routes(
 }
 
 fn configure_sozu_routing(
-    command_channel: &mut Channel<WorkerRequest, WorkerResponse>,
-    command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
-    tcp_channels: &mut TcpChannels,
+    channels: &mut Channels,
     storage: &BTreeMap<String, Entrypoint>,
     previous: &RoutingSnapshot,
-    http_port: u16,
-    https_port: u16,
     cluster_setup_delay_ms: u64,
-    acme_challenge_port: Option<u16>,
     middleware_port: u16,
 ) -> anyhow::Result<()> {
     info!(
@@ -502,7 +502,7 @@ fn configure_sozu_routing(
     // Since Sozu Pre rules are matched in insertion order, registering
     // higher-priority routes first ensures they take precedence.
     let mut sorted_entrypoints: Vec<(&String, &Entrypoint)> = storage.iter().collect();
-    sorted_entrypoints.sort_by(|a, b| b.1.config.priority.cmp(&a.1.config.priority));
+    sorted_entrypoints.sort_by_key(|(_, ep)| std::cmp::Reverse(ep.config.priority));
 
     for (cluster_id, entrypoint) in sorted_entrypoints {
         // Skip entrypoints that are byte-for-byte identical to the previous
@@ -521,11 +521,11 @@ fn configure_sozu_routing(
                 // Register ACME challenge frontend BEFORE normal frontend
                 // Pre rules are checked in insertion order, so the more specific
                 // ACME path must be registered first to take priority over "/"
-                if acme_challenge_port.is_some() {
+                if channels.acme_challenge_port.is_some() {
                     for hostname in &entrypoint.config.hostnames {
                         let acme_front = RequestHttpFrontend {
                             cluster_id: Some("acme-challenge".to_string()),
-                            address: SocketAddress::new_v4(0, 0, 0, 0, http_port),
+                            address: SocketAddress::new_v4(0, 0, 0, 0, channels.http_port),
                             hostname: hostname.clone(),
                             path: PathRule {
                                 value: "/.well-known/acme-challenge/".to_string(),
@@ -537,7 +537,7 @@ fn configure_sozu_routing(
                             ..Default::default()
                         };
                         if let Err(e) = send_to_worker(
-                            command_channel,
+                            &mut channels.http,
                             format!("add-frontend-acme-{}", hostname),
                             RequestType::AddHttpFrontend(acme_front),
                         ) {
@@ -550,17 +550,17 @@ fn configure_sozu_routing(
                 }
 
                 configure_http_entrypoint(
-                    command_channel,
-                    command_channel_https,
+                    &mut channels.http,
+                    &mut channels.https,
                     cluster_id,
                     entrypoint,
-                    http_port,
-                    https_port,
+                    channels.http_port,
+                    channels.https_port,
                     middleware_port,
                 )?;
             }
             Protocol::Tcp => {
-                configure_tcp_entrypoint(tcp_channels, cluster_id, entrypoint);
+                configure_tcp_entrypoint(&mut channels.tcp, cluster_id, entrypoint);
             }
             Protocol::Udp => {
                 debug!(
@@ -1090,12 +1090,7 @@ fn remove_acme_frontends(
 fn apply_routing_diff(
     previous: &RoutingSnapshot,
     current: &RoutingSnapshot,
-    command_channel: &mut Channel<WorkerRequest, WorkerResponse>,
-    command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
-    tcp_channels: &mut TcpChannels,
-    http_port: u16,
-    https_port: u16,
-    acme_challenge_port: Option<u16>,
+    channels: &mut Channels,
 ) {
     // Handle removed clusters
     for (cluster_id, old) in previous {
@@ -1104,22 +1099,26 @@ fn apply_routing_diff(
             match old.protocol {
                 Protocol::Http => {
                     remove_http_frontends(
-                        command_channel,
-                        command_channel_https,
+                        &mut channels.http,
+                        &mut channels.https,
                         cluster_id,
                         old,
-                        http_port,
-                        https_port,
+                        channels.http_port,
+                        channels.https_port,
                     );
-                    remove_backends(command_channel, command_channel_https, cluster_id, old);
-                    remove_cluster(command_channel, command_channel_https, cluster_id);
+                    remove_backends(&mut channels.http, &mut channels.https, cluster_id, old);
+                    remove_cluster(&mut channels.http, &mut channels.https, cluster_id);
 
-                    if acme_challenge_port.is_some() {
-                        remove_acme_frontends(command_channel, &old.config.hostnames, http_port);
+                    if channels.acme_challenge_port.is_some() {
+                        remove_acme_frontends(
+                            &mut channels.http,
+                            &old.config.hostnames,
+                            channels.http_port,
+                        );
                     }
                 }
                 Protocol::Tcp => {
-                    remove_tcp_entrypoint(tcp_channels, cluster_id, old);
+                    remove_tcp_entrypoint(&mut channels.tcp, cluster_id, old);
                 }
                 Protocol::Udp => {}
             }
@@ -1136,22 +1135,27 @@ fn apply_routing_diff(
             match old.protocol {
                 Protocol::Http => {
                     remove_http_frontends(
-                        command_channel,
-                        command_channel_https,
+                        &mut channels.http,
+                        &mut channels.https,
                         cluster_id,
                         old,
-                        http_port,
-                        https_port,
+                        channels.http_port,
+                        channels.https_port,
                     );
-                    remove_backends(command_channel, command_channel_https, cluster_id, old);
+                    remove_backends(&mut channels.http, &mut channels.https, cluster_id, old);
 
-                    if acme_challenge_port.is_some() && old.config.hostnames != new.config.hostnames
+                    if channels.acme_challenge_port.is_some()
+                        && old.config.hostnames != new.config.hostnames
                     {
-                        remove_acme_frontends(command_channel, &old.config.hostnames, http_port);
+                        remove_acme_frontends(
+                            &mut channels.http,
+                            &old.config.hostnames,
+                            channels.http_port,
+                        );
                     }
                 }
                 Protocol::Tcp => {
-                    remove_tcp_entrypoint(tcp_channels, cluster_id, old);
+                    remove_tcp_entrypoint(&mut channels.tcp, cluster_id, old);
                 }
                 Protocol::Udp => {}
             }


### PR DESCRIPTION
## Summary

Clippy `too_many_arguments` was firing on 8 functions across `proxy/sozu/`, `proxy/backend.rs`, and `provider/kubernetes/`. Rather than `#[allow]`-ing each, this PR introduces four small context structs that group the parameters that were already being passed together at every call site.

The refactor surfaces what was implicit: there is one "thing the reload thread needs" (channels + ports), one "input wiring of the proxy" (the various mpsc receivers), one "watcher context" (storage + reload + acme + diagnostics), and one "ingress parsing context" (id + namespace + tls hosts).

### Structs introduced

| Struct | Where | Replaces |
|---|---|---|
| `Channels` | `proxy/sozu/mod.rs` | 3 channels + 3 ports passed individually to `apply_routing_diff`, `configure_sozu_routing`, `handle_reload` |
| `ProxyInputs` | `proxy/backend.rs` (pub) | 8 args on `init_proxy` / `start_sozu_proxy` |
| `WatchCtx<'a>` | `provider/kubernetes/mod.rs` | `&storage / &reload_tx / &acme_notify / &diagnostics` threaded through 7 watcher methods |
| `IngressParseCtx<'a>` | `provider/kubernetes/mod.rs` | `&ing_id / &namespace / &tls_hosts / &provider` threaded through `path_to_entrypoint` + `backend_to_entrypoint` |

### Side cleanup

- `sort_by(\|a, b\| b.cmp(&a))` → `sort_by_key(\|x\| Reverse(...))` (clippy `unnecessary_sort_by`).

## Test plan

- [x] `cargo test --bin sozune` — 328/328 passed (no test changes; behaviour preserved)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin sozune` — 0 `too_many_arguments` left (was 8)
- [x] `bash tests/e2e/run-all.sh` — 66/66 passed (Docker e2e validates the full reload path: providers → storage → sozu workers → backends)

## Diff stats

`-37` lines net across 4 files. The `Channels` struct in particular collapses ~30 lines of repeated argument passing in the reload loop.

No behaviour change. Pure organisation.