### PR TITLE
Add Consul Catalog provider

### DIFF
--- a/documentation/providers/consul.md
+++ b/documentation/providers/consul.md
@@ -1,0 +1,96 @@
+# Consul provider
+
+The Consul provider discovers entrypoints from a HashiCorp [Consul](https://www.consul.net/) catalog. Sōzune connects to a Consul agent, lists registered services, reads each instance's health, and turns `sozune.*` service tags into routing configuration.
+
+This is the right provider when your services register in Consul (directly, via Nomad's `provider = "consul"`, or through any other registrator) and you want a Sōzu-powered ingress in front of them.
+
+## Configuration
+
+```yaml
+providers:
+  consul:
+    enabled: true
+    endpoint: "http://127.0.0.1:8500"
+    token: ""
+    datacenter: ""
+    poll_interval: 15
+    strict_checks: ["passing", "warning"]
+    expose_by_default: false
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enables the Consul provider |
+| `endpoint` | `http://127.0.0.1:8500` | Consul HTTP API endpoint. Use the agent the Sōzune host is closest to. |
+| `token` | `""` | Optional ACL token sent as `X-Consul-Token`. Required when ACLs are enabled. |
+| `datacenter` | `""` | Restrict discovery to a single datacenter (`?dc=`). Empty means the agent's default datacenter. |
+| `poll_interval` | `15` | Maximum time, in seconds, that a [blocking query](https://developer.hashicorp.com/consul/api-docs/features/blocking) waits before returning. Lower = faster reaction to a stuck wait, higher = fewer round-trips when nothing changes. |
+| `strict_checks` | `["passing", "warning"]` | Which Consul health-check states are allowed to receive traffic. With the default, only `critical` (and `maintenance`) instances are excluded. |
+| `expose_by_default` | `false` | If `true`, every service is a candidate even without a `sozune.enable=true` tag. |
+
+## How it works
+
+1. Sōzune issues a **blocking query** against `GET /v1/catalog/services?index=N&wait=<poll_interval>s`. Consul holds the connection open until the catalog changes (or `poll_interval` elapses).
+2. As soon as Consul responds with a new index, Sōzune fetches each service's instances via `GET /v1/health/service/<name>` — the health endpoint, so it sees the instances **and** their checks in one call.
+3. Instances whose aggregate health is not allowed by `strict_checks` are dropped before they ever become a backend.
+4. Service tags are parsed by the same engine that handles Docker / Swarm / Kubernetes / Nomad labels, so `sozune validate` and the runtime stay in sync.
+
+Changes (service register/deregister, health flip, scale) propagate within seconds, without polling spam when the cluster is idle.
+
+## Health filtering (`strict_checks`)
+
+Every Consul instance carries one or more checks. Sōzune computes the instance's **effective** status as the worst of its checks (`critical` > `warning` > `passing`; an instance with no checks counts as `passing`), then keeps the instance only if that status is listed in `strict_checks`.
+
+The default `["passing", "warning"]` matches Traefik's `strictChecks`: a `warning` instance still answers requests, so it keeps taking traffic — only `critical` (and Consul `maintenance`) instances are pulled out of rotation. Tighten to `["passing"]` if you want any non-green check to remove an instance.
+
+> Sōzu runs its own backend health checks on top of this. `strict_checks` is the Consul-side gate (it knows about application checks Sōzu can't see); Sōzu's checks are the proxy-side safety net.
+
+## Tags
+
+Service `tags` follow two conventions:
+
+- `key=value` → becomes a label `key` with value `value`.
+- bare `key` (no `=`) → becomes a flag label `key` with empty value, useful for boolean toggles like `sozune.enable`.
+
+A service registered directly against Consul:
+
+```json
+{
+  "Name": "api",
+  "Port": 8080,
+  "Tags": [
+    "sozune.enable=true",
+    "sozune.http.web.host=api.example.com"
+  ]
+}
+```
+
+Every annotation listed under [Docker labels](/documentation/providers/docker) — host, path, headers, rate limit, basic auth, redirects, sticky sessions, compression — is supported as-is on Consul services.
+
+## Backend resolution
+
+For each instance, Sōzune uses:
+
+- the service's `Service.Address` as the backend IP, falling back to the node's `Node.Address` when the service registers no address of its own (the common case for host-network services).
+- the instance's `Service.Port` as the backend port.
+
+If you declare `sozune.<proto>.<svc>.host` **without** an explicit `sozune.<proto>.<svc>.port`, Sōzune injects the Consul-registered port automatically. Explicit port tags always win.
+
+Consul's built-in `consul` service (the agents themselves) is always skipped.
+
+## Limitations
+
+- **One Consul agent per Sōzune instance.** For multiple datacenters, run one Sōzune per datacenter (or set `datacenter` and run several instances).
+- **Catalog only.** Consul Connect / service mesh and the KV store are not used.
+- **UDP services** are recognised at the tag level but not yet proxied (same caveat as the Docker provider).
+
+## Environment variables
+
+| Field | Env var |
+|---|---|
+| `providers.consul.enabled` | `SOZUNE_PROVIDER_CONSUL_ENABLED` |
+| `providers.consul.endpoint` | `SOZUNE_PROVIDER_CONSUL_ENDPOINT` |
+| `providers.consul.token` | `SOZUNE_PROVIDER_CONSUL_TOKEN` |
+| `providers.consul.datacenter` | `SOZUNE_PROVIDER_CONSUL_DATACENTER` |
+| `providers.consul.poll_interval` | `SOZUNE_PROVIDER_CONSUL_POLL_INTERVAL` |
+| `providers.consul.expose_by_default` | `SOZUNE_PROVIDER_CONSUL_EXPOSE_BY_DEFAULT` |

--- a/documentation/providers/nomad.md
+++ b/documentation/providers/nomad.md
@@ -87,12 +87,12 @@ If you declare `sozune.<proto>.<svc>.host` **without** an explicit `sozune.<prot
 
 ## Service provider: `nomad` vs `consul`
 
-Nomad services can register either against Nomad itself (`provider = "nomad"`) or Consul (`provider = "consul"`). Sōzune's Nomad provider only sees the **Nomad-native** registry. To route to Consul-registered services, run a separate Consul provider (not yet shipped — open an issue if you need it).
+Nomad services can register either against Nomad itself (`provider = "nomad"`) or Consul (`provider = "consul"`). Sōzune's Nomad provider only sees the **Nomad-native** registry. To route to Consul-registered services, enable the [Consul provider](/documentation/providers/consul) instead.
 
 ## Limitations
 
 - **One Nomad agent per Sōzune instance.** If you have several federated regions, run one Sōzune per region.
-- **No Consul integration.** As above.
+- **Nomad-native registry only.** For Consul-registered services, use the [Consul provider](/documentation/providers/consul).
 - **UDP services** are recognised at the tag level but not yet proxied (same caveat as the Docker provider).
 - **HCL stack changes** that don't change the services list (e.g. only env-var changes) won't wake up the blocking query — they'll be picked up on the next regular `poll_interval` tick.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,7 @@ pub struct ProvidersConfig {
     pub swarm: Option<SwarmConfig>,
     pub kubernetes: Option<KubernetesConfig>,
     pub nomad: Option<NomadConfig>,
+    pub consul: Option<ConsulConfig>,
     pub config_file: Option<ConfigFileConfig>,
     pub http: Option<HttpProviderConfig>,
 }
@@ -212,6 +213,42 @@ pub struct NomadConfig {
     #[serde(
         default,
         deserialize_with = "deserialize_nomad_expose_by_default_with_env"
+    )]
+    pub expose_by_default: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ConsulConfig {
+    #[serde(default, deserialize_with = "deserialize_consul_enabled_with_env")]
+    pub enabled: bool,
+    /// Consul HTTP API endpoint (e.g. `http://127.0.0.1:8500`).
+    #[serde(
+        default = "default_consul_endpoint",
+        deserialize_with = "deserialize_consul_endpoint_with_env"
+    )]
+    pub endpoint: String,
+    /// Optional ACL token sent as the `X-Consul-Token` header.
+    #[serde(default, deserialize_with = "deserialize_consul_token_with_env")]
+    pub token: String,
+    /// Restrict discovery to a single datacenter (`?dc=`). Empty means the
+    /// agent's default datacenter.
+    #[serde(default, deserialize_with = "deserialize_consul_datacenter_with_env")]
+    pub datacenter: String,
+    /// Polling interval, in seconds. Used as the `wait` bound for blocking
+    /// queries.
+    #[serde(
+        default = "default_consul_poll_interval",
+        deserialize_with = "deserialize_consul_poll_interval_with_env"
+    )]
+    pub poll_interval: u64,
+    /// Which Consul health-check states are allowed to receive traffic.
+    /// Defaults to `["passing", "warning"]` — only `critical` instances are
+    /// excluded. Mirrors Traefik's `strictChecks`.
+    #[serde(default = "default_consul_strict_checks")]
+    pub strict_checks: Vec<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_consul_expose_by_default_with_env"
     )]
     pub expose_by_default: bool,
 }
