### PR TITLE
Add http_fetch network extension for WASM plugins

### DIFF
--- a/documentation/middleware/wasm-plugins.md
+++ b/documentation/middleware/wasm-plugins.md
@@ -70,8 +70,35 @@ WASM plugins run after the native request-phase middlewares (forward-auth, rate-
 
 Each plugin invocation is bounded by a wall-clock timeout and a maximum linear memory, so a misbehaving guest can't hang or exhaust the proxy. Request/response bodies are buffered up to 1 MiB for the guest; larger bodies are passed through untouched.
 
+## Outbound HTTP (`allowed_hosts`)
+
+The http-wasm spec has no way for a guest to make a network call. Sōzune adds a
+non-standard `http_fetch` extension for plugins that must reach an external
+service — for example a [CrowdSec](https://www.crowdsec.net/) bouncer querying
+its LAPI.
+
+A plugin opts into the extension by declaring `allowed_hosts`. The guest may
+build the request path and query, but the host only performs the call if the
+target host is on the list — this prevents a guest from reaching arbitrary
+internal addresses (SSRF). An empty or absent `allowed_hosts` means the plugin
+has no network access.
+
+```yaml
+plugins:
+  crowdsec:
+    path: /plugins/sozune_crowdsec.wasm
+    allowed_hosts: ["crowdsec:8080"]
+    config:
+      lapi_host: "crowdsec:8080"
+      lapi_key: "<bouncer-api-key>"
+```
+
+A list entry may be a bare host (`crowdsec`) or include a port
+(`crowdsec:8080`); both forms match.
+
+> A guest using `http_fetch` is no longer portable to a vanilla http-wasm host
+> (the extension is Sōzune-specific).
+
 ## Writing a plugin
 
 A guest imports the host functions from the `http_handler` module and exports `handle_request`. You can target the ABI directly or use a guest SDK such as [`http-wasm-guest`](https://crates.io/crates/http-wasm-guest) for Rust. Sōzune's host side is the open-source [`http-wasm-host`](https://github.com/kemeter/http-wasm) crate.
-
-> **Note:** the http-wasm spec does not define outbound network calls from a guest. Plugins that need to reach an external service (e.g. a CrowdSec LAPI bouncer) are not yet supported and require a host extension — planned, not available today.

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,11 @@ pub struct PluginConfig {
     /// JSON bytes before handing it to the guest.
     #[serde(default)]
     pub config: serde_json::Value,
+    /// Hosts the plugin is allowed to reach via the outbound-HTTP extension
+    /// (`http_fetch`). Empty disables network access for the plugin. Listing
+    /// hosts opts the plugin into the non-standard fetch extension.
+    #[serde(default)]
+    pub allowed_hosts: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,8 +128,9 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
     let proxy_config = config.proxy.clone();
-    let plugins = middleware::build_plugin_registry(&config.plugins);
     let handle = tokio::runtime::Handle::current();
+    let plugin_fetch_client = middleware::build_forward_auth_client();
+    let plugins = middleware::build_plugin_registry(&config.plugins, &plugin_fetch_client, &handle);
     let proxy_task = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         proxy::backend::init_proxy(
             proxy::backend::ProxyInputs {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -122,25 +122,42 @@ pub type PluginRegistry = std::collections::HashMap<String, Arc<dyn Middleware>>
 /// plugin doesn't take down routing.
 pub fn build_plugin_registry(
     declared: &std::collections::HashMap<String, crate::config::PluginConfig>,
+    fetch_client: &reqwest::Client,
+    handle: &tokio::runtime::Handle,
 ) -> PluginRegistry {
     let mut registry = PluginRegistry::new();
     for (name, cfg) in declared {
-        match std::fs::read(&cfg.path) {
-            Ok(wasm) => {
-                let config_bytes = serde_json::to_vec(&cfg.config).unwrap_or_default();
-                match wasm::WasmMiddleware::from_bytes(
-                    &wasm,
-                    config_bytes,
-                    http_wasm_host::Limits::default(),
-                ) {
-                    Ok(mw) => {
-                        info!("Loaded WASM plugin '{}' from {}", name, cfg.path);
-                        registry.insert(name.clone(), Arc::new(mw));
-                    }
-                    Err(e) => error!("Failed to load WASM plugin '{}': {}", name, e),
-                }
+        let wasm = match std::fs::read(&cfg.path) {
+            Ok(w) => w,
+            Err(e) => {
+                error!("Cannot read WASM plugin '{}' at {}: {}", name, cfg.path, e);
+                continue;
             }
-            Err(e) => error!("Cannot read WASM plugin '{}' at {}: {}", name, cfg.path, e),
+        };
+        let config_bytes = serde_json::to_vec(&cfg.config).unwrap_or_default();
+        let limits = http_wasm_host::Limits::default();
+
+        // A plugin with declared allowed_hosts opts into the outbound-HTTP
+        // extension; otherwise it gets the standard sandbox with no network.
+        let built = if cfg.allowed_hosts.is_empty() {
+            wasm::WasmMiddleware::from_bytes(&wasm, config_bytes, limits)
+        } else {
+            wasm::WasmMiddleware::from_bytes_with_fetch(
+                &wasm,
+                config_bytes,
+                limits,
+                fetch_client.clone(),
+                handle.clone(),
+                cfg.allowed_hosts.clone(),
+            )
+        };
+
+        match built {
+            Ok(mw) => {
+                info!("Loaded WASM plugin '{}' from {}", name, cfg.path);
+                registry.insert(name.clone(), Arc::new(mw));
+            }
+            Err(e) => error!("Failed to load WASM plugin '{}': {}", name, e),
         }
     }
     registry

--- a/src/middleware/wasm.rs
+++ b/src/middleware/wasm.rs
@@ -15,7 +15,9 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::http::{HeaderName, HeaderValue, Request, Response, StatusCode};
 use http_body_util::BodyExt;
-use http_wasm_host::{HeaderKind, Host, Limits, Next, Plugin};
+use http_wasm_host::{
+    FetchRequest, FetchResponse, Fetcher, HeaderKind, Host, Limits, Next, Plugin,
+};
 use tracing::{error, warn};
 
 use super::chain::{Flow, Middleware, RequestCtx};
@@ -171,6 +173,77 @@ fn apply_headers(headers: &mut axum::http::HeaderMap, pairs: &[(String, String)]
     }
 }
 
+/// Serves the guest's `http_fetch` calls over the network. Bridges the
+/// synchronous guest ABI to the async reqwest client by blocking on the shared
+/// runtime. Outbound requests are restricted to `allowed_hosts` (anti-SSRF):
+/// the guest may pick the path/query, but only against pre-declared hosts.
+struct HostFetcher {
+    client: reqwest::Client,
+    handle: tokio::runtime::Handle,
+    allowed_hosts: Vec<String>,
+}
+
+/// Whether `url`'s host is permitted by `allowed_hosts`. An allow-list entry
+/// may be a bare host (`crowdsec`) or include a port (`crowdsec:8080`); a URL is
+/// accepted if its host alone, or its `host:port` authority, matches an entry.
+/// This dual match is why a config entry like `127.0.0.1:8080` works even though
+/// `Url::host_str` returns just `127.0.0.1`.
+fn host_allowed(url: &reqwest::Url, allowed_hosts: &[String]) -> bool {
+    let host = url.host_str().unwrap_or_default();
+    let authority = match url.port() {
+        Some(p) => format!("{host}:{p}"),
+        None => host.to_string(),
+    };
+    allowed_hosts.iter().any(|h| h == host || h == &authority)
+}
+
+impl Fetcher for HostFetcher {
+    fn fetch(&self, request: FetchRequest) -> Result<FetchResponse, String> {
+        // Validate the target against the allow-list before doing anything.
+        let url = reqwest::Url::parse(&request.url).map_err(|e| format!("invalid url: {e}"))?;
+        if !host_allowed(&url, &self.allowed_hosts) {
+            return Err(format!(
+                "host '{}' not in plugin allow-list",
+                url.host_str().unwrap_or_default()
+            ));
+        }
+
+        let method = reqwest::Method::from_bytes(request.method.as_bytes())
+            .map_err(|e| format!("invalid method: {e}"))?;
+
+        // The guest ABI is synchronous; block on the async client. `block_in_place`
+        // is safe on the multi-thread runtime sōzune runs on.
+        tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                let mut builder = self.client.request(method, url);
+                for (name, value) in &request.headers {
+                    builder = builder.header(name, value);
+                }
+                if !request.body.is_empty() {
+                    builder = builder.body(request.body);
+                }
+                let resp = builder.send().await.map_err(|e| e.to_string())?;
+                let status = resp.status().as_u16();
+                let headers = resp
+                    .headers()
+                    .iter()
+                    .filter_map(|(n, v)| {
+                        v.to_str()
+                            .ok()
+                            .map(|v| (n.as_str().to_string(), v.to_string()))
+                    })
+                    .collect();
+                let body = resp.bytes().await.map_err(|e| e.to_string())?.to_vec();
+                Ok(FetchResponse {
+                    status,
+                    headers,
+                    body,
+                })
+            })
+        })
+    }
+}
+
 /// A compiled http-wasm guest wired in as a middleware.
 pub struct WasmMiddleware {
     name: &'static str,
@@ -184,6 +257,32 @@ impl WasmMiddleware {
     pub fn from_bytes(wasm: &[u8], config: Vec<u8>, limits: Limits) -> anyhow::Result<Self> {
         let plugin = Plugin::from_bytes(wasm, limits)
             .map_err(|e| anyhow::anyhow!("failed to load wasm plugin: {e}"))?;
+        Ok(Self {
+            name: "wasm",
+            plugin: Arc::new(plugin),
+            config,
+        })
+    }
+
+    /// Like [`from_bytes`](Self::from_bytes) but enables the outbound-HTTP
+    /// extension: the guest's `http_fetch` calls go through `client`, restricted
+    /// to `allowed_hosts`.
+    pub fn from_bytes_with_fetch(
+        wasm: &[u8],
+        config: Vec<u8>,
+        limits: Limits,
+        client: reqwest::Client,
+        handle: tokio::runtime::Handle,
+        allowed_hosts: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let fetcher = Arc::new(HostFetcher {
+            client,
+            handle,
+            allowed_hosts,
+        });
+        let plugin = Plugin::from_bytes(wasm, limits)
+            .map_err(|e| anyhow::anyhow!("failed to load wasm plugin: {e}"))?
+            .with_fetcher(fetcher);
         Ok(Self {
             name: "wasm",
             plugin: Arc::new(plugin),
@@ -398,5 +497,45 @@ mod tests {
         s.add_header_value(HeaderKind::Response, "x-resp", "v");
         assert!(s.header_values(HeaderKind::Request, "x-resp").is_empty());
         assert_eq!(s.header_values(HeaderKind::Response, "x-resp"), vec!["v"]);
+    }
+
+    fn url(s: &str) -> reqwest::Url {
+        reqwest::Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn allow_list_matches_host_and_port_against_bare_host_entry() {
+        // Entry without port matches a URL on any port (host_str has no port).
+        let allowed = vec!["crowdsec".to_string()];
+        assert!(host_allowed(
+            &url("http://crowdsec:8080/v1/decisions"),
+            &allowed
+        ));
+        assert!(host_allowed(&url("http://crowdsec/x"), &allowed));
+    }
+
+    #[test]
+    fn allow_list_matches_host_port_entry() {
+        // Regression: a `host:port` entry must match even though Url::host_str
+        // returns only the host. This is the bug found testing CrowdSec for real
+        // (config had 127.0.0.1:8080, host_str returns 127.0.0.1).
+        let allowed = vec!["127.0.0.1:8080".to_string()];
+        assert!(host_allowed(
+            &url("http://127.0.0.1:8080/v1/decisions?ip=9.9.9.9"),
+            &allowed
+        ));
+    }
+
+    #[test]
+    fn allow_list_rejects_unlisted_host() {
+        let allowed = vec!["crowdsec:8080".to_string()];
+        assert!(!host_allowed(&url("http://evil.example/"), &allowed));
+        // wrong port when the entry pins a port
+        assert!(!host_allowed(&url("http://crowdsec:9999/"), &allowed));
+    }
+
+    #[test]
+    fn empty_allow_list_rejects_everything() {
+        assert!(!host_allowed(&url("http://crowdsec:8080/"), &[]));
     }
 }


### PR DESCRIPTION
Builds on the WASM plugin support (#67) by letting a plugin make outbound HTTP calls, so middleware like a CrowdSec bouncer (which must query the LAPI) can run as a plugin.

## What it does

- The base http-wasm ABI has no network call. This adds the non-standard `http_fetch` host function (provided by the [`http-wasm-host`](https://github.com/kemeter/http-wasm) crate, opt-in) and wires it into Sōzune via a `HostFetcher` that bridges the synchronous guest ABI to the async reqwest client.
- A plugin opts in by declaring `allowed_hosts`. The guest builds the request path/query, but the host only performs the call if the target host is on the list — anti-SSRF. No `allowed_hosts` means no network.

## Configuration

```yaml
plugins:
  crowdsec:
    path: /plugins/sozune_crowdsec.wasm
    allowed_hosts: ["crowdsec:8080"]
    config:
      lapi_host: "crowdsec:8080"
      lapi_key: "<bouncer-api-key>"
```

An allow-list entry may be a bare host or include a port; both match.

## Tests

- Unit tests for the allow-list (`host_allowed`), including a regression test for the `host:port` entry vs `Url::host_str` (host-only) case — a bug found while testing a real CrowdSec instance end to end.
- e2e suite stays green (69 passed).
- Docs updated: `documentation/middleware/wasm-plugins.md` documents `allowed_hosts`.

A guest using `http_fetch` is no longer portable to a vanilla http-wasm host; that trade-off is explicit (the extension is opt-in per plugin).

Verified in real conditions against a live CrowdSec LAPI: a banned IP is blocked with 403, a clean IP passes through. The CrowdSec bouncer guest itself lives in a separate repo (`kemeter/sozune-crowdsec`).