### PR TITLE
Middleware pipeline behind a trait

### DIFF
--- a/src/middleware/chain.rs
+++ b/src/middleware/chain.rs
@@ -1,0 +1,78 @@
+use axum::body::Body;
+use axum::http::{Request, Response};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use super::compress::Encoding;
+
+/// Shared per-request context passed to every middleware. Holds values that
+/// middlewares need but don't carry on the request itself (client address,
+/// resolved host, the negotiated response encoding picked from the request's
+/// `Accept-Encoding` but applied on the response).
+pub struct RequestCtx {
+    pub host: String,
+    pub client_addr: Option<SocketAddr>,
+    pub is_tls: bool,
+    /// Encoding negotiated from the request, consumed by the compression
+    /// middleware on the response side. `None` if the client accepts nothing
+    /// we support.
+    pub client_encoding: Option<Encoding>,
+}
+
+/// Outcome of a middleware's request phase.
+pub enum Flow {
+    /// Proceed down the chain. The middleware may have mutated the request
+    /// (e.g. forward-auth stamping headers).
+    Continue,
+    /// Stop here: return this response to the client. The backend and any
+    /// later middlewares are skipped.
+    ShortCircuit(Response<Body>),
+}
+
+/// A single middleware in the pipeline.
+///
+/// `on_request` runs before the backend (in chain order) and may mutate the
+/// request or short-circuit. `on_response` runs after the backend (in reverse
+/// order, onion-style) and transforms the response.
+#[async_trait::async_trait]
+pub trait Middleware: Send + Sync {
+    /// Stable identifier used in logs and diagnostics.
+    fn name(&self) -> &'static str;
+
+    async fn on_request(&self, _ctx: &mut RequestCtx, _req: &mut Request<Body>) -> Flow {
+        Flow::Continue
+    }
+
+    async fn on_response(&self, _ctx: &RequestCtx, resp: Response<Body>) -> Response<Body> {
+        resp
+    }
+}
+
+/// Run the request phase of every middleware in order. Returns `Err(response)`
+/// the moment one short-circuits, so the caller can return it without touching
+/// the backend.
+pub async fn run_request_phase(
+    middlewares: &[Arc<dyn Middleware>],
+    ctx: &mut RequestCtx,
+    req: &mut Request<Body>,
+) -> Result<(), Response<Body>> {
+    for mw in middlewares {
+        match mw.on_request(ctx, req).await {
+            Flow::Continue => {}
+            Flow::ShortCircuit(resp) => return Err(resp),
+        }
+    }
+    Ok(())
+}
+
+/// Run the response phase in reverse order (onion model).
+pub async fn run_response_phase(
+    middlewares: &[Arc<dyn Middleware>],
+    ctx: &RequestCtx,
+    mut resp: Response<Body>,
+) -> Response<Body> {
+    for mw in middlewares.iter().rev() {
+        resp = mw.on_response(ctx, resp).await;
+    }
+    resp
+}

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -1,8 +1,15 @@
-use axum::http::HeaderMap;
+use axum::body::Body;
+use axum::http::{HeaderMap, Request, Response};
+use axum::response::IntoResponse;
 use brotli::enc::BrotliEncoderParams;
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use http_body_util::BodyExt;
 use std::io::Write;