@@ -457,6 +494,32 @@ fn default_nomad_endpoint() -> String {
 
 fn default_nomad_poll_interval() -> u64 {
     15
+}
+
+impl Default for ConsulConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_consul_endpoint(),
+            token: String::new(),
+            datacenter: String::new(),
+            poll_interval: default_consul_poll_interval(),
+            strict_checks: default_consul_strict_checks(),
+            expose_by_default: false,
+        }
+    }
+}
+
+fn default_consul_endpoint() -> String {
+    "http://127.0.0.1:8500".to_string()
+}
+
+fn default_consul_poll_interval() -> u64 {
+    15
+}
+
+fn default_consul_strict_checks() -> Vec<String> {
+    vec!["passing".to_string(), "warning".to_string()]
 }
 
 fn default_swarm_endpoint() -> String {
@@ -782,6 +845,40 @@ deserialize_with_env!(
 deserialize_bool_with_env!(
     deserialize_nomad_expose_by_default_with_env,
     "SOZUNE_PROVIDER_NOMAD_EXPOSE_BY_DEFAULT",
+    false
+);
+
+deserialize_bool_with_env!(
+    deserialize_consul_enabled_with_env,
+    "SOZUNE_PROVIDER_CONSUL_ENABLED",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_consul_endpoint_with_env,
+    "SOZUNE_PROVIDER_CONSUL_ENDPOINT",
+    default_consul_endpoint
+);
+deserialize_string_with_env!(
+    deserialize_consul_token_with_env,
+    "SOZUNE_PROVIDER_CONSUL_TOKEN",
+    "",
+    literal
+);
+deserialize_string_with_env!(
+    deserialize_consul_datacenter_with_env,
+    "SOZUNE_PROVIDER_CONSUL_DATACENTER",
+    "",
+    literal
+);
+deserialize_with_env!(
+    deserialize_consul_poll_interval_with_env,
+    "SOZUNE_PROVIDER_CONSUL_POLL_INTERVAL",
+    u64,
+    default_consul_poll_interval
+);
+deserialize_bool_with_env!(
+    deserialize_consul_expose_by_default_with_env,
+    "SOZUNE_PROVIDER_CONSUL_EXPOSE_BY_DEFAULT",
     false
 );
 

--- a/src/provider/consul.rs
+++ b/src/provider/consul.rs
@@ -1,0 +1,724 @@
+use crate::config::ConsulConfig;
+use crate::diagnostics::{self, DiagnosticsStore};
+use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::diagnostic::log_diagnostics;
+use crate::labels::source::LabelSource;
+use crate::model::Entrypoint;
+use crate::provider::Provider;
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::sync::{Notify, mpsc};
+use tracing::{debug, error, info, warn};
+
+const PROVIDER_NAME: &str = crate::provider::CONSUL;
+const NETWORK_NAME: &str = "consul";
+
+pub struct ConsulProvider {
+    config: ConsulConfig,
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl Provider for ConsulProvider {
+    async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        // Trait callers don't share the runtime store; use a throwaway so
+        // diagnostics are at least logged.
+        let throwaway = diagnostics::new_store();
+        self.provide_into(&throwaway).await
+    }
+}
+
+impl ConsulProvider {
+    /// Same as `provide()` but writes diagnostics into the supplied store.
+    async fn provide_into(
+        &self,
+        diagnostics: &DiagnosticsStore,
+    ) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        let candidates = self.collect().await?;
+        let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
+        for candidate in candidates {
+            let result = diagnostics::parse_and_store(diagnostics, &candidate);
+            log_diagnostics(&candidate, &result.diagnostics);
+            for (key, mut entrypoint) in result.entrypoints {
+                let Some(backend) = entrypoint.backends.first().cloned() else {
+                    continue;
+                };
+                if let Some(existing) = entrypoints.get_mut(&key) {
+                    if !existing.backends.contains(&backend) {
+                        existing.backends.push(backend);
+                    }
+                } else {
+                    entrypoint.source = Some(PROVIDER_NAME.to_string());
+                    entrypoints.insert(key, entrypoint);
+                }
+            }
+        }
+        Ok(entrypoints)
+    }
+}
+
+#[async_trait]
+impl LabelSource for ConsulProvider {
+    async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
+        let (services, _) = self.list_services(None).await?;
+        let mut candidates = Vec::new();
+        for service_name in services {
+            match self.fetch_instances(&service_name).await {
+                Ok(instances) => {
+                    for instance in instances {
+                        candidates.push(instance.into_candidate(self.config.expose_by_default));
+                    }
+                }
+                Err(e) => warn!("Consul: failed to fetch instances for {service_name}: {e}"),
+            }
+        }
+        Ok(candidates)
+    }
+}
+
+impl ConsulProvider {
+    pub fn new(config: ConsulConfig) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("Failed to build Consul HTTP client")?;
+        Ok(Self { config, client })
+    }
+
+    fn build_url(&self, path: &str, index: Option<u64>) -> String {
+        let base = self.config.endpoint.trim_end_matches('/');
+        let mut url = format!("{base}{path}");
+        let mut params: Vec<String> = Vec::new();
+        if !self.config.datacenter.is_empty() {
+            params.push(format!("dc={}", self.config.datacenter));
+        }
+        if let Some(idx) = index {
+            params.push(format!("index={idx}"));
+            params.push(format!("wait={}s", self.config.poll_interval));
+        }
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+        url
+    }
+
+    /// Issue a Consul API call. Returns the decoded payload along with the
+    /// `X-Consul-Index` header value, which the caller passes back as `index`
+    /// on the next call to enable Consul's blocking-query mechanism.
+    async fn get_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        url: String,
+    ) -> anyhow::Result<(T, u64)> {
+        let mut req = self.client.get(&url);
+        if !self.config.token.is_empty() {
+            req = req.header("X-Consul-Token", &self.config.token);
+        }
+        let resp = req
+            .send()
+            .await
+            .with_context(|| format!("Consul request to {url} failed"))?;
+        if !resp.status().is_success() {
+            anyhow::bail!("Consul returned status {} for {}", resp.status(), url);
+        }
+        let new_index = resp
+            .headers()
+            .get("X-Consul-Index")
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+        let bytes = resp
+            .bytes()
+            .await
+            .with_context(|| format!("Failed to read Consul response from {url}"))?;
+        let body: T = serde_json::from_slice(&bytes)
+            .with_context(|| format!("Failed to decode Consul response from {url}"))?;
+        Ok((body, new_index))
+    }
+
+    /// List registered service names in the configured datacenter (or the
+    /// agent default). `GET /v1/catalog/services` returns a map of
+    /// `service name → tags`; we only need the keys here. Uses a Consul
+    /// blocking query when `index` is `Some` so Consul holds the response
+    /// until the catalog changes (or `poll_interval` elapses).
+    async fn list_services(&self, index: Option<u64>) -> anyhow::Result<(Vec<String>, u64)> {
+        let url = self.build_url("/v1/catalog/services", index);
+        let (payload, new_index) = self.get_json::<HashMap<String, Vec<String>>>(url).await?;
+        // Drop Consul's built-in "consul" service — it's the agents
+        // themselves, never a routable backend.
+        let names = payload
+            .into_keys()
+            .filter(|name| name != "consul")
+            .collect();
+        Ok((names, new_index))
+    }
+
+    /// Fetch the healthy instances of one service via the health endpoint,
+    /// which carries each instance's checks. Instances whose aggregate
+    /// health is not in `strict_checks` are dropped. Not a blocking query:
+    /// the services-list watcher already wakes us on catalog changes.
+    async fn fetch_instances(&self, service_name: &str) -> anyhow::Result<Vec<ServiceInstance>> {
+        let url = self.build_url(&format!("/v1/health/service/{service_name}"), None);
+        let (payload, _) = self.get_json::<Vec<RawHealthEntry>>(url).await?;
+        Ok(payload
+            .into_iter()
+            .filter(|entry| self.entry_is_allowed(entry))
+            .map(|entry| ServiceInstance::from_raw(service_name, entry))
+            .collect())
+    }
+
+    /// Whether an instance's aggregate health is allowed to take traffic.
+    /// The effective status is the worst of its checks (`critical` >
+    /// `warning` > `passing`); an instance is kept only if that status is
+    /// listed in `strict_checks`. An instance with no checks is treated as
+    /// `passing`.
+    fn entry_is_allowed(&self, entry: &RawHealthEntry) -> bool {
+        let status = aggregate_status(&entry.checks);
+        self.config.strict_checks.iter().any(|s| s == status)
+    }
+
+    /// Pull entrypoints once and merge them into storage with
+    /// `source = "consul"`. On any change vs the previous Consul-sourced
+    /// entries, push a reload.
+    async fn poll_once(
+        &self,
+        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: &mpsc::Sender<()>,
+        acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
+    ) {
+        let new_entrypoints = match self.provide_into(diagnostics).await {
+            Ok(map) => map,
+            Err(e) => {
+                warn!("Consul poll failed: {e}");
+                return;
+            }
+        };
+
+        let needs_update = {
+            let storage_read = match storage.read() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("internal state corrupted (configuration store), restart required: {e}");
+                    return;
+                }
+            };
+
+            let old_ids: HashSet<&String> = storage_read
+                .iter()
+                .filter(|(_, ep)| ep.source.as_deref() == Some(PROVIDER_NAME))
+                .map(|(id, _)| id)
+                .collect();
+            let new_ids: HashSet<&String> = new_entrypoints.keys().collect();
+
+            old_ids != new_ids
+                || new_entrypoints
+                    .iter()
+                    .any(|(id, ep)| storage_read.get(id).is_none_or(|existing| existing != ep))
+        };
+
+        if !needs_update {
+            return;
+        }
+
+        {
+            let mut storage_write = match storage.write() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("internal state corrupted (configuration store), restart required: {e}");
+                    return;
+                }
+            };
+            storage_write.retain(|_, ep| ep.source.as_deref() != Some(PROVIDER_NAME));
+            for (id, entrypoint) in new_entrypoints {
+                debug!(
+                    "Consul entrypoint: {id} ({} backend(s))",
+                    entrypoint.backends.len()
+                );
+                storage_write.insert(id, entrypoint);
+            }
+        }
+
+        info!("Consul provider config changed, triggering reload");
+        if let Err(e) = reload_tx.send(()).await {
+            warn!("could not apply configuration update; will retry on next change: {e}");
+        }
+        // Notify ACME unconditionally on any storage change: the manager
+        // checks for missing/expiring certs before re-issuing, so the extra
+        // notification is cheap and keeps the contract identical across
+        // providers (Docker, Swarm, Kubernetes, Nomad do the same).
+        acme_notify.notify_one();
+    }
+
+    pub async fn start_polling(
+        &self,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Starting Consul provider against {} (datacenter={}, strict_checks={:?}, expose_by_default={}, blocking-wait={}s)",
+            self.config.endpoint,
+            if self.config.datacenter.is_empty() {
+                "<default>"
+            } else {
+                self.config.datacenter.as_str()
+            },
+            self.config.strict_checks,
+            self.config.expose_by_default,
+            self.config.poll_interval,
+        );
+
+        // Initial pull (`index = None` → immediate response).
+        self.poll_once(&storage, &reload_tx, &acme_notify, &diagnostics)
+            .await;
+        let mut last_index = self
+            .list_services(None)
+            .await
+            .map(|(_, idx)| idx)
+            .unwrap_or(0);
+
+        loop {
+            // Blocking query: Consul holds the connection until the catalog
+            // changes or the configured wait elapses.
+            match self.list_services(Some(last_index)).await {
+                Ok((_, new_index)) => {
+                    if new_index != last_index {
+                        last_index = new_index;
+                        self.poll_once(&storage, &reload_tx, &acme_notify, &diagnostics)
+                            .await;
+                    }
+                    // Same index = wait timed out with no change. Loop right
+                    // back into another blocking call — no sleep needed.
+                }
+                Err(e) => {
+                    warn!("Consul blocking query failed, backing off 1s: {e}");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+}
+
+/// Worst-case status across an instance's checks. Consul check states, from
+/// best to worst: `passing`, `warning`, `critical` (plus `maintenance`,
+/// which we treat as the worst — an instance in maintenance should not take
+/// traffic). No checks → `passing`.
+fn aggregate_status(checks: &[RawCheck]) -> &'static str {
+    let mut worst = 0u8;
+    for check in checks {
+        let rank = match check.status.as_str() {
+            "passing" => 0,
+            "warning" => 1,
+            "critical" => 2,
+            _ => 3, // maintenance / unknown: treat as worse than critical
+        };
+        worst = worst.max(rank);
+    }
+    match worst {
+        0 => "passing",
+        1 => "warning",
+        2 => "critical",
+        _ => "maintenance",
+    }
+}
+
+/// Raw `GET /v1/health/service/<name>` entry: one registered instance with
+/// its node, service definition, and health checks.
+#[derive(Debug, Deserialize)]
+struct RawHealthEntry {
+    #[serde(rename = "Node")]
+    node: RawNode,
+    #[serde(rename = "Service")]
+    service: RawService,
+    #[serde(default, rename = "Checks")]
+    checks: Vec<RawCheck>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawNode {
+    #[serde(default, rename = "Address")]
+    address: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawService {
+    #[serde(rename = "ID")]
+    id: String,
+    #[serde(default, rename = "Service")]
+    service: String,
+    #[serde(default, rename = "Address")]
+    address: String,
+    #[serde(default, rename = "Port")]
+    port: u16,
+    #[serde(default, rename = "Tags")]
+    tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCheck {
+    #[serde(default, rename = "Status")]
+    status: String,
+}
+
+/// One service instance, ready to be turned into a `Candidate`.
+struct ServiceInstance {
+    id: String,
+    display_name: String,
+    address: String,
+    port: u16,
+    labels: HashMap<String, String>,
+}
+
+impl ServiceInstance {
+    fn from_raw(service_name: &str, entry: RawHealthEntry) -> Self {
+        let labels = parse_tags(&entry.service.tags);
+        // Consul: the service may register its own address; if empty, the
+        // instance is reachable at the node's address. Missing this fallback
+        // yields backends with no IP.
+        let address = if entry.service.address.is_empty() {
+            entry.node.address
+        } else {
+            entry.service.address
+        };
+        // Prefer the service's own name; fall back to the queried name.
+        let display_name = if entry.service.service.is_empty() {
+            service_name.to_string()
+        } else {
+            entry.service.service
+        };
+        Self {
+            id: entry.service.id,
+            display_name,
+            address,
+            port: entry.service.port,
+            labels,
+        }
+    }
+
+    fn into_candidate(mut self, expose_by_default: bool) -> Candidate {
+        self.synthesize_port_labels();
+
+        let networks = if self.address.is_empty() {
+            Vec::new()
+        } else {
+            vec![NetworkInfo {
+                name: NETWORK_NAME.to_string(),
+                ip: Some(self.address),
+            }]
+        };
+
+        Candidate {
+            provider: PROVIDER_NAME,
+            id: self.id,
+            display_name: self.display_name,
+            labels: self.labels,
+            networks,
+            enabled_default: expose_by_default,
+            health: None,
+        }
+    }
+
+    /// For every `sozune.<proto>.<svc>.host` declared, inject the
+    /// Consul-registered `Port` as `sozune.<proto>.<svc>.port` if the user
+    /// hasn't already set one. Explicit user ports win.
+    fn synthesize_port_labels(&mut self) {
+        if self.port == 0 {
+            return;
+        }
+        let port_str = self.port.to_string();
+        let prefixes: Vec<String> = self
+            .labels
+            .keys()
+            .filter_map(|k| {
+                k.strip_suffix(".host")
+                    .filter(|p| p.starts_with("sozune."))
+                    .map(|p| p.to_string())
+            })
+            .collect();
+        for prefix in prefixes {
+            let key = format!("{prefix}.port");
+            self.labels.entry(key).or_insert_with(|| port_str.clone());
+        }
+    }
+}
+
+/// Tags shaped `key=value` become labels; bare tags become flag labels with
+/// an empty value (so `sozune.enable` works as a tag too).
+fn parse_tags(tags: &[String]) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for tag in tags {
+        match tag.split_once('=') {
+            Some((k, v)) => {
+                out.insert(k.trim().to_string(), v.trim().to_string());
+            }
+            None => {
+                out.insert(tag.trim().to_string(), String::new());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> ConsulConfig {
+        ConsulConfig {
+            enabled: true,
+            endpoint: "http://127.0.0.1:8500".to_string(),
+            token: String::new(),
+            datacenter: String::new(),
+            poll_interval: 15,
+            strict_checks: vec!["passing".to_string(), "warning".to_string()],
+            expose_by_default: false,
+        }
+    }
+
+    fn check(status: &str) -> RawCheck {
+        RawCheck {
+            status: status.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_tags_supports_key_value_and_flag() {
+        let tags = vec![
+            "sozune.enable=true".to_string(),
+            "sozune.http.web.host=example.com".to_string(),
+            "tier-frontend".to_string(),
+        ];
+        let labels = parse_tags(&tags);
+        assert_eq!(
+            labels.get("sozune.enable").map(|s| s.as_str()),
+            Some("true")
+        );
+        assert_eq!(
+            labels.get("sozune.http.web.host").map(|s| s.as_str()),
+            Some("example.com")
+        );
+        assert_eq!(labels.get("tier-frontend").map(|s| s.as_str()), Some(""));
+    }
+
+    #[test]
+    fn aggregate_status_picks_the_worst_check() {
+        assert_eq!(aggregate_status(&[]), "passing");
+        assert_eq!(aggregate_status(&[check("passing")]), "passing");
+        assert_eq!(
+            aggregate_status(&[check("passing"), check("warning")]),
+            "warning"
+        );
+        assert_eq!(
+            aggregate_status(&[check("passing"), check("critical"), check("warning")]),
+            "critical"
+        );
+        assert_eq!(aggregate_status(&[check("maintenance")]), "maintenance");
+    }
+
+    #[test]
+    fn strict_checks_default_allows_passing_and_warning_but_not_critical() {
+        let provider = ConsulProvider::new(cfg()).unwrap();
+        let passing = RawHealthEntry {
+            node: RawNode {
+                address: "10.0.0.1".into(),
+            },
+            service: RawService {
+                id: "s1".into(),
+                service: "web".into(),
+                address: "10.0.0.5".into(),
+                port: 80,
+                tags: vec![],
+            },
+            checks: vec![check("passing")],
+        };
+        let warning = RawHealthEntry {
+            checks: vec![check("warning")],
+            ..raw_like(&passing)
+        };
+        let critical = RawHealthEntry {
+            checks: vec![check("critical")],
+            ..raw_like(&passing)
+        };
+        assert!(provider.entry_is_allowed(&passing));
+        assert!(provider.entry_is_allowed(&warning));
+        assert!(!provider.entry_is_allowed(&critical));
+    }
+
+    #[test]
+    fn strict_checks_passing_only_excludes_warning() {
+        let mut config = cfg();
+        config.strict_checks = vec!["passing".to_string()];
+        let provider = ConsulProvider::new(config).unwrap();
+        let warning = RawHealthEntry {
+            node: RawNode {
+                address: "10.0.0.1".into(),
+            },
+            service: RawService {
+                id: "s1".into(),
+                service: "web".into(),
+                address: "10.0.0.5".into(),
+                port: 80,
+                tags: vec![],
+            },
+            checks: vec![check("warning")],
+        };
+        assert!(!provider.entry_is_allowed(&warning));
+    }
+
+    #[test]
+    fn from_raw_falls_back_to_node_address_when_service_address_empty() {
+        let entry = RawHealthEntry {
+            node: RawNode {
+                address: "10.0.0.99".into(),
+            },
+            service: RawService {
+                id: "s1".into(),
+                service: "web".into(),
+                address: String::new(),
+                port: 8080,
+                tags: vec![],
+            },
+            checks: vec![],
+        };
+        let instance = ServiceInstance::from_raw("web", entry);
+        assert_eq!(instance.address, "10.0.0.99");
+    }
+
+    #[test]
+    fn from_raw_prefers_service_address() {
+        let entry = RawHealthEntry {
+            node: RawNode {
+                address: "10.0.0.99".into(),
+            },
+            service: RawService {
+                id: "s1".into(),
+                service: "web".into(),
+                address: "10.0.0.5".into(),
+                port: 8080,
+                tags: vec![],
+            },
+            checks: vec![],
+        };
+        let instance = ServiceInstance::from_raw("web", entry);
+        assert_eq!(instance.address, "10.0.0.5");
+    }
+
+    #[test]
+    fn synthesize_port_only_fills_missing_port_labels() {
+        let mut instance = ServiceInstance {
+            id: "s1".into(),
+            display_name: "web".into(),
+            address: "10.0.0.5".into(),
+            port: 8080,
+            labels: HashMap::from([
+                (
+                    "sozune.http.web.host".to_string(),
+                    "example.com".to_string(),
+                ),
+                (
+                    "sozune.http.api.host".to_string(),
+                    "api.example.com".to_string(),
+                ),
+                ("sozune.http.api.port".to_string(), "9000".to_string()),
+            ]),
+        };
+        instance.synthesize_port_labels();
+        assert_eq!(
+            instance
+                .labels
+                .get("sozune.http.web.port")
+                .map(|s| s.as_str()),
+            Some("8080"),
+            "missing port should be filled from Consul registration"
+        );
+        assert_eq!(
+            instance
+                .labels
+                .get("sozune.http.api.port")
+                .map(|s| s.as_str()),
+            Some("9000"),
+            "user-provided port must be preserved"
+        );
+    }
+
+    #[test]
+    fn into_candidate_exposes_address_as_consul_network() {
+        let instance = ServiceInstance {
+            id: "s1".into(),
+            display_name: "web".into(),
+            address: "10.0.0.5".into(),
+            port: 8080,
+            labels: HashMap::from([(
+                "sozune.http.web.host".to_string(),
+                "example.com".to_string(),
+            )]),
+        };
+        let candidate = instance.into_candidate(false);
+        assert_eq!(candidate.provider, PROVIDER_NAME);
+        assert_eq!(candidate.networks.len(), 1);
+        assert_eq!(candidate.networks[0].name, NETWORK_NAME);
+        assert_eq!(candidate.networks[0].ip.as_deref(), Some("10.0.0.5"));
+    }
+
+    #[test]
+    fn build_url_appends_datacenter_when_set() {
+        let mut config = cfg();
+        config.datacenter = "dc1".to_string();
+        let provider = ConsulProvider::new(config).unwrap();
+        let url = provider.build_url("/v1/catalog/services", None);
+        assert_eq!(url, "http://127.0.0.1:8500/v1/catalog/services?dc=dc1");
+    }
+
+    #[test]
+    fn build_url_omits_datacenter_when_empty() {
+        let provider = ConsulProvider::new(cfg()).unwrap();
+        let url = provider.build_url("/v1/catalog/services", None);
+        assert_eq!(url, "http://127.0.0.1:8500/v1/catalog/services");
+    }
+
+    #[test]
+    fn build_url_includes_blocking_query_params_when_index_set() {
+        let provider = ConsulProvider::new(cfg()).unwrap();
+        let url = provider.build_url("/v1/catalog/services", Some(42));
+        assert_eq!(
+            url,
+            "http://127.0.0.1:8500/v1/catalog/services?index=42&wait=15s"
+        );
+    }
+
+    #[test]
+    fn build_url_combines_datacenter_and_index() {
+        let mut config = cfg();
+        config.datacenter = "dc1".to_string();
+        let provider = ConsulProvider::new(config).unwrap();
+        let url = provider.build_url("/v1/catalog/services", Some(42));
+        assert_eq!(
+            url,
+            "http://127.0.0.1:8500/v1/catalog/services?dc=dc1&index=42&wait=15s"
+        );
+    }
+
+    /// Build a fresh `RawHealthEntry` mirroring `base`'s node/service so
+    /// tests can vary just the checks via struct update syntax.
+    fn raw_like(base: &RawHealthEntry) -> RawHealthEntry {
+        RawHealthEntry {
+            node: RawNode {
+                address: base.node.address.clone(),
+            },
+            service: RawService {
+                id: base.service.id.clone(),
+                service: base.service.service.clone(),
+                address: base.service.address.clone(),
+                port: base.service.port,
+                tags: base.service.tags.clone(),
+            },
+            checks: vec![],
+        }
+    }
+}

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -4,6 +4,7 @@ use crate::model::Entrypoint;
 use crate::provider::{
     Provider,
     config::ConfigProvider,
+    consul::ConsulProvider,
     docker::DockerProvider,
     http::HttpProvider,
     kubernetes::{KubernetesProvider, gateway},
@@ -285,6 +286,33 @@ pub async fn start_services(
                 .await
             {
                 error!("Nomad provider failed: {}", e);
+            }
+        });
+    }
+
+    // Start Consul provider if enabled
+    if let Some(consul_config) = &config.providers.consul
+        && consul_config.enabled
+    {
+        info!("Starting Consul provider");
+        let consul_provider = ConsulProvider::new(consul_config.clone())
+            .context("Failed to create Consul provider")?;
+        let storage_consul = Arc::clone(&storage);
+        let reload_tx_consul = reload_tx.clone();
+        let acme_notify_consul = Arc::clone(&acme_notify);
+        let diagnostics_consul = Arc::clone(&diagnostics);
+
+        tokio::spawn(async move {
+            if let Err(e) = consul_provider
+                .start_polling(
+                    storage_consul,
+                    reload_tx_consul,
+                    acme_notify_consul,
+                    diagnostics_consul,
+                )
+                .await
+            {
+                error!("Consul provider failed: {}", e);
             }
         });
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -12,11 +12,14 @@ pub const PODMAN: &str = "podman";
 pub const SWARM: &str = "swarm";
 pub const KUBERNETES: &str = "kubernetes";
 pub const NOMAD: &str = "nomad";
+pub const CONSUL: &str = "consul";
 pub const HTTP: &str = "http";
 pub const CONFIG: &str = "config";
 
 /// Every provider known to sōzune, in display order for `/providers`.
-pub const ALL: &[&str] = &[DOCKER, PODMAN, SWARM, KUBERNETES, NOMAD, HTTP, CONFIG];
+pub const ALL: &[&str] = &[
+    DOCKER, PODMAN, SWARM, KUBERNETES, NOMAD, CONSUL, HTTP, CONFIG,
+];
 
 #[async_trait]
 pub trait Provider {
@@ -24,6 +27,7 @@ pub trait Provider {
 }
 
 pub mod config;
+pub mod consul;
 pub mod docker;
 pub mod factory;
 pub mod http;

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -67,7 +67,7 @@ const FOLDER_ORDER = [
 const PAGE_ORDER: Record<string, string[]> = {
   'getting-started': ['installation', 'quick-start'],
   routing: ['hostnames', 'path-matching', 'load-balancing', 'tcp'],
-  providers: ['docker', 'swarm', 'http'],
+  providers: ['docker', 'podman', 'swarm', 'kubernetes', 'nomad', 'consul', 'http'],
   middleware: [
     'auth',
     'headers',


### PR DESCRIPTION
Adds a Consul provider that discovers entrypoints from a Consul catalog — the `Consul provider (Catalog + health, blocking queries, tags→labels)` item from `ROADMAP.md`. Modelled on the existing Nomad provider (same HashiCorp blocking-query pattern, tags→labels, port synthesis, source-tagged storage merge).

## How it works

1. Blocking query on `GET /v1/catalog/services?index=N&wait=<poll_interval>s` — Consul holds the connection until the catalog changes.
2. For each service, `GET /v1/health/service/<name>` returns instances **with** their checks in one call.
3. Instances whose aggregate health is not allowed by `strict_checks` are dropped before becoming backends.
4. Tags are parsed by the same engine as Docker / Swarm / Kubernetes / Nomad labels.

## Health filtering (`strict_checks`)

Follows Traefik's model: `strict_checks` defaults to `["passing", "warning"]`, so a `warning` instance keeps taking traffic and only `critical` / `maintenance` are pulled out. The effective status is the worst of an instance's checks; no checks → `passing`. Tighten to `["passing"]` for stricter behaviour. (Sōzu's own backend health checks still run on top — this is the Consul-side gate.)

## Consul specifics handled

- `X-Consul-Token` auth header and `?dc=` datacenter param.
- `Service.Address` with fallback to `Node.Address` when the service registers no address of its own (otherwise backends would have no IP).
- Consul's built-in `consul` service (the agents) is skipped.

## Configuration

```yaml
providers:
  consul:
    enabled: true
    endpoint: "http://127.0.0.1:8500"
    token: ""
    datacenter: ""
    poll_interval: 15
    strict_checks: ["passing", "warning"]
    expose_by_default: false
```

Each field also reads from `SOZUNE_PROVIDER_CONSUL_*` env vars. `expose_by_default` defaults to `false` (consistent with the other Sōzune providers, unlike Traefik's `true`).

## Scope

Catalog only — no Consul Connect / service mesh, no KV store. UDP recognised at the tag level but not proxied (same as Docker).

## Tests

12 unit tests: tag parsing, `strict_checks` filtering (default allows passing+warning, excludes critical; `["passing"]` excludes warning), aggregate worst-check status, `Node.Address` fallback, port synthesis, URL building (datacenter / blocking index / combined). Full unit suite 367 passed; e2e shell suite 69 passed, 0 failed; `cargo fmt --check` clean.

## Docs

New `documentation/providers/consul.md`; the Nomad doc's "no Consul provider yet" notes are updated to point at it; sidebar order in `website/src/lib/docs.ts` updated.