### PR TITLE
Add GET /providers endpoint and dashboard page

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -131,12 +131,31 @@ export interface DiagnosticsResponse {
   items: { candidate_id: string; diagnostics: Diagnostic[] }[];
 }
 
+export interface Provider {
+  /** Provider identifier — matches `entrypoint.source` for entries it emits. */
+  name: string;
+  /** The provider block exists in `config.yaml` (regardless of `enabled`). */
+  configured: boolean;
+  /** The provider is configured *and* its `enabled` flag is true. */
+  enabled: boolean;
+  /** Live count of entrypoints in storage whose `source` matches this provider. */
+  entrypoint_count: number;
+}
+
+export interface ProvidersResponse {
+  providers: Provider[];
+}
+
 export function listEntrypoints(): Promise<Entrypoint[]> {
   return request<Entrypoint[]>('/entrypoints');
 }
 
 export function listDiagnostics(): Promise<DiagnosticsResponse> {
   return request<DiagnosticsResponse>('/diagnostics');
+}
+
+export function listProviders(): Promise<ProvidersResponse> {
+  return request<ProvidersResponse>('/providers');
 }
 
 export function getEntrypoint(id: string): Promise<Entrypoint> {

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
 
   const nav = [
     { href: './', label: 'Entrypoints', icon: 'grid' },
+    { href: './providers', label: 'Providers', icon: 'plug' },
     { href: './diagnostics', label: 'Diagnostics', icon: 'warning' },
     { href: './certificates', label: 'Certificates', icon: 'lock' },
     { href: './health', label: 'Health', icon: 'pulse' },
@@ -89,6 +90,8 @@
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="2.5"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.4 1.4M11.55 11.55l1.4 1.4M3.05 12.95l1.4-1.4M11.55 4.45l1.4-1.4"/></svg>
               {:else if item.icon === 'warning'}
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2L1.5 13.5h13L8 2z"/><path d="M8 6.5v3.5"/><circle cx="8" cy="11.5" r="0.5" fill="currentColor"/></svg>
+              {:else if item.icon === 'plug'}
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 1v3M10 1v3"/><rect x="4" y="4" width="8" height="5" rx="1"/><path d="M8 9v3a2 2 0 0 0 2 2h2"/></svg>
               {/if}
             </span>
             <span>{item.label}</span>

--- a/dashboard/src/routes/providers/+page.svelte
+++ b/dashboard/src/routes/providers/+page.svelte
@@ -1,0 +1,326 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { listProviders, type Provider } from '$lib/api';
+
+  let providers = $state<Provider[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  async function refresh() {
+    try {
+      const res = await listProviders();
+      providers = res.providers;
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  onMount(() => {
+    void refresh();
+    // Counts come from live storage — refresh on the same cadence as Health.
+    poll = setInterval(() => void refresh(), 5000);
+  });
+
+  onDestroy(() => {
+    if (poll) clearInterval(poll);
+  });
+
+  function timeAgo(d: Date | null): string {
+    if (!d) return '';
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) return 'just now';
+    if (s < 60) return `${s}s ago`;
+    return `${Math.floor(s / 60)}m ago`;
+  }
+
+  function statusOf(p: Provider): 'active' | 'disabled' | 'unconfigured' {
+    if (p.enabled) return 'active';
+    if (p.configured) return 'disabled';
+    return 'unconfigured';
+  }
+
+  function statusLabel(s: 'active' | 'disabled' | 'unconfigured'): string {
+    switch (s) {
+      case 'active':
+        return 'enabled';
+      case 'disabled':
+        return 'disabled';
+      case 'unconfigured':
+        return 'not configured';
+    }
+  }
+
+  // Pre-compute the totals shown above the table.
+  let activeCount = $derived(providers.filter((p) => p.enabled).length);
+  let totalEntrypoints = $derived(
+    providers.reduce((acc, p) => acc + p.entrypoint_count, 0)
+  );
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>Providers</h1>
+    <p class="subtitle">Service discovery sources sōzune knows about</p>
+  </div>
+  <div class="header-actions">
+    {#if lastFetch}
+      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+    {/if}
+    <button class="btn-secondary" onclick={refresh} disabled={loading}>
+      {loading ? 'loading…' : 'Refresh'}
+    </button>
+  </div>
+</header>
+
+<section class="stats">
+  <div class="stat-card">
+    <div class="stat-label">Enabled</div>
+    <div class="stat-value">{activeCount}<span class="unit">/ {providers.length}</span></div>
+    <div class="stat-sub">providers currently active</div>
+  </div>
+  <div class="stat-card">
+    <div class="stat-label">Entrypoints</div>
+    <div class="stat-value">{totalEntrypoints}</div>
+    <div class="stat-sub">across every provider</div>
+  </div>
+</section>
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong> {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && providers.length > 0}
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Status</th>
+          <th class="num">Entrypoints</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each providers as p (p.name)}
+          {@const s = statusOf(p)}
+          <tr class:disabled={s !== 'active'}>
+            <td>
+              <span class="provider-name">{p.name}</span>
+            </td>
+            <td>
+              <span class="status-pill" class:active={s === 'active'} class:warn={s === 'disabled'}>
+                <span class="dot" class:active={s === 'active'} class:warn={s === 'disabled'}></span>
+                {statusLabel(s)}
+              </span>
+            </td>
+            <td class="num mono">{p.entrypoint_count}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && providers.length === 0 && !errorMsg}
+  <div class="empty">No providers reported.</div>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .stat-card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.125rem;
+  }
+  .stat-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .stat-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 0.35rem;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+  }
+  .unit {
+    font-size: 0.85rem;
+    color: var(--fg-2);
+    font-weight: 500;
+    margin-left: 4px;
+  }
+  .stat-sub {
+    font-size: 0.75rem;
+    color: var(--fg-3);
+    margin-top: 0.25rem;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0;
+    overflow: hidden;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.7rem 1rem;
+    font-size: 0.85rem;
+    border-bottom: 1px solid var(--border);
+  }
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+  th {
+    font-weight: 500;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    background: var(--bg-0);
+  }
+  td.num, th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  td.mono {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+  }
+  tr.disabled .provider-name {
+    color: var(--fg-2);
+  }
+  tr.disabled td.num {
+    color: var(--fg-3);
+  }
+  .provider-name {
+    font-weight: 500;
+    color: var(--fg-0);
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.18rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--fg-2);
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+  }
+  .status-pill.active {
+    color: var(--success);
+    background: var(--success-bg);
+    border-color: transparent;
+  }
+  .status-pill.warn {
+    color: var(--fg-1);
+    background: var(--bg-2);
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--fg-3);
+  }
+  .dot.active {
+    background: var(--success);
+  }
+  .dot.warn {
+    background: var(--fg-2);
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+
+  .empty {
+    color: var(--fg-2);
+    font-size: 0.85rem;
+    padding: 1.5rem;
+    text-align: center;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+</style>

--- a/documentation/configuration/api.md
+++ b/documentation/configuration/api.md
@@ -1,6 +1,6 @@
 # REST API
 
-Sōzune exposes a REST API to manage entrypoints on the fly, without restarting.
+Sōzune exposes a REST API to manage entrypoints on the fly, without restarting. The API also surfaces real-time diagnostics, backend health, and the identity of the currently authenticated user — everything the dashboard needs to drive an interactive UI.
 
 ## Configuration
 
@@ -33,52 +33,119 @@ Generate a hash with:
 echo -n "your-password" | sha256sum
 ```
 
-Then call the API with the password — sozune hashes it on receive and compares in constant time:
+Then call the API with the password — sōzune hashes it on receive and compares in constant time:
 
 ```bash
 curl -u admin:your-password http://localhost:3035/entrypoints
 ```
 
-The hash format matches what sozune accepts in route-level basic auth (`sozune.http.<svc>.auth.basic`), so the same generation step works on both sides.
+The hash format matches what sōzune accepts in route-level basic auth (`sozune.http.<svc>.auth.basic`), so the same generation step works on both sides.
 
 ## Roles
 
-| Role | GET | POST / PUT / DELETE |
+| Role | GET / HEAD / OPTIONS | POST / PUT / DELETE |
 |---|---|---|
 | `admin` (default) | yes | yes |
-| `read-only` | yes | 403 |
+| `read-only` | yes | `403 Forbidden` |
 
-`role` can be omitted; it defaults to `admin`.
+`role` can be omitted in `config.yaml`; it defaults to `admin`.
+
+Read-only users can still read every endpoint, including `/diagnostics` and `/me`. Write attempts return `403` with a JSON error body:
+
+```json
+{ "error": "read-only role cannot perform this operation" }
+```
 
 ## Securing the API on a network
 
 > **HTTP Basic over plaintext HTTP sends the password in the clear on every request.** It is only safe when the connection is encrypted.
 
-Sōzune's API listens in HTTP. If you bind it to anything other than `127.0.0.1`, put it behind TLS yourself. Two common patterns:
+The default `listen_address: "127.0.0.1:3035"` keeps the API local-only — fine for CLI use from the same host, never expose it on `0.0.0.0` without TLS in front.
 
-- **Behind sozune itself** — declare an entrypoint that points at `127.0.0.1:3035` with `tls: true` and an ACME-issued certificate, and only the TLS-fronted hostname is reachable from outside.
+To expose it remotely, put it behind TLS:
+
+- **Behind sōzune itself** — declare an entrypoint that points at `127.0.0.1:3035` with `tls: true` and an ACME-issued certificate.
 - **Behind another reverse proxy** that already terminates TLS (nginx, Caddy, an ingress controller).
 
-The default `listen_address: "127.0.0.1:3035"` keeps the API local-only — fine for CLI use from the same host, never expose it on `0.0.0.0` without TLS in front.
+## CORS
+
+When `cors_origins` is empty, the API responds with `Access-Control-Allow-Origin: *` (every origin allowed). Set `cors_origins` to a list of explicit origins to restrict the browser-side calls — useful when the dashboard is served from a different domain than the API.
+
+Allowed methods are `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`. Allowed headers: `Authorization`, `Content-Type`, `Accept`.
+
+## Common error responses
+
+Every error response body is JSON with an `error` field:
+
+| Status | When |
+|---|---|
+| `400 Bad Request` | Malformed JSON in the request body |
+| `401 Unauthorized` | Missing or invalid `Authorization: Basic ...` header. Response includes `WWW-Authenticate: Basic realm="sozune"`. |
+| `403 Forbidden` | Authenticated but the role doesn't permit the operation (read-only writes, or attempting to mutate a provider-owned entrypoint) |
+| `404 Not Found` | Unknown entrypoint id |
+| `415 Unsupported Media Type` | `Content-Type` is missing or not `application/json` on a write |
+| `422 Unprocessable Entity` | JSON parsed but required fields are missing or the wrong type |
+| `500 Internal Server Error` | Internal state lock poisoned (unrecoverable; sōzune needs a restart) |
 
 ## Endpoints
 
 ### `GET /health`
 
-Service status. No auth.
+Liveness probe. No auth required.
 
 ```bash
 curl http://localhost:3035/health
-# 200 OK
 ```
+
+```json
+{ "status": "ok" }
+```
+
+Returns `200 OK` as long as the API server can answer. It does not validate downstream state (worker reachability, provider connectivity).
+
+### `GET /me`
+
+Returns the authenticated user's identity. The dashboard hits this on login to validate credentials and learn its role.
+
+```bash
+curl -u dashboard:your-password http://localhost:3035/me
+```
+
+```json
+{
+  "name": "dashboard",
+  "role": "read-only"
+}
+```
+
+`role` is either `"admin"` or `"read-only"`.
 
 ### `GET /entrypoints`
 
-Lists every entrypoint (Docker + API). Available to both roles.
+Lists every entrypoint sōzune currently routes — from every provider (Docker, Podman, Swarm, Nomad, Kubernetes Ingress/Gateway API, HTTP, config file) plus those created through this API. Available to both roles.
+
+```bash
+curl -u admin:your-password http://localhost:3035/entrypoints
+```
+
+Response: a JSON array of entrypoint objects (see [Entrypoint schema](#entrypoint-schema) below). Each item also carries:
+
+- `unhealthy_backends`: list of `"<address>:<port>"` backend strings the health checker has marked unhealthy for this entrypoint
+- `diagnostics`: list of [Diagnostic objects](#diagnostic-schema) associated with this entrypoint, including runtime collision lints (W018)
+
+### `GET /entrypoints/{id}`
+
+Fetches a single entrypoint by its id. Returns `404` if unknown. Available to both roles.
+
+```bash
+curl -u admin:your-password http://localhost:3035/entrypoints/http_api
+```
+
+Response shape identical to one element of `GET /entrypoints` — entrypoint object plus `unhealthy_backends` and `diagnostics`.
 
 ### `POST /entrypoints`
 
-Creates an entrypoint through the API. Admin only.
+Creates an entrypoint through the API. **Admin only.**
 
 ```bash
 curl -X POST http://localhost:3035/entrypoints \
@@ -93,25 +160,232 @@ curl -X POST http://localhost:3035/entrypoints \
     "config": {
       "hostnames": ["api.example.com"],
       "tls": true,
-      "https_redirect": true
+      "https_redirect": true,
+      "priority": 0
     }
   }'
 ```
 
-The `config` object accepts the same fields as the [HTTP provider](/documentation/providers/http) schema. Optional fields default to `null` / `false` when omitted.
+Required fields: `name`, `backends`, `protocol`, `config`. See [CreateEntrypointRequest schema](#createentrypointrequest-schema) for the full field list.
 
-### `GET /entrypoints/:id`
+Response: `201 Created` with the created entrypoint in the body. The `id` is generated by sōzune; the entrypoint's `source` is `"api"`.
 
-Fetches a single entrypoint.
+### `PUT /entrypoints/{id}`
 
-### `PUT /entrypoints/:id`
+Replaces an existing entrypoint created through the API. **Admin only.**
 
-Updates an entrypoint (only those created through the API, not Docker). Admin only.
+```bash
+curl -X PUT http://localhost:3035/entrypoints/http_my-api \
+  -u admin:your-password \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-api",
+    "backends": [{ "address": "10.0.0.6", "port": 8080, "weight": 100 }],
+    "protocol": "Http",
+    "config": { "hostnames": ["api.example.com"], "tls": true, "priority": 0 }
+  }'
+```
 
-### `DELETE /entrypoints/:id`
+Response: `200 OK` with the updated entrypoint.
 
-Deletes an entrypoint. Admin only.
+Returns `403 Forbidden` if the entrypoint was discovered from a provider (Docker, Kubernetes, etc.) — those are read-only through the API. To change them, edit the source (container labels, Ingress/HTTPRoute spec, Nomad service tags…).
 
-## Note
+### `DELETE /entrypoints/{id}`
 
-Entrypoints discovered from Docker are **read-only** through the API. To change them, edit the container labels.
+Deletes an entrypoint. **Admin only.** Returns `204 No Content` on success.
+
+```bash
+curl -X DELETE -u admin:your-password http://localhost:3035/entrypoints/http_my-api
+```
+
+Same `403 Forbidden` rule as `PUT`: provider-owned entrypoints cannot be deleted through the API.
+
+### `GET /providers`
+
+Snapshot of every provider sōzune knows about, with its `enabled` flag and the number of entrypoints it currently owns in the storage. Useful for a dashboard "what's wired up?" overview. Available to both roles.
+
+```bash
+curl -u admin:your-password http://localhost:3035/providers
+```
+
+```json
+{
+  "providers": [
+    { "name": "docker",     "enabled": true,  "configured": true,  "entrypoint_count": 5 },
+    { "name": "podman",     "enabled": false, "configured": false, "entrypoint_count": 0 },
+    { "name": "swarm",      "enabled": false, "configured": false, "entrypoint_count": 0 },
+    { "name": "kubernetes", "enabled": true,  "configured": true,  "entrypoint_count": 12 },
+    { "name": "nomad",      "enabled": false, "configured": false, "entrypoint_count": 0 },
+    { "name": "http",       "enabled": false, "configured": false, "entrypoint_count": 0 },
+    { "name": "config",     "enabled": true,  "configured": true,  "entrypoint_count": 2 }
+  ]
+}
+```
+
+- `name`: identifier matching `entrypoint.source` for entrypoints emitted by this provider
+- `configured`: the provider block exists in `config.yaml` (truthy when `providers.<name>` is present, regardless of `enabled`)
+- `enabled`: the provider's `enabled` flag from `config.yaml` — only enabled providers are actually running and contributing entrypoints
+- `entrypoint_count`: live count of entrypoints in storage whose `source` matches this provider name
+
+The list always contains every known provider, even when not configured, so the dashboard can render "configure me" rows next to inactive providers.
+
+### `GET /diagnostics`
+
+Snapshot of every diagnostic sōzune has computed: per-candidate diagnostics from the parser, plus global lints (e.g. `W015` ACME enabled but no `tls=true`) and runtime collision lints (`W018`). Available to both roles.
+
+```bash
+curl -u admin:your-password http://localhost:3035/diagnostics
+```
+
+```json
+{
+  "total": 3,
+  "global": [
+    {
+      "code": "W015",
+      "severity": "warn",
+      "message": "ACME enabled but no entrypoint declares tls=true",
+      "hint": "set tls=true on at least one HTTP entrypoint to enable certificate provisioning"
+    }
+  ],
+  "items": [
+    {
+      "candidate_id": "/sozune-test-app",
+      "diagnostics": [
+        {
+          "code": "W001",
+          "severity": "warn",
+          "label": "sozune.http.app.port",
+          "value": "abc",
+          "message": "invalid port value, falling back to default",
+          "hint": "use a positive integer between 1 and 65535"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `total`: number of diagnostics across `global` + every `items[*].diagnostics`
+- `global`: cross-cutting diagnostics not tied to a single candidate
+- `items`: per-candidate diagnostics, sorted by `candidate_id` for stable ordering
+
+The full diagnostic code reference is documented at [`sozune explain <CODE>`](/documentation/configuration/diagnostics).
+
+## Entrypoint schema
+
+The canonical shape of an entrypoint as returned by `GET /entrypoints`, `GET /entrypoints/{id}`, `POST`, and `PUT`:
+
+```jsonc
+{
+  "id": "http_my-api",                  // sōzune-generated, stable across reloads
+  "name": "my-api",                     // user-supplied, used as the cluster name
+  "protocol": "Http",                   // "Http" | "Tcp" | "Udp"
+  "backends": [
+    { "address": "10.0.0.5", "port": 8080, "weight": 100 }
+  ],
+  "source": "api",                      // "api" | "docker" | "swarm" | "kubernetes" | "nomad" | "http" | "config"
+  "config": {
+    "hostnames": ["api.example.com"],   // exact, wildcard (*.example.com), or regex (/[a-z]+.example.com/)
+    "path": {                           // optional path matcher
+      "rule_type": "Prefix",            // "Prefix" | "Exact" | "Regex"
+      "value": "/v1"
+    },
+    "tls": true,                        // enable TLS termination (provisions an ACME cert)
+    "strip_prefix": false,
+    "add_prefix": null,                 // string, mutually exclusive with strip_prefix
+    "https_redirect": true,
+    "https_redirect_port": null,        // override 443
+    "redirect": null,                   // "forward" | "permanent" | "unauthorized"
+    "redirect_scheme": null,            // "use_same" | "use_http" | "use_https"
+    "redirect_template": null,
+    "www_authenticate": null,
+    "priority": 0,                      // higher wins on rule collision
+    "auth": null,                       // see below
+    "forward_auth": null,               // see below
+    "headers": [],                      // see below
+    "backend_timeout": null,            // milliseconds
+    "rate_limit": null,                 // see below
+    "sticky_session": false,
+    "compress": false,                  // zstd/br/gzip negotiated via Accept-Encoding
+    "entrypoint": null,                 // TCP listener name (required for protocol=Tcp)
+    "methods": []                       // ["GET", "POST", ...]; empty = any method
+  },
+  "unhealthy_backends": [],             // only on GET responses
+  "diagnostics": []                     // only on GET responses
+}
+```
+
+### Sub-schemas
+
+`auth` (basic auth on this route):
+
+```jsonc
+{
+  "basic": [
+    { "username": "alice", "password_hash": "<sha256-hex>" }
+  ]
+}
+```
+
+`forward_auth`:
+
+```jsonc
+{
+  "address": "http://authelia:9091/api/verify",
+  "response_headers": ["Remote-User", "Remote-Email", "Remote-Groups"],
+  "trust_forward_header": false
+}
+```
+
+`headers` (each item adds or replaces one header on the request, response, or both):
+
+```jsonc
+[
+  { "name": "X-Powered-By", "value": "sozune", "direction": "response" }
+]
+```
+
+`direction` is `"request"`, `"response"`, or `"both"`. Defaults to `"request"`.
+
+`rate_limit`:
+
+```jsonc
+{ "average": 100, "burst": 50 }
+```
+
+`average` is requests per second; `burst` is the bucket size. `burst < average` disables the burst window.
+
+## `CreateEntrypointRequest` schema
+
+POST and PUT accept the same body shape — the four required top-level fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Logical service name. Becomes part of the generated `id`. |
+| `backends` | array of `Backend` | At least one backend; each has `address` (IPv4, IPv6, or hostname), `port`, and optional `weight` (defaults to `100`) |
+| `protocol` | `"Http"` \| `"Tcp"` \| `"Udp"` | Routing protocol. UDP is parsed but not yet wired in. |
+| `config` | `EntrypointConfig` | All routing options. See [Entrypoint schema](#entrypoint-schema). Every field except `hostnames` and `priority` is optional and defaults to its zero value. |
+
+`id` and `source` are ignored if present in the request — sōzune assigns them.
+
+## Diagnostic schema
+
+```jsonc
+{
+  "code": "W001",
+  "severity": "error" | "warn" | "info",
+  "message": "invalid port value, falling back to default",
+  "label": "sozune.http.app.port",   // optional: the offending label name
+  "value": "abc",                    // optional: the offending value
+  "hint": "use a positive integer between 1 and 65535"  // optional remediation hint
+}
+```
+
+Run `sozune explain <CODE>` for the full cause / effect / fix / example of each code.
+
+## Note on provider-owned entrypoints
+
+Entrypoints discovered from a provider (Docker labels, Kubernetes Ingress/HTTPRoute, Nomad service tags, Swarm service labels, HTTP poll, config file) are **read-only through the API**. `PUT` and `DELETE` against them return `403 Forbidden`. To change them, edit the source.
+
+The `source` field on each entrypoint indicates which provider owns it — useful when the dashboard wants to render "edit through Docker" vs "edit through API" affordances.

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -25,6 +25,10 @@ pub struct AppState {
     pub unhealthy_backends: Arc<RwLock<HashSet<String>>>,
     pub diagnostics: crate::diagnostics::DiagnosticsStore,
     pub acme_enabled: bool,
+    /// Snapshot of the provider section from `config.yaml`. Read-only — used
+    /// by `GET /providers` to surface which providers are configured and
+    /// whether their `enabled` flag is set.
+    pub providers: crate::config::ProvidersConfig,
 }
 
 /// Build the JSON payload for an entrypoint, augmenting it with the
@@ -162,6 +166,7 @@ pub async fn serve(
     unhealthy_backends: Arc<RwLock<HashSet<String>>>,
     diagnostics: crate::diagnostics::DiagnosticsStore,
     acme_enabled: bool,
+    providers: crate::config::ProvidersConfig,
 ) -> anyhow::Result<()> {
     if config.users.is_empty() {
         anyhow::bail!(
@@ -176,6 +181,7 @@ pub async fn serve(
         unhealthy_backends,
         diagnostics,
         acme_enabled,
+        providers,
     };
 
     let protected = Router::new()
@@ -190,6 +196,7 @@ pub async fn serve(
                 .delete(delete_entrypoint),
         )
         .route("/diagnostics", get(list_diagnostics))
+        .route("/providers", get(list_providers))
         .route_layer(axum_middleware::from_fn(require_admin));
 
     let me_route = Router::new().route("/me", get(me));
@@ -405,6 +412,95 @@ fn global_lints(state: &AppState) -> Vec<crate::labels::diagnostic::Diagnostic> 
         out.push(d);
     }
     out
+}
+
+/// `GET /providers` — snapshot of every provider sōzune knows about, its
+/// configured `enabled` flag, and how many entrypoints it currently owns in
+/// the storage. Lets the dashboard render a "what's wired up?" overview
+/// without inferring it from the entrypoint list.
+async fn list_providers(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
+    let storage = match state.storage.read() {
+        Ok(guard) => guard,
+        Err(e) => {
+            error!(
+                "internal state corrupted (configuration store), restart required: {}",
+                e
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal server error"})),
+            );
+        }
+    };
+
+    // Count entrypoints per source so the dashboard can show "Docker: 5
+    // entrypoints" next to each provider row. Sources sōzune emits today
+    // are listed under `documented_sources` below; an unknown source still
+    // gets counted but won't have a matching provider row.
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for ep in storage.values() {
+        if let Some(src) = ep.source.as_deref() {
+            *counts.entry(src.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    let providers = &state.providers;
+    let rows = [
+        (
+            "docker",
+            providers.docker.as_ref().is_some_and(|c| c.enabled),
+            providers.docker.is_some(),
+        ),
+        (
+            "podman",
+            providers.podman.as_ref().is_some_and(|c| c.enabled),
+            providers.podman.is_some(),
+        ),
+        (
+            "swarm",
+            providers.swarm.as_ref().is_some_and(|c| c.enabled),
+            providers.swarm.is_some(),
+        ),
+        (
+            "kubernetes",
+            providers.kubernetes.as_ref().is_some_and(|c| c.enabled),
+            providers.kubernetes.is_some(),
+        ),
+        (
+            "nomad",
+            providers.nomad.as_ref().is_some_and(|c| c.enabled),
+            providers.nomad.is_some(),
+        ),
+        (
+            "http",
+            providers.http.as_ref().is_some_and(|c| c.enabled),
+            providers.http.is_some(),
+        ),
+        (
+            "config",
+            providers.config_file.as_ref().is_some_and(|c| c.enabled),
+            providers.config_file.is_some(),
+        ),
+    ];
+
+    let items: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|(name, enabled, configured)| {
+            serde_json::json!({
+                "name": name,
+                "enabled": enabled,
+                "configured": configured,
+                "entrypoint_count": counts.get(*name).copied().unwrap_or(0),
+            })
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "providers": items,
+        })),
+    )
 }
 
 async fn get_entrypoint(
@@ -655,6 +751,7 @@ mod tests {
             unhealthy_backends: Arc::new(RwLock::new(HashSet::new())),
             diagnostics: crate::diagnostics::new_store(),
             acme_enabled: false,
+            providers: crate::config::ProvidersConfig::default(),
         }
     }
 
@@ -671,6 +768,7 @@ mod tests {
                     .delete(delete_entrypoint),
             )
             .route("/diagnostics", get(list_diagnostics))
+            .route("/providers", get(list_providers))
             .route_layer(axum_middleware::from_fn(require_admin));
 
         let me_route = Router::new().route("/me", get(me));
@@ -1761,6 +1859,118 @@ mod tests {
             response.status(),
             StatusCode::OK,
             "GET /diagnostics is a read endpoint and must be open to read-only users"
+        );
+    }
+
+    // ---- /providers -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn providers_endpoint_lists_every_known_provider() {
+        let app = test_app(test_state());
+        let response = app
+            .oneshot(
+                Request::get("/providers")
+                    .header("authorization", basic("admin", "admin-pass"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let items = json["providers"].as_array().expect("providers is an array");
+
+        // Every provider known to sōzune must appear in the list, even when
+        // not configured — the dashboard relies on the full set to show
+        // "configure me" rows next to inactive providers.
+        let names: Vec<&str> = items.iter().map(|p| p["name"].as_str().unwrap()).collect();
+        for expected in [
+            "docker",
+            "podman",
+            "swarm",
+            "kubernetes",
+            "nomad",
+            "http",
+            "config",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "missing provider `{}` in /providers response: got {:?}",
+                expected,
+                names
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn providers_endpoint_counts_entrypoints_per_source() {
+        let state = test_state();
+        {
+            let mut storage = state.storage.write().unwrap();
+            storage.insert(
+                "a".into(),
+                make_ep("a", "x.example.com", None, Some("docker")),
+            );
+            storage.insert(
+                "b".into(),
+                make_ep("b", "y.example.com", None, Some("docker")),
+            );
+            storage.insert(
+                "c".into(),
+                make_ep("c", "z.example.com", None, Some("nomad")),
+            );
+        }
+        let app = test_app(state);
+        let response = app
+            .oneshot(
+                Request::get("/providers")
+                    .header("authorization", basic("admin", "admin-pass"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let items = json["providers"].as_array().unwrap();
+        let count_for = |name: &str| -> u64 {
+            items
+                .iter()
+                .find(|p| p["name"] == name)
+                .and_then(|p| p["entrypoint_count"].as_u64())
+                .unwrap()
+        };
+        assert_eq!(count_for("docker"), 2);
+        assert_eq!(count_for("nomad"), 1);
+        assert_eq!(count_for("swarm"), 0);
+    }
+
+    #[tokio::test]
+    async fn providers_endpoint_allows_read_only_user() {
+        let app = test_app(test_state_with_users(vec![user(
+            "viewer",
+            "viewer-pass",
+            Role::ReadOnly,
+        )]));
+        let response = app
+            .oneshot(
+                Request::get("/providers")
+                    .header("authorization", basic("viewer", "viewer-pass"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "GET /providers is a read endpoint and must be open to read-only users"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let unhealthy_api = Arc::clone(&unhealthy_backends);
     let diagnostics_api = Arc::clone(&diagnostics_store);
     let acme_enabled_api = acme_enabled;
+    let providers_api = config.providers.clone();
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
@@ -177,6 +178,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 unhealthy_api,
                 diagnostics_api,
                 acme_enabled_api,
+                providers_api,
             )
             .await?;
         }


### PR DESCRIPTION
## Summary

Adds a `GET /providers` REST endpoint and a matching dashboard page so the dashboard (or any operator) can see which providers are configured, which are enabled, and how many entrypoints each one currently owns — without having to infer it from the entrypoint list.

The endpoint also gives an honest reason for `Provider::name()` to exist: previously it was a trait method clippy flagged as `dead_code`. Now `entrypoint.source` (string) and the API row name come from the same place.

## What's in here

### Backend

- `GET /providers` returns the full list of known providers (`docker`, `podman`, `swarm`, `kubernetes`, `nomad`, `http`, `config`) with three flags each:
  - `configured`: the provider block exists in `config.yaml`
  - `enabled`: the configured block has `enabled: true`
  - `entrypoint_count`: live count from storage, filtered by `entrypoint.source`
- Available to both roles (read endpoint). Wired through `require_admin` like `/entrypoints` and `/diagnostics`, which already lets `GET/HEAD/OPTIONS` through for `read-only`.
- 3 new unit tests: every known provider listed, counts per source, read-only access.

### Documentation

`documentation/configuration/api.md` rewritten: 117 → ~365 lines. Adds previously-undocumented endpoints (`/me`, `/diagnostics`, `/providers`), full Entrypoint JSON schema, sub-schemas for `auth` / `forward_auth` / `headers` / `rate_limit`, complete error code table (400/401/403/404/415/422/500), CORS behaviour, and CSRF/role nuances (`GET/HEAD/OPTIONS` always pass).

### Dashboard

New page at `/providers` rendering:
- Two summary cards: `Enabled X/Y providers` and `Total entrypoints across providers`
- A table with one row per provider showing a status pill (`enabled` / `disabled` / `not configured`) and entrypoint count
- Polls every 5s so live count changes show up
- Nav entry "Providers" with a plug icon between Entrypoints and Diagnostics

## Test plan

- [x] `cargo test --bin sozune` — 331/331 (328 + 3 new for `/providers`)
- [x] `cargo fmt --check` clean
- [x] `bash tests/e2e/run-all.sh` — 66/66
- [x] `cd dashboard && bun run build` — OK
- [x] `biome check` on touched files — clean