+use tracing::{debug, error};
+
+use super::chain::{Flow, Middleware, RequestCtx};
+use super::diag;
 
 const COMPRESSIBLE_TYPES: &[&str] = &[
     "text/",
@@ -95,6 +102,62 @@ fn brotli_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
 
 fn zstd_compress(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     zstd::encode_all(std::io::Cursor::new(data), 3)
+}
+
+/// Middleware wrapper: compresses the response body when the client accepts a
+/// supported encoding and the content is compressible. The encoding is
+/// negotiated from the request (`ctx.client_encoding`) and applied here on the
+/// response. Behavior matches the previous inline compression step.
+pub struct CompressMiddleware;
+
+#[async_trait::async_trait]
+impl Middleware for CompressMiddleware {
+    fn name(&self) -> &'static str {
+        "compress"
+    }
+
+    async fn on_request(&self, ctx: &mut RequestCtx, req: &mut Request<Body>) -> Flow {
+        // Negotiate now, on the request, but apply on the response.
+        ctx.client_encoding = pick_encoding(req.headers());
+        Flow::Continue
+    }
+
+    async fn on_response(&self, ctx: &RequestCtx, resp: Response<Body>) -> Response<Body> {
+        let (mut parts, body) = resp.into_parts();
+
+        let encoding = ctx
+            .client_encoding
+            .filter(|_| is_compressible(&parts.headers) && !is_already_compressed(&parts.headers));
+
+        let Some(encoding) = encoding else {
+            return Response::from_parts(parts, body);
+        };
+
+        let body = Body::new(body.map_err(|e| axum::Error::new(std::io::Error::other(e))));
+        match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
+            Ok(bytes) => match compress(&bytes, encoding) {
+                Ok(compressed) => {
+                    parts
+                        .headers
+                        .insert("content-encoding", encoding.header_value().parse().unwrap());
+                    parts.headers.insert(
+                        "content-length",
+                        compressed.len().to_string().parse().unwrap(),
+                    );
+                    parts.headers.remove("transfer-encoding");
+                    Response::from_parts(parts, Body::from(compressed))
+                }
+                Err(e) => {
+                    debug!("Compression failed, sending uncompressed: {}", e);
+                    Response::from_parts(parts, Body::from(bytes))
+                }
+            },
+            Err(e) => {
+                error!("Failed to read response body for compression: {}", e);
+                diag::forwarding_failed("response-body-read-failed", &e.to_string()).into_response()
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -1,8 +1,9 @@
 use axum::body::Body;
-use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, Response, StatusCode};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode};
 use std::net::SocketAddr;
 use tracing::{debug, error, warn};
 
+use super::chain::{Flow, Middleware, RequestCtx};
 use crate::model::ForwardAuthConfig;
 
 /// Snapshot of the incoming request needed to call the forward-auth endpoint.
@@ -143,6 +144,54 @@ pub async fn evaluate(
         .body(Body::from(body_bytes))
         .unwrap_or_else(|_| bad_gateway("forward-auth: cannot build response"));
     ForwardAuthOutcome::Deny(response)
+}
+
+/// Middleware wrapper: calls the forward-auth endpoint before the backend.
+/// On allow, stamps the configured response headers onto the request; on deny,
+/// short-circuits with the auth service's response. Matches the previous
+/// inline forward-auth step (which ran first in the chain).
+pub struct ForwardAuthMiddleware {
+    config: ForwardAuthConfig,
+    client: reqwest::Client,
+}
+
+impl ForwardAuthMiddleware {
+    pub fn new(config: ForwardAuthConfig, client: reqwest::Client) -> Self {
+        Self { config, client }
+    }
+}
+
+#[async_trait::async_trait]
+impl Middleware for ForwardAuthMiddleware {
+    fn name(&self) -> &'static str {
+        "forward-auth"
+    }
+
+    async fn on_request(&self, ctx: &mut RequestCtx, req: &mut Request<Body>) -> Flow {
+        // Snapshot the request before the async call so the future stays Send
+        // (axum Body is !Sync).
+        let snapshot = AuthRequestSnapshot {
+            method: req.method().clone(),
+            uri: req
+                .uri()
+                .path_and_query()
+                .map(|pq| pq.as_str().to_string())
+                .unwrap_or_else(|| req.uri().path().to_string()),
+            host: ctx.host.clone(),
+            headers: req.headers().clone(),
+            is_tls: ctx.is_tls,
+        };
+
+        match evaluate(&self.client, &self.config, snapshot, ctx.client_addr).await {
+            ForwardAuthOutcome::Allow { headers } => {
+                for (name, value) in headers {
+                    req.headers_mut().insert(name, value);
+                }
+                Flow::Continue
+            }
+            ForwardAuthOutcome::Deny(response) => Flow::ShortCircuit(response),
+        }
+    }
 }
 
 fn build_outgoing_headers(

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,4 @@
+pub mod chain;
 mod compress;
 mod diag;
 mod forward_auth;
@@ -12,15 +13,27 @@ use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
 use tracing::info;
 
-use crate::model::{Backend, EntrypointConfig, ForwardAuthConfig};
-use rate_limit::RateLimiter;
+use crate::model::{Backend, EntrypointConfig};
+use chain::Middleware;
+use compress::CompressMiddleware;
+use forward_auth::ForwardAuthMiddleware;
+use rate_limit::{RateLimitMiddleware, RateLimiter};
+
+/// Build the shared HTTP client used by forward-auth middlewares. Same config
+/// as before: short timeout, no redirect following.
+pub fn build_forward_auth_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(forward_auth::TIMEOUT_SECS))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("reqwest client builds with default config")
+}
 
 /// Shared state for the middleware server
 #[derive(Clone)]
 pub struct MiddlewareAppState {
     pub route_table: Arc<RwLock<MiddlewareRouteTable>>,
     pub http_client: Client<hyper_util::client::legacy::connect::HttpConnector, axum::body::Body>,
-    pub forward_auth_client: reqwest::Client,
 }
 
 pub type MiddlewareState = Arc<RwLock<MiddlewareRouteTable>>;
