### PR TITLE
Clean up all remaining clippy warnings

### DIFF
--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -713,7 +713,7 @@ fn parse_asn1_time(data: &[u8]) -> Option<i64> {
 
     // Convert to Unix timestamp (simplified, no leap seconds)
     let days = days_from_civil(year, month, day)?;
-    Some(days as i64 * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64)
+    Some(days * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64)
 }
 
 /// Convert a civil date to days since Unix epoch (algorithm from Howard Hinnant)

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -444,53 +444,49 @@ async fn list_providers(State(state): State<AppState>) -> (StatusCode, Json<serd
         }
     }
 
-    let providers = &state.providers;
-    let rows = [
-        (
-            "docker",
-            providers.docker.as_ref().is_some_and(|c| c.enabled),
-            providers.docker.is_some(),
-        ),
-        (
-            "podman",
-            providers.podman.as_ref().is_some_and(|c| c.enabled),
-            providers.podman.is_some(),
-        ),
-        (
-            "swarm",
-            providers.swarm.as_ref().is_some_and(|c| c.enabled),
-            providers.swarm.is_some(),
-        ),
-        (
-            "kubernetes",
-            providers.kubernetes.as_ref().is_some_and(|c| c.enabled),
-            providers.kubernetes.is_some(),
-        ),
-        (
-            "nomad",
-            providers.nomad.as_ref().is_some_and(|c| c.enabled),
-            providers.nomad.is_some(),
-        ),
-        (
-            "http",
-            providers.http.as_ref().is_some_and(|c| c.enabled),
-            providers.http.is_some(),
-        ),
-        (
-            "config",
-            providers.config_file.as_ref().is_some_and(|c| c.enabled),
-            providers.config_file.is_some(),
-        ),
-    ];
-
-    let items: Vec<serde_json::Value> = rows
+    let p = &state.providers;
+    // Iterate `provider::ALL` so the response order, and the set of names,
+    // come from the same source as `Provider::name()` and `Entrypoint::source`.
+    // Adding a new provider only requires registering its constant in
+    // `provider/mod.rs` and matching it below.
+    let items: Vec<serde_json::Value> = crate::provider::ALL
         .iter()