@@ -31,15 +44,33 @@ pub struct MiddlewareRouteTable {
     pub(super) routes: std::collections::HashMap<String, Arc<MiddlewareRoute>>,
 }
 
-/// Middleware configuration for a single entrypoint
-#[derive(Debug)]
+/// Middleware configuration for a single entrypoint.
+///
+/// The middleware stack is an ordered list run before (and after) the backend.
+/// `backend_timeout` is not a middleware — it's a property of the backend
+/// forward itself — so it stays a plain field.
 pub struct MiddlewareRoute {
     pub backends: Vec<(String, u16)>,
     pub backend_counter: AtomicUsize,
     pub backend_timeout: Option<u64>,
-    pub rate_limiter: Option<RateLimiter>,
-    pub compress: bool,
-    pub forward_auth: Option<ForwardAuthConfig>,
+    pub middlewares: Vec<Arc<dyn Middleware>>,
+}
+
+impl std::fmt::Debug for MiddlewareRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MiddlewareRoute")
+            .field("backends", &self.backends)
+            .field("backend_timeout", &self.backend_timeout)
+            .field(
+                "middlewares",
+                &self
+                    .middlewares
+                    .iter()
+                    .map(|m| m.name())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
 }
 
 impl MiddlewareRouteTable {
@@ -89,15 +120,35 @@ pub fn needs_middleware(config: &EntrypointConfig) -> bool {
         || config.forward_auth.is_some()
 }
 
-/// Build middleware route from entrypoint config
+/// Build middleware route from entrypoint config.
+///
+/// The stack is assembled in the same order the proxy applied it inline:
+/// forward-auth, then rate-limit (both before the backend), then compression
+/// (on the response). `forward_auth_client` is the shared client from
+/// [`build_forward_auth_client`].
 pub fn build_middleware_route(
     config: &EntrypointConfig,
     backends: &[Backend],
+    forward_auth_client: &reqwest::Client,
 ) -> Arc<MiddlewareRoute> {
-    let rate_limiter = config
-        .rate_limit
-        .as_ref()
-        .map(|rl| RateLimiter::new(rl.average, rl.burst));
+    let mut middlewares: Vec<Arc<dyn Middleware>> = Vec::new();
+
+    if let Some(cfg) = config.forward_auth.as_ref() {
+        middlewares.push(Arc::new(ForwardAuthMiddleware::new(
+            cfg.clone(),
+            forward_auth_client.clone(),
+        )));
+    }
+
+    if let Some(rl) = config.rate_limit.as_ref() {
+        middlewares.push(Arc::new(RateLimitMiddleware::new(RateLimiter::new(
+            rl.average, rl.burst,
+        ))));
+    }
+
+    if config.compress {
+        middlewares.push(Arc::new(CompressMiddleware));
+    }
 
     Arc::new(MiddlewareRoute {
         backends: backends
@@ -106,9 +157,7 @@ pub fn build_middleware_route(
             .collect(),
         backend_counter: AtomicUsize::new(0),
         backend_timeout: config.backend_timeout,
-        rate_limiter,
-        compress: config.compress,
-        forward_auth: config.forward_auth.clone(),
+        middlewares,
     })
 }
 
@@ -117,11 +166,6 @@ pub async fn serve(port: u16, route_table: MiddlewareState) -> anyhow::Result<()
     let app_state = MiddlewareAppState {
         route_table,
         http_client: Client::builder(TokioExecutor::new()).build_http(),
-        forward_auth_client: reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(forward_auth::TIMEOUT_SECS))
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("reqwest client builds with default config"),
     };
 
     let app = Router::new()

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -1,6 +1,6 @@
 use axum::body::Body;
 use axum::extract::{ConnectInfo, State};
-use axum::http::{HeaderName, HeaderValue, Request, Response, StatusCode, Uri};
+use axum::http::{Request, Response, StatusCode, Uri};
 use axum::response::IntoResponse;
 use http_body_util::BodyExt;
 use std::net::SocketAddr;
@@ -9,16 +9,14 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, error, info, warn};
 
 use super::MiddlewareAppState;
-use super::compress;
+use super::chain::{self, RequestCtx};
 use super::diag;
-use super::forward_auth::{self, AuthRequestSnapshot, ForwardAuthOutcome};
-use super::rate_limit::RateLimitResult;
 
 /// Main proxy handler: identifies the route by Host header,
 /// applies middleware stack, and forwards to the real backend.
 pub async fn handle_proxy(
     State(state): State<MiddlewareAppState>,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> impl IntoResponse {
     let start = Instant::now();
     let client_addr = req
@@ -78,63 +76,37 @@ pub async fn handle_proxy(
         }
     };
 
-    // 1. Forward auth (runs before rate limit, headers, compression)
-    let mut auth_injected_headers: Vec<(HeaderName, HeaderValue)> = Vec::new();
-    if let Some(cfg) = route.forward_auth.as_ref() {
-        let snapshot = AuthRequestSnapshot {
-            method: req.method().clone(),
-            uri: req
-                .uri()
-                .path_and_query()
-                .map(|pq| pq.as_str().to_string())
-                .unwrap_or_else(|| req.uri().path().to_string()),
-            host: host.clone(),
-            headers: req.headers().clone(),
-            is_tls: req
-                .headers()
-                .get("x-forwarded-proto")
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.eq_ignore_ascii_case("https"))
-                .unwrap_or(false),
-        };
-        match forward_auth::evaluate(&state.forward_auth_client, cfg, snapshot, client_addr).await {
-            ForwardAuthOutcome::Allow { headers } => {
-                auth_injected_headers = headers;
-            }
-            ForwardAuthOutcome::Deny(response) => {
-                let status = response.status().as_u16();
-                let duration = start.elapsed();
-                info!(
-                    "{} {} {} {} {} {}ms (forward-auth)",
-                    source_ip,
-                    method,
-                    host,
-                    path,
-                    status,
-                    duration.as_millis()
-                );
-                return response.into_response();
-            }
-        }
-    }
-
-    // 2. Rate limit check
-    if let Some(ref limiter) = route.rate_limiter {
-        let source_ip = req
+    // Build the per-request context shared across middlewares.
+    let mut ctx = RequestCtx {
+        host: host.clone(),
+        client_addr,
+        is_tls: req
             .headers()
-            .get("x-forwarded-for")
+            .get("x-forwarded-proto")
             .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.split(',').next())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_else(|| host.clone());
+            .map(|s| s.eq_ignore_ascii_case("https"))
+            .unwrap_or(false),
+        client_encoding: None,
+    };
 
-        if matches!(limiter.check(&source_ip), RateLimitResult::Limited) {
-            warn!("Rate limited request from {} to {}", source_ip, host);
-            return diag::rate_limited(&host).into_response();
-        }
+    // Request phase: run the middleware stack in order. A middleware may mutate
+    // the request (e.g. forward-auth stamping headers) or short-circuit (e.g.
+    // forward-auth deny, rate limit).
+    if let Err(response) = chain::run_request_phase(&route.middlewares, &mut ctx, &mut req).await {
+        let duration = start.elapsed();
+        info!(
+            "{} {} {} {} {} {}ms (middleware)",
+            source_ip,
+            method,
+            host,
+            path,
+            response.status().as_u16(),
+            duration.as_millis()
+        );
+        return response.into_response();
     }
 