-        .map(|(name, enabled, configured)| {
+        .map(|&name| {
+            let (configured, enabled) = match name {
+                crate::provider::DOCKER => (
+                    p.docker.is_some(),
+                    p.docker.as_ref().is_some_and(|c| c.enabled),
+                ),
+                crate::provider::PODMAN => (
+                    p.podman.is_some(),
+                    p.podman.as_ref().is_some_and(|c| c.enabled),
+                ),
+                crate::provider::SWARM => (
+                    p.swarm.is_some(),
+                    p.swarm.as_ref().is_some_and(|c| c.enabled),
+                ),
+                crate::provider::KUBERNETES => (
+                    p.kubernetes.is_some(),
+                    p.kubernetes.as_ref().is_some_and(|c| c.enabled),
+                ),
+                crate::provider::NOMAD => (
+                    p.nomad.is_some(),
+                    p.nomad.as_ref().is_some_and(|c| c.enabled),
+                ),
+                crate::provider::HTTP => {
+                    (p.http.is_some(), p.http.as_ref().is_some_and(|c| c.enabled))
+                }
+                crate::provider::CONFIG => (
+                    p.config_file.is_some(),
+                    p.config_file.as_ref().is_some_and(|c| c.enabled),
+                ),
+                _ => (false, false),
+            };
             serde_json::json!({
                 "name": name,
                 "enabled": enabled,
                 "configured": configured,
-                "entrypoint_count": counts.get(*name).copied().unwrap_or(0),
+                "entrypoint_count": counts.get(name).copied().unwrap_or(0),
             })
         })
         .collect();

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -280,21 +280,21 @@ fn check_acme(cfg: &AppConfig, results: &mut Vec<CheckResult>) {
     }
 
     let dir = Path::new(&acme.certs_dir);
-    if !dir.exists() {
-        if let Err(e) = std::fs::create_dir_all(dir) {
-            results.push(
-                CheckResult::fail(
-                    "acme",
-                    format!("ACME directory `{}`", acme.certs_dir),
-                    format!("does not exist and cannot be created: {e}"),
-                )
-                .with_fix(format!(
-                    "create the directory and ensure sozune can write to it: `mkdir -p {} && chown $(id -un) {}`",
-                    acme.certs_dir, acme.certs_dir
-                )),
-            );
-            return;
-        }
+    if !dir.exists()
+        && let Err(e) = std::fs::create_dir_all(dir)
+    {
+        results.push(
+            CheckResult::fail(
+                "acme",
+                format!("ACME directory `{}`", acme.certs_dir),
+                format!("does not exist and cannot be created: {e}"),
+            )
+            .with_fix(format!(
+                "create the directory and ensure sozune can write to it: `mkdir -p {} && chown $(id -un) {}`",
+                acme.certs_dir, acme.certs_dir
+            )),
+        );
+        return;
     }
 
     let probe = dir.join(".sozune-doctor-write-probe");

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -1,7 +1,5 @@
 use clap::Args;
 
-use crate::labels::diagnostic::DiagnosticCode;
-
 #[derive(Args, Debug)]
 pub struct ExplainArgs {
     /// Diagnostic code to explain (e.g. E002, W009, I001).
@@ -293,6 +291,7 @@ const ENTRIES: &[Entry] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::labels::diagnostic::DiagnosticCode;
 
     #[test]
     fn every_diagnostic_code_has_an_entry() {

--- a/src/labels/diagnostic.rs
+++ b/src/labels/diagnostic.rs
@@ -17,6 +17,10 @@ pub enum DiagnosticCode {
     // Errors — block routing
     E001Disabled,
     E002MissingHost,
+    /// Reserved: documented in `sozune explain E003` but not yet emitted at
+    /// runtime. Belongs to the Docker provider when `inspect_container`
+    /// fails — surface that path before removing the variant.
+    #[allow(dead_code)]
     E003InspectFailed,
     E004NoServices,
     E005MissingTcpEntrypoint,
@@ -169,6 +173,11 @@ pub struct ParseResult {
 }
 
 impl ParseResult {
+    /// Whether any diagnostic in this result is `Severity::Error`.
+    /// Exercised by the parser tests; kept as part of the public API surface
+    /// so test fixtures and external consumers can gate on parse errors
+    /// without re-implementing the filter.
+    #[allow(dead_code)]
     pub fn has_errors(&self) -> bool {
         self.diagnostics
             .iter()

--- a/src/labels/source.rs
+++ b/src/labels/source.rs
@@ -8,8 +8,6 @@ use async_trait::async_trait;
 /// trait — they bypass the label parser entirely.
 #[async_trait]
 pub trait LabelSource: Send + Sync {
-    fn provider_name(&self) -> &'static str;
-
     /// Produce one `Candidate` per discoverable unit (container, job, pod).
     async fn collect(&self) -> Result<Vec<Candidate>>;
 }

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -104,13 +104,13 @@ pub async fn evaluate(
     if status.is_success() {
         let mut allow = Vec::new();
         for header_name in &cfg.response_headers {
-            if let Some(v) = resp.headers().get(header_name) {
-                if let (Ok(name), Ok(value)) = (
+            if let Some(v) = resp.headers().get(header_name)
+                && let (Ok(name), Ok(value)) = (
                     HeaderName::try_from(header_name.as_str()),
                     HeaderValue::from_bytes(v.as_bytes()),
-                ) {
-                    allow.push((name, value));
-                }
+                )
+            {
+                allow.push((name, value));
             }
         }
         return ForwardAuthOutcome::Allow { headers: allow };
@@ -175,10 +175,10 @@ fn build_outgoing_headers(
         (_, _, Some(ip)) => ip,
         _ => String::new(),
     };
-    if !appended_xff.is_empty() {
-        if let Ok(v) = HeaderValue::from_str(&appended_xff) {
-            out.insert(HeaderName::from_static("x-forwarded-for"), v);
-        }
+    if !appended_xff.is_empty()
+        && let Ok(v) = HeaderValue::from_str(&appended_xff)
+    {
+        out.insert(HeaderName::from_static("x-forwarded-for"), v);
     }
     out
 }

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -61,7 +61,11 @@ impl RateLimiter {
         }
     }
 
-    /// Remove stale buckets that haven't been used recently
+    /// Remove stale buckets that haven't been used recently. Exercised by
+    /// the rate_limit tests; not yet wired into the runtime — should be
+    /// called periodically (every minute or so) to prevent unbounded growth
+    /// when many ephemeral clients hit the limiter.
+    #[allow(dead_code)]
     pub fn cleanup(&self) {
         let mut buckets = match self.buckets.lock() {
             Ok(guard) => guard,

--- a/src/provider/config.rs
+++ b/src/provider/config.rs
@@ -42,10 +42,6 @@ impl Provider for ConfigProvider {
             .map(|ep| (ep.id.clone(), ep))
             .collect())
     }
-
-    fn name(&self) -> &'static str {
-        "config"
-    }
 }
 
 impl ConfigProvider {
@@ -116,12 +112,15 @@ impl ConfigProvider {
 
                         // Remove existing config entrypoints
                         storage_write.retain(|_, entrypoint| {
-                            entrypoint.source.as_ref().is_none_or(|s| s != "config")
+                            entrypoint
+                                .source
+                                .as_ref()
+                                .is_none_or(|s| s != crate::provider::CONFIG)
                         });
 
                         // Add new config entrypoints
                         for (id, mut entrypoint) in new_entrypoints {
-                            entrypoint.source = Some("config".to_string());
+                            entrypoint.source = Some(crate::provider::CONFIG.to_string());
                             info!("Reloaded config entrypoint: {}", id);
                             storage_write.insert(id, entrypoint);
                         }

--- a/src/provider/docker.rs
+++ b/src/provider/docker.rs
@@ -39,18 +39,10 @@ impl Provider for DockerProvider {
             .map_err(anyhow::Error::new)?;
         Ok(hashmap.into_iter().collect())
     }
-
-    fn name(&self) -> &'static str {
-        self.name
-    }
 }
 
 #[async_trait]
 impl LabelSource for DockerProvider {
-    fn provider_name(&self) -> &'static str {
-        self.name
-    }
-
     async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
         let containers = self
             .docker
@@ -89,7 +81,7 @@ impl LabelSource for DockerProvider {
 
 impl DockerProvider {
     pub fn new(config: DockerConfig) -> Result<Self, bollard::errors::Error> {
-        Self::new_named(config, "docker")
+        Self::new_named(config, crate::provider::DOCKER)
     }
 
     pub fn new_named(
@@ -532,7 +524,7 @@ impl DockerProvider {
             }
 
             for (key, entrypoint) in result.entrypoints {
-                if entrypoint.backends.first().is_none() {
+                if entrypoint.backends.is_empty() {
                     continue;
                 }
                 merge_or_insert_entrypoint(&mut entrypoints, key, entrypoint, &container_id);

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -51,7 +51,7 @@ pub async fn start_services(
                         if storage_write.contains_key(&id) {
                             warn!("Duplicate entrypoint ID {} from config file provider", id);
                         }
-                        entrypoint.source = Some("config".to_string());
+                        entrypoint.source = Some(crate::provider::CONFIG.to_string());
                         info!("Loaded entrypoint from config: {}", id);
                         storage_write.insert(id, entrypoint);
                     }

--- a/src/provider/http.rs
+++ b/src/provider/http.rs
@@ -71,7 +71,7 @@ impl HttpProvider {
 
                         let old_ids: std::collections::HashSet<&String> = storage_read
                             .iter()
-                            .filter(|(_, ep)| ep.source.as_deref() == Some("http"))
+                            .filter(|(_, ep)| ep.source.as_deref() == Some(crate::provider::HTTP))
                             .map(|(id, _)| id)
                             .collect();
 
@@ -102,9 +102,10 @@ impl HttpProvider {
                                 continue;
                             }
                         };
-                        storage_write.retain(|_, ep| ep.source.as_deref() != Some("http"));
+                        storage_write
+                            .retain(|_, ep| ep.source.as_deref() != Some(crate::provider::HTTP));
                         for (id, mut entrypoint) in new_entrypoints {
-                            entrypoint.source = Some("http".to_string());
+                            entrypoint.source = Some(crate::provider::HTTP.to_string());
                             debug!("HTTP provider entrypoint: {}", id);
                             storage_write.insert(id, entrypoint);
                         }
@@ -240,7 +241,7 @@ mod tests {
         let storage_read = storage.read().unwrap();
         assert_eq!(storage_read.len(), 1);
         let ep = storage_read.get("web").unwrap();
-        assert_eq!(ep.source.as_deref(), Some("http"));
+        assert_eq!(ep.source.as_deref(), Some(crate::provider::HTTP));
         assert_eq!(ep.config.hostnames, vec!["example.com"]);
     }
 

--- a/src/provider/kubernetes/mod.rs
+++ b/src/provider/kubernetes/mod.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, RwLock};
 use tokio::sync::{Notify, mpsc};
 use tracing::{debug, error, info, warn};
 
-const PROVIDER_NAME: &str = "kubernetes";
+const PROVIDER_NAME: &str = crate::provider::KUBERNETES;
 const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 
 /// Maps `namespace/service` → (slice name → ready pod IPs from that slice).
@@ -71,18 +71,10 @@ impl Provider for KubernetesProvider {
         }
         Ok(entrypoints)
     }
-
-    fn name(&self) -> &'static str {
-        self.name
-    }
 }
 
 #[async_trait]
 impl LabelSource for KubernetesProvider {
-    fn provider_name(&self) -> &'static str {
-        self.name
-    }
-
     async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
         let client = self.build_client().await?;
         let services: Api<Service> = self.scoped_api(&client);

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2,10 +2,25 @@ use crate::model::Entrypoint;
 use async_trait::async_trait;
 use std::collections::BTreeMap;
 
+/// Canonical provider identifiers. Each provider's `Provider::name()`
+/// returns one of these, every `Entrypoint::source` set by a provider
+/// uses one of these, and the `/providers` API endpoint iterates over
+/// `ALL` to render its rows. Single source of truth so the three never
+/// drift apart.
+pub const DOCKER: &str = "docker";
+pub const PODMAN: &str = "podman";
+pub const SWARM: &str = "swarm";
+pub const KUBERNETES: &str = "kubernetes";
+pub const NOMAD: &str = "nomad";
+pub const HTTP: &str = "http";
+pub const CONFIG: &str = "config";
+
+/// Every provider known to sōzune, in display order for `/providers`.
+pub const ALL: &[&str] = &[DOCKER, PODMAN, SWARM, KUBERNETES, NOMAD, HTTP, CONFIG];
+
 #[async_trait]
 pub trait Provider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>>;
-    fn name(&self) -> &'static str;
 }
 
 pub mod config;

--- a/src/provider/nomad.rs
+++ b/src/provider/nomad.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use tokio::sync::{Notify, mpsc};
 use tracing::{debug, error, info, warn};
 
-const PROVIDER_NAME: &str = "nomad";
+const PROVIDER_NAME: &str = crate::provider::NOMAD;
 const NETWORK_NAME: &str = "nomad";
 
 pub struct NomadProvider {
@@ -29,10 +29,6 @@ impl Provider for NomadProvider {
         // diagnostics are at least logged.
         let throwaway = diagnostics::new_store();
         self.provide_into(&throwaway).await
-    }
-
-    fn name(&self) -> &'static str {
-        PROVIDER_NAME
     }
 }
 
@@ -67,10 +63,6 @@ impl NomadProvider {
 
 #[async_trait]
 impl LabelSource for NomadProvider {
-    fn provider_name(&self) -> &'static str {
-        PROVIDER_NAME
-    }
-
     async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
         let (services, _) = self.list_services(None).await?;
         let mut candidates = Vec::new();

--- a/src/provider/podman.rs
+++ b/src/provider/podman.rs
@@ -22,7 +22,7 @@ impl PodmanProvider {
             expose_by_default: config.expose_by_default,
         };
         Ok(Self {
-            inner: DockerProvider::new_named(docker_config, "podman")?,
+            inner: DockerProvider::new_named(docker_config, crate::provider::PODMAN)?,
         })
     }
 
@@ -44,18 +44,10 @@ impl Provider for PodmanProvider {
     async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
         self.inner.provide().await
     }
-
-    fn name(&self) -> &'static str {
-        "podman"
-    }
 }
 
 #[async_trait]
 impl LabelSource for PodmanProvider {
-    fn provider_name(&self) -> &'static str {
-        "podman"
-    }
-
     async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
         self.inner.collect().await
     }

--- a/src/provider/swarm.rs
+++ b/src/provider/swarm.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use tokio::sync::{Notify, mpsc};
 use tracing::{debug, error, info, warn};
 
-const SOURCE: &str = "swarm";
+const SOURCE: &str = crate::provider::SWARM;
 
 pub struct SwarmProvider {
     docker: Docker,
@@ -375,10 +375,6 @@ impl Provider for SwarmProvider {
         let throwaway = diagnostics::new_store();
         self.provide_into(&throwaway).await
     }
-
-    fn name(&self) -> &'static str {
-        SOURCE
-    }
 }
 
 impl SwarmProvider {
@@ -414,10 +410,6 @@ impl SwarmProvider {
 
 #[async_trait]
 impl LabelSource for SwarmProvider {
-    fn provider_name(&self) -> &'static str {
-        SOURCE
-    }
-
     async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
         self.build_candidates().await.map_err(anyhow::Error::new)
     }

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -27,7 +27,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
 /// Snapshot of the storage at the moment of the last successful reload, keyed
@@ -215,7 +214,7 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
     wait_for_worker_ready(&mut command_channel_https, "HTTPS", timeout)?;
 
     // Spawn one Sōzu TCP worker per declared listener.
-    let (mut tcp_channels, tcp_worker_handles) = spawn_tcp_workers(config)?;
+    let (tcp_channels, tcp_worker_handles) = spawn_tcp_workers(config)?;
 
     // Initial configuration will be handled by provider reload signals
     info!("Waiting for providers to populate configuration");
@@ -916,8 +915,6 @@ fn configure_tcp_entrypoint(
         }
     }
 }
-
-/// Register the ACME challenge cluster and backend (frontends are added per-hostname during reload)
 
 fn remove_http_frontends(
     command_channel: &mut Channel<WorkerRequest, WorkerResponse>,


### PR DESCRIPTION
## Summary

`cargo clippy --bin sozune` went from **14 warnings** down to **0**. Goal: silence the noise so the next warning to appear is visible immediately instead of drowning in pre-existing ones.

No behaviour change — all unit tests (331/331) and Docker e2e (66/66) still pass.

## Fixes applied

### Mechanical (clippy auto-suggestions)

- Removed unused imports: `DiagnosticCode` (moved into the `#[cfg(test)]` module that actually uses it), `tokio::sync::mpsc` from `proxy/sozu/mod.rs`
- Removed orphan doc-comment in `proxy/sozu/mod.rs:920` left over from the ACME split refactor
- Removed `mut` from `tcp_channels` (never mutated before being moved into `Channels`)
- Removed `as i64` cast on a value already typed `i64` in `acme/mod.rs`
- Collapsed 3× nested `if`s (`cli/doctor.rs`, `middleware/forward_auth.rs` ×2) using `if X && let Y = ... { }`
- Replaced `first().is_none()` with `is_empty()` in `provider/docker.rs`

### Dead trait methods removed

- `LabelSource::provider_name()` — defined but never called. Removed from the trait and from all 5 impls (`docker`, `podman`, `swarm`, `nomad`, `kubernetes`). `Candidate::provider` already carries this information.
- `Provider::name()` — same story. Removed from the trait and 6 impls. The new constants below replace it everywhere it could have been useful.

### Single source of truth for provider names

`src/provider/mod.rs` now exports canonical identifiers:

```rust
pub const DOCKER: &str = "docker";
pub const PODMAN: &str = "podman";
pub const SWARM: &str = "swarm";
pub const KUBERNETES: &str = "kubernetes";
pub const NOMAD: &str = "nomad";
pub const HTTP: &str = "http";
pub const CONFIG: &str = "config";

pub const ALL: &[&str] = &[DOCKER, PODMAN, SWARM, KUBERNETES, NOMAD, HTTP, CONFIG];
```

Every place that used to hardcode `"docker"`/`"swarm"`/etc. now references the constants:
- `Entrypoint::source` assignments in each provider
- `list_providers` API handler iterates on `ALL` instead of a hardcoded `rows` array
- `DockerProvider::new()` and `PodmanProvider::new()` pass the constants into `new_named()`
- The `SOURCE` / `PROVIDER_NAME` constants inside each provider module now point at the central constants

Adding a new provider now means adding **one constant + one match arm in `list_providers`**, instead of three independent strings that could drift.

### Documented dead code

Three items kept and marked `#[allow(dead_code)]` with explanatory comments instead of being deleted:

- `ParseResult::has_errors()` — exercised by parser tests, useful as part of the public API surface
- `RateLimiter::cleanup()` — exercised by rate-limit tests, **should** be wired into a periodic task in the runtime (noted as TODO in the comment)
- `DiagnosticCode::E003InspectFailed` — documented by `sozune explain E003` but no provider emits it yet. Belongs to Docker's `inspect_container` failure path — noted as a real gap to fill before removing.

## Test plan

- [x] `cargo clippy --bin sozune` — 0 warnings (was 14)
- [x] `cargo test --bin sozune` — 331/331
- [x] `cargo fmt --check` clean
- [x] `bash tests/e2e/run-all.sh` — 66/66

## Diff size

18 files, +112 / -134 (-22 lines net). The code is shorter despite the docstrings added to the `#[allow(dead_code)]` items.