-    // 3. Pick a backend using round-robin
+    // Pick a backend using round-robin.
     let (backend_host, backend_port) = match route.next_backend() {
         Some(b) => b.clone(),
         None => {
@@ -143,7 +115,7 @@ pub async fn handle_proxy(
         }
     };
 
-    // 4. Build the forwarded URI
+    // Build the forwarded URI.
     let original_path = req.uri().path().to_string();
     let query = req
         .uri()
@@ -158,8 +130,6 @@ pub async fn handle_proxy(
         backend_host, backend_port, forwarded_path, query
     );
 
-    let client_encoding = compress::pick_encoding(req.headers());
-
     debug!(
         "Proxying {} {} -> {}",
         req.method(),
@@ -167,7 +137,7 @@ pub async fn handle_proxy(
         target_uri
     );
 
-    // 5. Check for WebSocket upgrade
+    // Check for WebSocket upgrade.
     let is_websocket = req
         .headers()
         .get("upgrade")
@@ -178,15 +148,9 @@ pub async fn handle_proxy(
         return handle_websocket(req, &backend_host, backend_port, &forwarded_path, &query).await;
     }
 
-    // 6. Build the forwarded request
+    // Build the forwarded request.
     let (mut parts, body) = req.into_parts();
 
-    // Stamp forward-auth response headers onto the request before forwarding.
-    for (name, value) in auth_injected_headers {
-        parts.headers.insert(name, value);
-    }
-
-    // Update the URI
     parts.uri = match target_uri.parse::<Uri>() {
         Ok(uri) => uri,
         Err(e) => {
@@ -197,7 +161,7 @@ pub async fn handle_proxy(
 
     let forwarded_req = Request::from_parts(parts, body);
 
-    // 7. Send the request to the real backend
+    // Send the request to the real backend.
     let timeout_secs = route.backend_timeout.unwrap_or(30);
 
     let response_future = state.http_client.request(forwarded_req);
@@ -219,53 +183,22 @@ pub async fn handle_proxy(
         }
     };
 
-    let response = match result {
+    let backend_response = match result {
         Ok(resp) => {
-            let (mut parts, body) = resp.into_parts();
-
-            let encoding = client_encoding.filter(|_| {
-                route.compress
-                    && compress::is_compressible(&parts.headers)
-                    && !compress::is_already_compressed(&parts.headers)
-            });
-
-            if let Some(encoding) = encoding {
-                let body = Body::new(body.map_err(|e| axum::Error::new(std::io::Error::other(e))));
-                match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
-                    Ok(bytes) => match compress::compress(&bytes, encoding) {
-                        Ok(compressed) => {
-                            parts.headers.insert(
-                                "content-encoding",
-                                encoding.header_value().parse().unwrap(),
-                            );
-                            parts.headers.insert(
-                                "content-length",
-                                compressed.len().to_string().parse().unwrap(),
-                            );
-                            parts.headers.remove("transfer-encoding");
-                            Response::from_parts(parts, Body::from(compressed)).into_response()
-                        }
-                        Err(e) => {
-                            debug!("Compression failed, sending uncompressed: {}", e);
-                            Response::from_parts(parts, Body::from(bytes)).into_response()
-                        }
-                    },
-                    Err(e) => {
-                        error!("Failed to read response body for compression: {}", e);
-                        diag::forwarding_failed("response-body-read-failed", &e.to_string())
-                            .into_response()
-                    }
-                }
-            } else {
-                let body = Body::new(body.map_err(|e| axum::Error::new(std::io::Error::other(e))));
-                Response::from_parts(parts, body).into_response()
-            }
+            let (parts, body) = resp.into_parts();
+            let body = Body::new(body.map_err(|e| axum::Error::new(std::io::Error::other(e))));
+            Response::from_parts(parts, body)
         }
         Err(e) => {
             error!("Failed to forward request to {}: {}", target_uri, e);
-            diag::backend_unreachable(&format!("backend at {target_uri}: {e}")).into_response()
+            return diag::backend_unreachable(&format!("backend at {target_uri}: {e}"))
+                .into_response();
         }
     };
+
+    // Response phase: run the middleware stack in reverse (onion model). This is
+    // where compression applies.
+    let response = chain::run_response_phase(&route.middlewares, &ctx, backend_response).await;
 
     let duration = start.elapsed();
     info!(
@@ -278,7 +211,7 @@ pub async fn handle_proxy(
         duration.as_millis()
     );
 
-    response
+    response.into_response()
 }
 
 /// Handle WebSocket upgrade by establishing a TCP tunnel to the backend

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -2,6 +2,13 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use axum::body::Body;
+use axum::http::Request;
+use tracing::warn;
+
+use super::chain::{Flow, Middleware, RequestCtx};
+use super::diag;
+
 /// Token bucket rate limiter per source IP
 #[derive(Debug)]
 pub struct RateLimiter {
@@ -74,6 +81,44 @@ impl RateLimiter {
 
         let now = Instant::now();
         buckets.retain(|_, bucket| now.duration_since(bucket.last_refill).as_secs() < 3600);
+    }
+}
+
+/// Middleware wrapper: short-circuits with a 429-equivalent diagnostic when
+/// the source IP exceeds its bucket. Behavior matches the previous inline
+/// rate-limit step in `handle_proxy`.
+pub struct RateLimitMiddleware {
+    limiter: RateLimiter,
+}
+
+impl RateLimitMiddleware {
+    pub fn new(limiter: RateLimiter) -> Self {
+        Self { limiter }
+    }
+}
+
+#[async_trait::async_trait]
+impl Middleware for RateLimitMiddleware {
+    fn name(&self) -> &'static str {
+        "rate-limit"
+    }
+
+    async fn on_request(&self, ctx: &mut RequestCtx, req: &mut Request<Body>) -> Flow {
+        // Prefer the leftmost X-Forwarded-For entry; fall back to the host,
+        // matching the prior inline behavior.
+        let source_ip = req
+            .headers()
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.split(',').next())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| ctx.host.clone());
+
+        if matches!(self.limiter.check(&source_ip), RateLimitResult::Limited) {
+            warn!("Rate limited request from {} to {}", source_ip, ctx.host);
+            return Flow::ShortCircuit(diag::rate_limited(&ctx.host));
+        }
+        Flow::Continue
     }
 }
 

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -466,19 +466,23 @@ fn update_middleware_routes(
 
     table.clear();
 
+    let forward_auth_client = middleware::build_forward_auth_client();
+
     for (cluster_id, entrypoint) in storage {
         if !matches!(entrypoint.protocol, Protocol::Http) {
             continue;
         }
         if middleware::needs_middleware(&entrypoint.config) {
-            let route =
-                middleware::build_middleware_route(&entrypoint.config, &entrypoint.backends);
+            let route = middleware::build_middleware_route(
+                &entrypoint.config,
+                &entrypoint.backends,
+                &forward_auth_client,
+            );
             debug!(
-                "Middleware route for {} (hosts: {:?}): rate_limited={}, compress={}",
+                "Middleware route for {} (hosts: {:?}): {} middleware(s)",
                 cluster_id,
                 entrypoint.config.hostnames,
-                route.rate_limiter.is_some(),
-                route.compress,
+                route.middlewares.len(),
             );
             table.update_routes_for_entrypoint(&entrypoint.config.hostnames, route);
         }

--- a/tests/e2e/run-all.sh
+++ b/tests/e2e/run-all.sh
@@ -333,7 +333,7 @@ EOF
 
 # -- Start backends --
 log "Starting test containers..."
-docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d --wait
+docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d --wait --wait-timeout 90
 
 # -- Start sozune --
 log "Starting sozune (HTTP on :$HTTP_PORT, HTTPS on :$HTTPS_PORT)..."


### PR DESCRIPTION
Refactor the built-in middlewares (forward-auth, rate-limit, compression) to run as an ordered pipeline behind a common trait, instead of being hard-wired into the proxy handler.

Same behavior as before — same order, same responses. This is structural: it makes the request path clearer and lets new middlewares slot in without rewiring the proxy.

Validated with the existing unit tests and the full e2e suite (compression, rate-limit, forward-auth, websocket, SSE all green).