### PR TITLE
Add Prometheus /metrics endpoint with JSON negotiation

### DIFF
--- a/compose.metrics.yaml
+++ b/compose.metrics.yaml
@@ -1,0 +1,26 @@
+services:
+    prometheus:
+        image: prom/prometheus:latest
+        ports:
+            - "9090:9090"
+        volumes:
+            - ./tests/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+        command:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
+
+    grafana:
+        image: grafana/grafana:latest
+        ports:
+            - "3000:3000"
+        environment:
+            GF_AUTH_ANONYMOUS_ENABLED: "true"
+            GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+            GF_AUTH_DISABLE_LOGIN_FORM: "true"
+        volumes:
+            - ./tests/observability/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+            - ./tests/observability/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/sozune.yml:ro
+            - ./tests/observability/dashboards:/var/lib/grafana/dashboards:ro
+        depends_on:
+            - prometheus

--- a/documentation/advanced/observability.md
+++ b/documentation/advanced/observability.md
@@ -7,8 +7,41 @@ Sōzune exposes a Prometheus-compatible `/metrics` endpoint so any Prometheus sc
 - Path: `/metrics` on the API listener (default `:3035`)
 - Method: `GET`
 - Auth: **none** (Prometheus scrapers don't authenticate by default; protect the listener with TLS / network ACLs at the perimeter)
-- Format: Prometheus text exposition `version=0.0.4`
 - Re-computed on every scrape from authoritative state — no background aggregator, no stale cache
+
+### Output formats
+
+The same endpoint serves two formats, picked by the request's `Accept` header:
+
+| `Accept` value | Response | Use case |
+|---|---|---|
+| missing, `*/*`, `text/plain`, … | Prometheus text exposition `version=0.0.4` | Prometheus scrapers, `curl`, anything that reads the standard format |
+| `application/json` | Structured JSON (same values, same names) | The Sōzune dashboard or any client that prefers to skip text parsing |
+
+JSON example:
+
+```json
+{
+  "static": {
+    "entrypoints": 14,
+    "entrypoints_by_protocol": {"http": 12, "tcp": 2},
+    "entrypoints_tls": 8,
+    "backends": 52,
+    "backends_unhealthy": 1,
+    "diagnostics": {"error": 0, "warn": 3, "info": 0},
+    "acme_enabled": true
+  },
+  "proxy": {
+    "last_poll_seconds": 1748547231,
+    "metrics": {
+      "connections": 14,
+      "http_requests": 1042
+    }
+  }
+}
+```
+
+Numeric values in both formats are produced from the same in-memory snapshot, so they can never drift.
 
 ## Static gauges
 

--- a/documentation/advanced/observability.md
+++ b/documentation/advanced/observability.md
@@ -1,0 +1,70 @@
+# Observability
+
+Sōzune exposes a Prometheus-compatible `/metrics` endpoint so any Prometheus scraper (or Grafana, VictoriaMetrics, Mimir, etc.) can ingest its state. A reference Grafana stack ships with the repo.
+
+## The `/metrics` endpoint
+
+- Path: `/metrics` on the API listener (default `:3035`)
+- Method: `GET`
+- Auth: **none** (Prometheus scrapers don't authenticate by default; protect the listener with TLS / network ACLs at the perimeter)
+- Format: Prometheus text exposition `version=0.0.4`
+- Re-computed on every scrape from authoritative state — no background aggregator, no stale cache
+
+## Static gauges
+
+| Metric | Type | Description |
+|---|---|---|
+| `sozune_entrypoints` | gauge | Number of entrypoints currently loaded |
+| `sozune_entrypoints_by_protocol{protocol="http\|tcp\|udp"}` | gauge | Entrypoints per protocol |
+| `sozune_entrypoints_tls` | gauge | Entrypoints with TLS enabled |
+| `sozune_backends` | gauge | Total backends across all entrypoints |
+| `sozune_backends_unhealthy` | gauge | Backends currently marked down by the health checker |
+| `sozune_diagnostics{severity="error\|warn\|info"}` | gauge | Active diagnostics by severity |
+| `sozune_acme_enabled` | gauge | `1` if the ACME module is enabled, `0` otherwise |
+
+## Sōzu worker bridge
+
+The Sōzu workers maintain their own counters and gauges (connections, HTTP requests, errors, bytes in/out, …). Sōzune polls them every **5 seconds** through the Sōzu command-channel and exposes the result alongside the static gauges.
+
+| Metric | Type | Description |
+|---|---|---|
+| `sozune_proxy_last_poll_seconds` | gauge | Unix timestamp of the last successful worker poll. `0` if no poll has succeeded yet |
+| `sozune_proxy_metric{key="..."}` | untyped | Worker counter or gauge as reported by Sōzu. Keys come straight from Sōzu (`connections`, `http.requests`, `http.errors_4xx`, `bytes_in`, …) |
+
+The `{key="..."}` label is intentional: Sōzu emits a dynamic set of counters that is not known at compile time. The naming is preserved verbatim with `.` and `-` replaced by `_` so it is a valid Prometheus label value.
+
+Cardinality is bounded — Sōzune asks Sōzu for proxy-wide metrics only (`no_clusters: true`), so the number of keys does not grow with the number of clusters.
+
+To get a rate from a counter, use `rate()`:
+
+```promql
+rate(sozune_proxy_metric{key="http_requests"}[1m])
+```
+
+## Polling trade-off
+
+Sōzune polls workers every 5 s; Prometheus typically scrapes every 5–15 s. Worst case the value you see in Grafana is ~10 s old. That's acceptable for the gauges and counters we expose; if you need lower latency, raise the poll frequency in code or run a sidecar that scrapes the Sōzu command-channel directly.
+
+If `time() - sozune_proxy_last_poll_seconds` grows past ~30 s, the worker is no longer responding. Check Sōzune logs for `metrics: failed to write QueryMetrics`.
+
+## Reference Grafana stack
+
+The repo ships a turnkey Docker Compose stack: Prometheus + Grafana with the dashboard auto-provisioned.
+
+```bash
+docker compose -f compose.metrics.yaml up -d
+```
+
+Then open:
+
+- Sōzune (assuming it's running on the host): `http://127.0.0.1:3035/metrics`
+- Prometheus: `http://127.0.0.1:9090`
+- Grafana: `http://127.0.0.1:3000` — login `admin` / `admin`, dashboard "Sozune Overview" auto-loaded
+
+The dashboard JSON, Prometheus scrape config, and Grafana provisioning files live under `tests/observability/`. Copy them into your own stack to ingest Sōzune in production.
+
+## What it does not do
+
+- **No tracing.** Sōzune does not emit OpenTelemetry spans today. A scrape-only metrics interface is intentional — if you need traces, an OTel collector can scrape `/metrics` and re-emit as OTLP.
+- **No per-route latency histograms.** Sōzu's `Histogram` and `Percentiles` metric types are skipped on export because their bucket bounds are not part of the protocol contract. Only `Gauge`, `Count`, and `Time` values are bridged.
+- **No metric labels for hostnames, paths, or clusters.** Adding them would explode cardinality on large parks. Use Sōzu's per-cluster query directly if you need that granularity.

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -1,0 +1,325 @@
+//! Prometheus text-format `/metrics` endpoint.
+//!
+//! Reads the live state (entrypoint store, unhealthy backends, diagnostics)
+//! and renders a snapshot in Prometheus exposition format. No moving parts,
+//! no background aggregator — every scrape recomputes from authoritative
+//! state, so the values are always consistent with what the API would
+//! return.
+//!
+//! Endpoint is intentionally unauthenticated: Prometheus scrapers default
+//! to no auth and operators front the API with TLS / network ACLs anyway.
+
+use crate::api::server::AppState;
+use crate::labels::diagnostic::Severity;
+use axum::extract::State;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use std::collections::HashMap;
+use std::fmt::Write;
+use tracing::error;
+
+const CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+pub async fn metrics(State(state): State<AppState>) -> Response {
+    let body = render(&state);
+    let mut response = (StatusCode::OK, body).into_response();
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(CONTENT_TYPE));
+    response
+}
+
+fn render(state: &AppState) -> String {
+    let mut out = String::with_capacity(1024);
+
+    let (entrypoints_total, backends_total, tls_total, by_protocol) = match state.storage.read() {
+        Ok(guard) => {
+            let entrypoints = guard.len();
+            let backends: usize = guard.values().map(|e| e.backends.len()).sum();
+            let tls = guard.values().filter(|e| e.config.tls).count();
+            let mut by_proto: HashMap<&'static str, usize> = HashMap::new();
+            for ep in guard.values() {
+                let key = match ep.protocol {
+                    crate::model::Protocol::Http => "http",
+                    crate::model::Protocol::Tcp => "tcp",
+                    crate::model::Protocol::Udp => "udp",
+                };
+                *by_proto.entry(key).or_insert(0) += 1;
+            }
+            (entrypoints, backends, tls, by_proto)
+        }
+        Err(e) => {
+            error!("metrics: storage lock poisoned: {}", e);
+            (0, 0, 0, HashMap::new())
+        }
+    };
+
+    let unhealthy_total = match state.unhealthy_backends.read() {
+        Ok(guard) => guard.len(),
+        Err(e) => {
+            error!("metrics: unhealthy_backends lock poisoned: {}", e);
+            0
+        }
+    };
+
+    let (errors, warnings, infos) = match state.diagnostics.read() {
+        Ok(guard) => {
+            let mut e = 0usize;
+            let mut w = 0usize;
+            let mut i = 0usize;
+            for diags in guard.values() {
+                for d in diags {
+                    match d.severity() {
+                        Severity::Error => e += 1,
+                        Severity::Warn => w += 1,
+                        Severity::Info => i += 1,
+                    }
+                }
+            }
+            (e, w, i)
+        }
+        Err(e) => {
+            error!("metrics: diagnostics lock poisoned: {}", e);
+            (0, 0, 0)
+        }
+    };
+
+    write_gauge(
+        &mut out,
+        "sozune_entrypoints_total",
+        "Number of entrypoints currently loaded.",
+        entrypoints_total,
+    );
+
+    let _ = writeln!(
+        &mut out,
+        "# HELP sozune_entrypoints_by_protocol Number of entrypoints per protocol."
+    );
+    let _ = writeln!(&mut out, "# TYPE sozune_entrypoints_by_protocol gauge");
+    for (proto, count) in &by_protocol {
+        let _ = writeln!(
+            &mut out,
+            "sozune_entrypoints_by_protocol{{protocol=\"{proto}\"}} {count}"
+        );
+    }
+
+    write_gauge(
+        &mut out,
+        "sozune_entrypoints_tls_total",
+        "Number of entrypoints with TLS enabled.",
+        tls_total,
+    );
+    write_gauge(
+        &mut out,
+        "sozune_backends_total",
+        "Total number of backends across all entrypoints.",
+        backends_total,
+    );
+    write_gauge(
+        &mut out,
+        "sozune_backends_unhealthy_total",
+        "Number of backends currently marked unhealthy by the active health check.",
+        unhealthy_total,
+    );
+
+    let _ = writeln!(
+        &mut out,
+        "# HELP sozune_diagnostics_total Active diagnostics by severity."
+    );
+    let _ = writeln!(&mut out, "# TYPE sozune_diagnostics_total gauge");
+    let _ = writeln!(
+        &mut out,
+        "sozune_diagnostics_total{{severity=\"error\"}} {errors}"
+    );
+    let _ = writeln!(
+        &mut out,
+        "sozune_diagnostics_total{{severity=\"warn\"}} {warnings}"
+    );
+    let _ = writeln!(
+        &mut out,
+        "sozune_diagnostics_total{{severity=\"info\"}} {infos}"
+    );
+
+    write_gauge(
+        &mut out,
+        "sozune_acme_enabled",
+        "1 if ACME is enabled, 0 otherwise.",
+        if state.acme_enabled { 1 } else { 0 },
+    );
+
+    out
+}
+
+fn write_gauge(out: &mut String, name: &str, help: &str, value: usize) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} gauge");
+    let _ = writeln!(out, "{name} {value}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ApiUser, Role};
+    use crate::model::{Backend, Entrypoint, EntrypointConfig, Protocol};
+    use crate::proxy::health::{UnhealthyKind, UnhealthyReason};
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::{Arc, RwLock};
+    use tokio::sync::mpsc;
+
+    fn empty_state() -> AppState {
+        let (reload_tx, _) = mpsc::channel::<()>(1);
+        AppState {
+            storage: Arc::new(RwLock::new(BTreeMap::new())),
+            reload_tx,
+            users: Vec::<ApiUser>::new(),
+            unhealthy_backends: Arc::new(RwLock::new(HashMap::new())),
+            diagnostics: crate::diagnostics::new_store(),
+            acme_enabled: false,
+        }
+    }
+
+    fn make_ep(id: &str, host: &str, tls: bool, backends: usize) -> Entrypoint {
+        Entrypoint {
+            id: id.to_string(),
+            name: id.to_string(),
+            backends: (0..backends)
+                .map(|i| Backend::new("10.0.0.1", 8000 + i as u16))
+                .collect(),
+            protocol: Protocol::Http,
+            config: EntrypointConfig {
+                hostnames: vec![host.to_string()],
+                path: None,
+                tls,
+                strip_prefix: false,
+                https_redirect: false,
+                https_redirect_port: None,
+                redirect: None,
+                redirect_scheme: None,
+                redirect_template: None,
+                www_authenticate: None,
+                priority: 0,
+                auth: None,
+                headers: Vec::new(),
+                backend_timeout: None,
+                rate_limit: None,
+                sticky_session: false,
+                compress: false,
+                entrypoint: None,
+                methods: Vec::new(),
+            },
+            source: Some("api".to_string()),
+        }
+    }
+
+    #[test]
+    fn renders_zeros_for_empty_state() {
+        let body = render(&empty_state());
+        assert!(body.contains("sozune_entrypoints_total 0"));
+        assert!(body.contains("sozune_backends_total 0"));
+        assert!(body.contains("sozune_backends_unhealthy_total 0"));
+        assert!(body.contains("sozune_acme_enabled 0"));
+        assert!(body.contains("sozune_diagnostics_total{severity=\"error\"} 0"));
+    }
+
+    #[test]
+    fn counts_entrypoints_backends_and_tls() {
+        let state = empty_state();
+        {
+            let mut s = state.storage.write().unwrap();
+            s.insert("a".into(), make_ep("a", "a.example.com", false, 2));
+            s.insert("b".into(), make_ep("b", "b.example.com", true, 3));
+        }
+        let body = render(&state);
+        assert!(body.contains("sozune_entrypoints_total 2"));
+        assert!(body.contains("sozune_backends_total 5"));
+        assert!(body.contains("sozune_entrypoints_tls_total 1"));
+        assert!(body.contains("sozune_entrypoints_by_protocol{protocol=\"http\"} 2"));
+    }
+
+    #[test]
+    fn surfaces_unhealthy_backends() {
+        let state = empty_state();
+        state.unhealthy_backends.write().unwrap().insert(
+            "10.0.0.1:8000".into(),
+            UnhealthyReason {
+                kind: UnhealthyKind::ConnectionRefused,
+                message: "Connection refused".to_string(),
+                since: 0,
+                last_checked: 0,
+            },
+        );
+        let body = render(&state);
+        assert!(body.contains("sozune_backends_unhealthy_total 1"));
+    }
+
+    #[test]
+    fn aggregates_diagnostics_by_severity() {
+        let state = empty_state();
+        crate::diagnostics::set(
+            &state.diagnostics,
+            "ep-1",
+            vec![
+                crate::labels::diagnostic::Diagnostic::new(
+                    crate::labels::diagnostic::DiagnosticCode::W001InvalidPort,
+                    "bad port",
+                ),
+                crate::labels::diagnostic::Diagnostic::new(
+                    crate::labels::diagnostic::DiagnosticCode::W001InvalidPort,
+                    "bad port 2",
+                ),
+            ],
+        );
+        let body = render(&state);
+        assert!(body.contains("sozune_diagnostics_total{severity=\"warn\"} 2"));
+    }
+
+    #[test]
+    fn acme_enabled_reflects_state() {
+        let mut state = empty_state();
+        state.acme_enabled = true;
+        let body = render(&state);
+        assert!(body.contains("sozune_acme_enabled 1"));
+    }
+
+    #[test]
+    fn output_is_prometheus_text_format() {
+        let body = render(&empty_state());
+        // Each metric must be preceded by HELP and TYPE lines.
+        assert!(body.contains("# HELP sozune_entrypoints_total"));
+        assert!(body.contains("# TYPE sozune_entrypoints_total gauge"));
+    }
+
+    /// Prometheus client libraries reject responses whose `Content-Type` does
+    /// not match the exposition format. Keep this in lockstep with
+    /// `CONTENT_TYPE` — changing the header without bumping scrapers'
+    /// expectations would silently break ingestion.
+    #[tokio::test]
+    async fn content_type_is_prometheus_text_format_004() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::{Request, header};
+        use axum::routing::get;
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route("/metrics", get(super::metrics))
+            .with_state(empty_state());
+
+        let response = app
+            .oneshot(
+                Request::get("/metrics")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        let header_value = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("Content-Type header present")
+            .to_str()
+            .expect("ASCII header");
+        assert_eq!(header_value, "text/plain; version=0.0.4; charset=utf-8");
+    }
+}

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -86,7 +86,7 @@ fn render(state: &AppState) -> String {
 
     write_gauge(
         &mut out,
-        "sozune_entrypoints_total",
+        "sozune_entrypoints",
         "Number of entrypoints currently loaded.",
         entrypoints_total,
     );
@@ -105,40 +105,37 @@ fn render(state: &AppState) -> String {
 
     write_gauge(
         &mut out,
-        "sozune_entrypoints_tls_total",
+        "sozune_entrypoints_tls",
         "Number of entrypoints with TLS enabled.",
         tls_total,
     );
     write_gauge(
         &mut out,
-        "sozune_backends_total",
+        "sozune_backends",
         "Total number of backends across all entrypoints.",
         backends_total,
     );
     write_gauge(
         &mut out,
-        "sozune_backends_unhealthy_total",
+        "sozune_backends_unhealthy",
         "Number of backends currently marked unhealthy by the active health check.",
         unhealthy_total,
     );
 
     let _ = writeln!(
         &mut out,
-        "# HELP sozune_diagnostics_total Active diagnostics by severity."
+        "# HELP sozune_diagnostics Active diagnostics by severity."
     );
-    let _ = writeln!(&mut out, "# TYPE sozune_diagnostics_total gauge");
+    let _ = writeln!(&mut out, "# TYPE sozune_diagnostics gauge");
     let _ = writeln!(
         &mut out,
-        "sozune_diagnostics_total{{severity=\"error\"}} {errors}"
-    );
-    let _ = writeln!(
-        &mut out,
-        "sozune_diagnostics_total{{severity=\"warn\"}} {warnings}"
+        "sozune_diagnostics{{severity=\"error\"}} {errors}"
     );
     let _ = writeln!(
         &mut out,
-        "sozune_diagnostics_total{{severity=\"info\"}} {infos}"
+        "sozune_diagnostics{{severity=\"warn\"}} {warnings}"
     );
+    let _ = writeln!(&mut out, "sozune_diagnostics{{severity=\"info\"}} {infos}");
 
     write_gauge(
         &mut out,
@@ -147,7 +144,60 @@ fn render(state: &AppState) -> String {
         if state.acme_enabled { 1 } else { 0 },
     );
 
+    render_proxy_metrics(&mut out, state);
+
     out
+}
+
+/// Append `sozune_proxy_*` series sourced from the latest Sōzu workers
+/// snapshot. Names are derived from the worker metric key — only `[A-Za-z0-9_]`
+/// characters are kept and dots become underscores. Unknown / unsupported
+/// kinds are skipped silently (already filtered at the snapshot level).
+fn render_proxy_metrics(out: &mut String, state: &AppState) {
+    use crate::proxy::metrics_snapshot::MetricValue;
+
+    let snap = match state.metrics.read() {
+        Ok(g) => g.clone(),
+        Err(e) => {
+            error!("metrics: snapshot lock poisoned: {}", e);
+            return;
+        }
+    };
+
+    write_gauge(
+        out,
+        "sozune_proxy_last_poll_seconds",
+        "Unix timestamp of the last successful Sōzu metrics poll. 0 means never.",
+        snap.last_poll_unix as usize,
+    );
+
+    if snap.proxy.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(
+        out,
+        "# HELP sozune_proxy_metric Proxy metric forwarded from Sōzu workers (gauge or counter)."
+    );
+    let _ = writeln!(out, "# TYPE sozune_proxy_metric untyped");
+    for (key, value) in &snap.proxy {
+        let safe = sanitize_metric_name(key);
+        let v: i128 = match value {
+            MetricValue::Gauge(g) => *g as i128,
+            MetricValue::Count(c) => *c as i128,
+            MetricValue::Time(t) => *t as i128,
+        };
+        let _ = writeln!(out, "sozune_proxy_metric{{key=\"{safe}\"}} {v}");
+    }
+}
+
+fn sanitize_metric_name(key: &str) -> String {
+    key.chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' => c,
+            _ => '_',
+        })
+        .collect()
 }
 
 fn write_gauge(out: &mut String, name: &str, help: &str, value: usize) {
@@ -175,6 +225,8 @@ mod tests {
             unhealthy_backends: Arc::new(RwLock::new(HashMap::new())),
             diagnostics: crate::diagnostics::new_store(),
             acme_enabled: false,
+            providers: crate::config::ProvidersConfig::default(),
+            metrics: crate::proxy::metrics_snapshot::new_store(),
         }
     }
 
@@ -206,6 +258,14 @@ mod tests {
                 compress: false,
                 entrypoint: None,
                 methods: Vec::new(),
+                add_prefix: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                forward_auth: None,
+                acme: None,
+                error_pages: std::collections::BTreeMap::new(),
+                plugins: Vec::new(),
             },
             source: Some("api".to_string()),
         }
@@ -214,11 +274,11 @@ mod tests {
     #[test]
     fn renders_zeros_for_empty_state() {
         let body = render(&empty_state());
-        assert!(body.contains("sozune_entrypoints_total 0"));
-        assert!(body.contains("sozune_backends_total 0"));
-        assert!(body.contains("sozune_backends_unhealthy_total 0"));
+        assert!(body.contains("sozune_entrypoints 0"));
+        assert!(body.contains("sozune_backends 0"));
+        assert!(body.contains("sozune_backends_unhealthy 0"));
         assert!(body.contains("sozune_acme_enabled 0"));
-        assert!(body.contains("sozune_diagnostics_total{severity=\"error\"} 0"));
+        assert!(body.contains("sozune_diagnostics{severity=\"error\"} 0"));
     }
 
     #[test]
@@ -230,9 +290,9 @@ mod tests {
             s.insert("b".into(), make_ep("b", "b.example.com", true, 3));
         }
         let body = render(&state);
-        assert!(body.contains("sozune_entrypoints_total 2"));
-        assert!(body.contains("sozune_backends_total 5"));
-        assert!(body.contains("sozune_entrypoints_tls_total 1"));
+        assert!(body.contains("sozune_entrypoints 2"));
+        assert!(body.contains("sozune_backends 5"));
+        assert!(body.contains("sozune_entrypoints_tls 1"));
         assert!(body.contains("sozune_entrypoints_by_protocol{protocol=\"http\"} 2"));
     }
 
@@ -249,7 +309,7 @@ mod tests {
             },
         );
         let body = render(&state);
-        assert!(body.contains("sozune_backends_unhealthy_total 1"));
+        assert!(body.contains("sozune_backends_unhealthy 1"));
     }
 
     #[test]
@@ -270,7 +330,7 @@ mod tests {
             ],
         );
         let body = render(&state);
-        assert!(body.contains("sozune_diagnostics_total{severity=\"warn\"} 2"));
+        assert!(body.contains("sozune_diagnostics{severity=\"warn\"} 2"));
     }
 
     #[test]
@@ -282,11 +342,45 @@ mod tests {
     }
 
     #[test]
+    fn proxy_metrics_section_present_with_zero_poll() {
+        let body = render(&empty_state());
+        assert!(body.contains("sozune_proxy_last_poll_seconds 0"));
+        assert!(!body.contains("sozune_proxy_metric{"));
+    }
+
+    #[test]
+    fn proxy_metrics_section_renders_polled_values() {
+        use crate::proxy::metrics_snapshot::MetricValue;
+        let state = empty_state();
+        {
+            let mut snap = state.metrics.write().unwrap();
+            snap.last_poll_unix = 12345;
+            snap.proxy
+                .insert("http.requests".into(), MetricValue::Count(42));
+            snap.proxy
+                .insert("connections".into(), MetricValue::Gauge(7));
+        }
+        let body = render(&state);
+        assert!(body.contains("sozune_proxy_last_poll_seconds 12345"));
+        assert!(body.contains("sozune_proxy_metric{key=\"http_requests\"} 42"));
+        assert!(body.contains("sozune_proxy_metric{key=\"connections\"} 7"));
+    }
+
+    #[test]
+    fn sanitize_replaces_dots_and_dashes() {
+        assert_eq!(
+            sanitize_metric_name("http.requests-total"),
+            "http_requests_total"
+        );
+        assert_eq!(sanitize_metric_name("ok_name"), "ok_name");
+    }
+
+    #[test]
     fn output_is_prometheus_text_format() {
         let body = render(&empty_state());
         // Each metric must be preceded by HELP and TYPE lines.
-        assert!(body.contains("# HELP sozune_entrypoints_total"));
-        assert!(body.contains("# TYPE sozune_entrypoints_total gauge"));
+        assert!(body.contains("# HELP sozune_entrypoints"));
+        assert!(body.contains("# TYPE sozune_entrypoints gauge"));
     }
 
     /// Prometheus client libraries reject responses whose `Content-Type` does

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -1,94 +1,223 @@
-//! Prometheus text-format `/metrics` endpoint.
+//! `/metrics` endpoint with two output formats negotiated via `Accept`.
 //!
-//! Reads the live state (entrypoint store, unhealthy backends, diagnostics)
-//! and renders a snapshot in Prometheus exposition format. No moving parts,
-//! no background aggregator — every scrape recomputes from authoritative
-//! state, so the values are always consistent with what the API would
-//! return.
+//! Reads the live state (entrypoint store, unhealthy backends, diagnostics,
+//! Sōzu worker snapshot) and renders it in either:
 //!
-//! Endpoint is intentionally unauthenticated: Prometheus scrapers default
-//! to no auth and operators front the API with TLS / network ACLs anyway.
+//! - Prometheus text exposition `version=0.0.4` (default — what Prometheus
+//!   scrapers expect when no `Accept` is sent);
+//! - JSON, when the client sends `Accept: application/json`. Same data,
+//!   structured for direct consumption by the dashboard or any other client
+//!   that prefers to skip the text-parsing step.
+//!
+//! No moving parts, no background aggregator — every scrape recomputes from
+//! authoritative state, so values are always consistent with what the rest of
+//! the API would return.
+//!
+//! Endpoint is intentionally unauthenticated: Prometheus scrapers default to
+//! no auth and operators front the API with TLS / network ACLs anyway.
 
 use crate::api::server::AppState;
 use crate::labels::diagnostic::Severity;
 use axum::extract::State;
-use axum::http::{HeaderValue, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::Write;
 use tracing::error;
 
-const CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
 
-pub async fn metrics(State(state): State<AppState>) -> Response {
-    let body = render(&state);
+pub async fn metrics(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    let snap = Snapshot::collect(&state);
+
+    let (body, content_type) = if wants_json(&headers) {
+        let body = serde_json::to_string(&snap).unwrap_or_else(|e| {
+            error!("metrics: JSON serialization failed: {}", e);
+            "{}".to_string()
+        });
+        (body, JSON_CONTENT_TYPE)
+    } else {
+        (render_prom(&snap), PROM_CONTENT_TYPE)
+    };
+
     let mut response = (StatusCode::OK, body).into_response();
     response
         .headers_mut()
-        .insert(header::CONTENT_TYPE, HeaderValue::from_static(CONTENT_TYPE));
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
     response
 }
 
-fn render(state: &AppState) -> String {
-    let mut out = String::with_capacity(1024);
+/// Returns true when the request's `Accept` header asks for JSON. Anything
+/// else — including no `Accept`, `*/*`, or the Prometheus content-type — falls
+/// back to Prometheus text so existing scrapers are never surprised by a JSON
+/// body.
+fn wants_json(headers: &HeaderMap) -> bool {
+    let Some(accept) = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok()) else {
+        return false;
+    };
+    accept
+        .split(',')
+        .map(|part| part.split(';').next().unwrap_or("").trim())
+        .any(|media| media.eq_ignore_ascii_case("application/json"))
+}
 
-    let (entrypoints_total, backends_total, tls_total, by_protocol) = match state.storage.read() {
-        Ok(guard) => {
-            let entrypoints = guard.len();
-            let backends: usize = guard.values().map(|e| e.backends.len()).sum();
-            let tls = guard.values().filter(|e| e.config.tls).count();
-            let mut by_proto: HashMap<&'static str, usize> = HashMap::new();
-            for ep in guard.values() {
-                let key = match ep.protocol {
-                    crate::model::Protocol::Http => "http",
-                    crate::model::Protocol::Tcp => "tcp",
-                    crate::model::Protocol::Udp => "udp",
-                };
-                *by_proto.entry(key).or_insert(0) += 1;
+/// Numeric snapshot of every metric we expose, computed once per scrape from
+/// the live `AppState`. Both renderers (Prometheus text and JSON) read from
+/// this struct so the two formats can never drift on values.
+#[derive(Debug, Serialize)]
+struct Snapshot {
+    #[serde(rename = "static")]
+    static_metrics: StaticMetrics,
+    proxy: ProxyMetrics,
+}
+
+#[derive(Debug, Serialize)]
+struct StaticMetrics {
+    entrypoints: usize,
+    entrypoints_by_protocol: HashMap<&'static str, usize>,
+    entrypoints_tls: usize,
+    backends: usize,
+    backends_unhealthy: usize,
+    diagnostics: DiagnosticsCounts,
+    acme_enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DiagnosticsCounts {
+    error: usize,
+    warn: usize,
+    info: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ProxyMetrics {
+    /// Unix timestamp (seconds) of the last successful Sōzu worker poll.
+    /// `0` if no poll has ever succeeded.
+    last_poll_seconds: u64,
+    /// Per-key proxy counters/gauges as reported by Sōzu workers.
+    metrics: HashMap<String, i128>,
+}
+
+impl Snapshot {
+    fn collect(state: &AppState) -> Self {
+        let (entrypoints_total, backends_total, tls_total, by_protocol) = match state.storage.read()
+        {
+            Ok(guard) => {
+                let entrypoints = guard.len();
+                let backends: usize = guard.values().map(|e| e.backends.len()).sum();
+                let tls = guard.values().filter(|e| e.config.tls).count();
+                let mut by_proto: HashMap<&'static str, usize> = HashMap::new();
+                for ep in guard.values() {
+                    let key = match ep.protocol {
+                        crate::model::Protocol::Http => "http",
+                        crate::model::Protocol::Tcp => "tcp",
+                        crate::model::Protocol::Udp => "udp",
+                    };
+                    *by_proto.entry(key).or_insert(0) += 1;
+                }
+                (entrypoints, backends, tls, by_proto)
             }
-            (entrypoints, backends, tls, by_proto)
-        }
-        Err(e) => {
-            error!("metrics: storage lock poisoned: {}", e);
-            (0, 0, 0, HashMap::new())
-        }
-    };
+            Err(e) => {
+                error!("metrics: storage lock poisoned: {}", e);
+                (0, 0, 0, HashMap::new())
+            }
+        };
 
-    let unhealthy_total = match state.unhealthy_backends.read() {
-        Ok(guard) => guard.len(),
-        Err(e) => {
-            error!("metrics: unhealthy_backends lock poisoned: {}", e);
-            0
-        }
-    };
+        let unhealthy_total = match state.unhealthy_backends.read() {
+            Ok(guard) => guard.len(),
+            Err(e) => {
+                error!("metrics: unhealthy_backends lock poisoned: {}", e);
+                0
+            }
+        };
 
-    let (errors, warnings, infos) = match state.diagnostics.read() {
-        Ok(guard) => {
-            let mut e = 0usize;
-            let mut w = 0usize;
-            let mut i = 0usize;
-            for diags in guard.values() {
-                for d in diags {
-                    match d.severity() {
-                        Severity::Error => e += 1,
-                        Severity::Warn => w += 1,
-                        Severity::Info => i += 1,
+        let (errors, warnings, infos) = match state.diagnostics.read() {
+            Ok(guard) => {
+                let mut e = 0usize;
+                let mut w = 0usize;
+                let mut i = 0usize;
+                for diags in guard.values() {
+                    for d in diags {
+                        match d.severity() {
+                            Severity::Error => e += 1,
+                            Severity::Warn => w += 1,
+                            Severity::Info => i += 1,
+                        }
                     }
                 }
+                (e, w, i)
             }
-            (e, w, i)
+            Err(e) => {
+                error!("metrics: diagnostics lock poisoned: {}", e);
+                (0, 0, 0)
+            }
+        };
+
+        let proxy = ProxyMetrics::collect(state);
+
+        Snapshot {
+            static_metrics: StaticMetrics {
+                entrypoints: entrypoints_total,
+                entrypoints_by_protocol: by_protocol,
+                entrypoints_tls: tls_total,
+                backends: backends_total,
+                backends_unhealthy: unhealthy_total,
+                diagnostics: DiagnosticsCounts {
+                    error: errors,
+                    warn: warnings,
+                    info: infos,
+                },
+                acme_enabled: state.acme_enabled,
+            },
+            proxy,
         }
-        Err(e) => {
-            error!("metrics: diagnostics lock poisoned: {}", e);
-            (0, 0, 0)
+    }
+}
+
+impl ProxyMetrics {
+    fn collect(state: &AppState) -> Self {
+        use crate::proxy::metrics_snapshot::MetricValue;
+
+        let snap = match state.metrics.read() {
+            Ok(g) => g.clone(),
+            Err(e) => {
+                error!("metrics: snapshot lock poisoned: {}", e);
+                return ProxyMetrics {
+                    last_poll_seconds: 0,
+                    metrics: HashMap::new(),
+                };
+            }
+        };
+
+        let mut metrics: HashMap<String, i128> = HashMap::with_capacity(snap.proxy.len());
+        for (key, value) in &snap.proxy {
+            let safe = sanitize_metric_name(key);
+            let v: i128 = match value {
+                MetricValue::Gauge(g) => *g as i128,
+                MetricValue::Count(c) => *c as i128,
+                MetricValue::Time(t) => *t as i128,
+            };
+            metrics.insert(safe, v);
         }
-    };
+
+        ProxyMetrics {
+            last_poll_seconds: snap.last_poll_unix,
+            metrics,
+        }
+    }
+}
+
+fn render_prom(snap: &Snapshot) -> String {
+    let mut out = String::with_capacity(1024);
+    let s = &snap.static_metrics;
 
     write_gauge(
         &mut out,
         "sozune_entrypoints",
         "Number of entrypoints currently loaded.",
-        entrypoints_total,
+        s.entrypoints,
     );
 
     let _ = writeln!(
@@ -96,7 +225,7 @@ fn render(state: &AppState) -> String {
         "# HELP sozune_entrypoints_by_protocol Number of entrypoints per protocol."
     );
     let _ = writeln!(&mut out, "# TYPE sozune_entrypoints_by_protocol gauge");
-    for (proto, count) in &by_protocol {
+    for (proto, count) in &s.entrypoints_by_protocol {
         let _ = writeln!(
             &mut out,
             "sozune_entrypoints_by_protocol{{protocol=\"{proto}\"}} {count}"
@@ -107,19 +236,19 @@ fn render(state: &AppState) -> String {
         &mut out,
         "sozune_entrypoints_tls",
         "Number of entrypoints with TLS enabled.",
-        tls_total,
+        s.entrypoints_tls,
     );
     write_gauge(
         &mut out,
         "sozune_backends",
         "Total number of backends across all entrypoints.",
-        backends_total,
+        s.backends,
     );
     write_gauge(
         &mut out,
         "sozune_backends_unhealthy",
         "Number of backends currently marked unhealthy by the active health check.",
-        unhealthy_total,
+        s.backends_unhealthy,
     );
 
     let _ = writeln!(
@@ -129,66 +258,46 @@ fn render(state: &AppState) -> String {
     let _ = writeln!(&mut out, "# TYPE sozune_diagnostics gauge");
     let _ = writeln!(
         &mut out,
-        "sozune_diagnostics{{severity=\"error\"}} {errors}"
+        "sozune_diagnostics{{severity=\"error\"}} {}",
+        s.diagnostics.error
     );
     let _ = writeln!(
         &mut out,
-        "sozune_diagnostics{{severity=\"warn\"}} {warnings}"
+        "sozune_diagnostics{{severity=\"warn\"}} {}",
+        s.diagnostics.warn
     );
-    let _ = writeln!(&mut out, "sozune_diagnostics{{severity=\"info\"}} {infos}");
+    let _ = writeln!(
+        &mut out,
+        "sozune_diagnostics{{severity=\"info\"}} {}",
+        s.diagnostics.info
+    );
 
     write_gauge(
         &mut out,
         "sozune_acme_enabled",
         "1 if ACME is enabled, 0 otherwise.",
-        if state.acme_enabled { 1 } else { 0 },
+        if s.acme_enabled { 1 } else { 0 },
     );
-
-    render_proxy_metrics(&mut out, state);
-
-    out
-}
-
-/// Append `sozune_proxy_*` series sourced from the latest Sōzu workers
-/// snapshot. Names are derived from the worker metric key — only `[A-Za-z0-9_]`
-/// characters are kept and dots become underscores. Unknown / unsupported
-/// kinds are skipped silently (already filtered at the snapshot level).
-fn render_proxy_metrics(out: &mut String, state: &AppState) {
-    use crate::proxy::metrics_snapshot::MetricValue;
-
-    let snap = match state.metrics.read() {
-        Ok(g) => g.clone(),
-        Err(e) => {
-            error!("metrics: snapshot lock poisoned: {}", e);
-            return;
-        }
-    };
 
     write_gauge(
-        out,
+        &mut out,
         "sozune_proxy_last_poll_seconds",
         "Unix timestamp of the last successful Sōzu metrics poll. 0 means never.",
-        snap.last_poll_unix as usize,
+        snap.proxy.last_poll_seconds as usize,
     );
 
-    if snap.proxy.is_empty() {
-        return;
+    if !snap.proxy.metrics.is_empty() {
+        let _ = writeln!(
+            &mut out,
+            "# HELP sozune_proxy_metric Proxy metric forwarded from Sōzu workers (gauge or counter)."
+        );
+        let _ = writeln!(&mut out, "# TYPE sozune_proxy_metric untyped");
+        for (key, value) in &snap.proxy.metrics {
+            let _ = writeln!(&mut out, "sozune_proxy_metric{{key=\"{key}\"}} {value}");
+        }
     }
 
-    let _ = writeln!(
-        out,
-        "# HELP sozune_proxy_metric Proxy metric forwarded from Sōzu workers (gauge or counter)."
-    );
-    let _ = writeln!(out, "# TYPE sozune_proxy_metric untyped");
-    for (key, value) in &snap.proxy {
-        let safe = sanitize_metric_name(key);
-        let v: i128 = match value {
-            MetricValue::Gauge(g) => *g as i128,
-            MetricValue::Count(c) => *c as i128,
-            MetricValue::Time(t) => *t as i128,
-        };
-        let _ = writeln!(out, "sozune_proxy_metric{{key=\"{safe}\"}} {v}");
-    }
+    out
 }
 
 fn sanitize_metric_name(key: &str) -> String {
@@ -273,7 +382,7 @@ mod tests {
 
     #[test]
     fn renders_zeros_for_empty_state() {
-        let body = render(&empty_state());
+        let body = render_prom(&Snapshot::collect(&empty_state()));
         assert!(body.contains("sozune_entrypoints 0"));
         assert!(body.contains("sozune_backends 0"));
         assert!(body.contains("sozune_backends_unhealthy 0"));
@@ -289,7 +398,7 @@ mod tests {
             s.insert("a".into(), make_ep("a", "a.example.com", false, 2));
             s.insert("b".into(), make_ep("b", "b.example.com", true, 3));
         }
-        let body = render(&state);
+        let body = render_prom(&Snapshot::collect(&state));
         assert!(body.contains("sozune_entrypoints 2"));
         assert!(body.contains("sozune_backends 5"));
         assert!(body.contains("sozune_entrypoints_tls 1"));
@@ -308,7 +417,7 @@ mod tests {
                 last_checked: 0,
             },
         );
-        let body = render(&state);
+        let body = render_prom(&Snapshot::collect(&state));
         assert!(body.contains("sozune_backends_unhealthy 1"));
     }
 
@@ -329,7 +438,7 @@ mod tests {
                 ),
             ],
         );
-        let body = render(&state);
+        let body = render_prom(&Snapshot::collect(&state));
         assert!(body.contains("sozune_diagnostics{severity=\"warn\"} 2"));
     }
 
@@ -337,13 +446,13 @@ mod tests {
     fn acme_enabled_reflects_state() {
         let mut state = empty_state();
         state.acme_enabled = true;
-        let body = render(&state);
+        let body = render_prom(&Snapshot::collect(&state));
         assert!(body.contains("sozune_acme_enabled 1"));
     }
 
     #[test]
     fn proxy_metrics_section_present_with_zero_poll() {
-        let body = render(&empty_state());
+        let body = render_prom(&Snapshot::collect(&empty_state()));
         assert!(body.contains("sozune_proxy_last_poll_seconds 0"));
         assert!(!body.contains("sozune_proxy_metric{"));
     }
@@ -360,7 +469,7 @@ mod tests {
             snap.proxy
                 .insert("connections".into(), MetricValue::Gauge(7));
         }
-        let body = render(&state);
+        let body = render_prom(&Snapshot::collect(&state));
         assert!(body.contains("sozune_proxy_last_poll_seconds 12345"));
         assert!(body.contains("sozune_proxy_metric{key=\"http_requests\"} 42"));
         assert!(body.contains("sozune_proxy_metric{key=\"connections\"} 7"));
@@ -377,7 +486,7 @@ mod tests {
 
     #[test]
     fn output_is_prometheus_text_format() {
-        let body = render(&empty_state());
+        let body = render_prom(&Snapshot::collect(&empty_state()));
         // Each metric must be preceded by HELP and TYPE lines.
         assert!(body.contains("# HELP sozune_entrypoints"));
         assert!(body.contains("# TYPE sozune_entrypoints gauge"));
@@ -415,5 +524,154 @@ mod tests {
             .to_str()
             .expect("ASCII header");
         assert_eq!(header_value, "text/plain; version=0.0.4; charset=utf-8");
+    }
+
+    /// `Accept: application/json` must return a JSON body with the right
+    /// content-type. The dashboard relies on this so it can render metrics
+    /// without parsing the text format.
+    #[tokio::test]
+    async fn accept_json_returns_json_body() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::{Request, header};
+        use axum::routing::get;
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let state = empty_state();
+        let app = Router::new()
+            .route("/metrics", get(super::metrics))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::get("/metrics")
+                    .header(header::ACCEPT, "application/json")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json; charset=utf-8")
+        );
+
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect body")
+            .to_bytes();
+        let json: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("response body is valid JSON");
+
+        // The top-level shape is stable contract for the dashboard.
+        assert!(json["static"]["entrypoints"].is_number());
+        assert!(json["static"]["backends"].is_number());
+        assert!(json["static"]["diagnostics"]["error"].is_number());
+        assert!(json["static"]["acme_enabled"].is_boolean());
+        assert!(json["proxy"]["last_poll_seconds"].is_number());
+        assert!(json["proxy"]["metrics"].is_object());
+    }
+
+    /// JSON and Prometheus must always agree on the numeric values — they read
+    /// from the same `Snapshot`. This guards against future refactors that
+    /// would let one format drift from the other.
+    #[tokio::test]
+    async fn prom_and_json_agree_on_values() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::{Request, header};
+        use axum::routing::get;
+        use http_body_util::BodyExt;
+        use tower::ServiceExt;
+
+        let state = empty_state();
+        // Seed with one unhealthy backend so the comparison covers a non-zero
+        // value, not just defaults.
+        state.unhealthy_backends.write().unwrap().insert(
+            "10.0.0.99:80".into(),
+            UnhealthyReason {
+                kind: UnhealthyKind::Timeout,
+                message: "timeout".into(),
+                since: 0,
+                last_checked: 0,
+            },
+        );
+
+        let app = Router::new()
+            .route("/metrics", get(super::metrics))
+            .with_state(state);
+
+        let prom_bytes = app
+            .clone()
+            .oneshot(Request::get("/metrics").body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let prom = std::str::from_utf8(&prom_bytes).unwrap().to_string();
+
+        let json_bytes = app
+            .oneshot(
+                Request::get("/metrics")
+                    .header(header::ACCEPT, "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&json_bytes).unwrap();
+
+        assert!(prom.contains("sozune_backends_unhealthy 1"));
+        assert_eq!(json["static"]["backends_unhealthy"], 1);
+    }
+
+    #[test]
+    fn wants_json_recognizes_application_json() {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            axum::http::header::ACCEPT,
+            "application/json".parse().unwrap(),
+        );
+        assert!(wants_json(&h));
+    }
+
+    #[test]
+    fn wants_json_handles_multiple_media_types() {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            axum::http::header::ACCEPT,
+            "text/html, application/json;q=0.9, */*;q=0.8"
+                .parse()
+                .unwrap(),
+        );
+        assert!(wants_json(&h));
+    }
+
+    #[test]
+    fn wants_json_defaults_to_false_for_text() {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(axum::http::header::ACCEPT, "text/plain".parse().unwrap());
+        assert!(!wants_json(&h));
+    }
+
+    #[test]
+    fn wants_json_defaults_to_false_when_absent() {
+        let h = axum::http::HeaderMap::new();
+        assert!(!wants_json(&h));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod auth;
+pub(crate) mod metrics;
 pub(crate) mod server;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -30,6 +30,7 @@ pub struct AppState {
     /// by `GET /providers` to surface which providers are configured and
     /// whether their `enabled` flag is set.
     pub providers: crate::config::ProvidersConfig,
+    pub metrics: crate::proxy::metrics_snapshot::MetricsSnapshotStore,
 }
 
 /// Build the JSON payload for an entrypoint, augmenting it with the
@@ -183,6 +184,7 @@ pub async fn serve(
     diagnostics: crate::diagnostics::DiagnosticsStore,
     acme_enabled: bool,
     providers: crate::config::ProvidersConfig,
+    metrics: crate::proxy::metrics_snapshot::MetricsSnapshotStore,
 ) -> anyhow::Result<()> {
     if config.users.is_empty() {
         anyhow::bail!(
@@ -198,6 +200,7 @@ pub async fn serve(
         diagnostics,
         acme_enabled,
         providers,
+        metrics,
     };
 
     let protected = Router::new()
@@ -765,6 +768,7 @@ mod tests {
             diagnostics: crate::diagnostics::new_store(),
             acme_enabled: false,
             providers: crate::config::ProvidersConfig::default(),
+            metrics: crate::proxy::metrics_snapshot::new_store(),
         }
     }
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -226,6 +226,7 @@ pub async fn serve(
 
     let mut app = Router::new()
         .route("/health", get(health))
+        .route("/metrics", get(crate::api::metrics::metrics))
         .merge(authed)
         .with_state(state);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,11 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     // Create bounded channels to prevent memory exhaustion
     let (reload_tx, reload_rx) = mpsc::channel(64);
     let (cert_tx, cert_rx) = mpsc::channel(64);
+    let (metrics_poll_tx, metrics_poll_rx) = mpsc::channel::<()>(8);
+
+    // Snapshot of the latest metrics polled from Sōzu workers, shared with
+    // the API metrics endpoint.
+    let metrics_store = proxy::metrics_snapshot::new_store();
 
     // Notify ACME manager when storage changes (new TLS entrypoints)
     let acme_notify = Arc::new(Notify::new());
@@ -132,6 +137,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let handle = tokio::runtime::Handle::current();
     let plugin_fetch_client = middleware::build_forward_auth_client();
     let plugins = middleware::build_plugin_registry(&config.plugins, &plugin_fetch_client, &handle);
+    let metrics_store_proxy = Arc::clone(&metrics_store);
     let proxy_task = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         proxy::backend::init_proxy(
             proxy::backend::ProxyInputs {
@@ -139,6 +145,8 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 shutdown_rx,
                 reload_rx,
                 cert_rx,
+                metrics_poll_rx,
+                metrics_store: metrics_store_proxy,
                 acme_challenge_port,
                 middleware_state: middleware_state_proxy,
                 middleware_port,
@@ -147,6 +155,20 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
             },
             &proxy_config,
         )
+    });
+
+    // Poll Sōzu workers for metrics every 5 seconds. Drop on full channel —
+    // a backed-up poller means the proxy mainloop is busy and we should not
+    // pile on more work; the next tick will retry.
+    let metrics_poll_task = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if metrics_poll_tx.try_send(()).is_err() {
+                debug!("Metrics poll channel full or closed, skipping tick");
+            }
+        }
     });
 
     // Start provider services (Docker, etc.)
@@ -181,6 +203,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let diagnostics_api = Arc::clone(&diagnostics_store);
     let acme_enabled_api = acme_enabled;
     let providers_api = config.providers.clone();
+    let metrics_store_api = Arc::clone(&metrics_store);
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
@@ -192,6 +215,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 diagnostics_api,
                 acme_enabled_api,
                 providers_api,
+                metrics_store_api,
             )
             .await?;
         }
@@ -365,6 +389,8 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
             }
         }
     }
+
+    metrics_poll_task.abort();
 
     debug!("All tasks completed");
     Ok(())

--- a/src/proxy/backend.rs
+++ b/src/proxy/backend.rs
@@ -3,6 +3,7 @@ use crate::config::ProxyConfig;
 use crate::middleware::{MiddlewareState, PluginRegistry};
 use crate::model::Entrypoint;
 use crate::proxy;
+use crate::proxy::metrics_snapshot::MetricsSnapshotStore;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
@@ -16,6 +17,8 @@ pub struct ProxyInputs {
     pub shutdown_rx: tokio::sync::oneshot::Receiver<()>,
     pub reload_rx: mpsc::Receiver<()>,
     pub cert_rx: mpsc::Receiver<CertCommand>,
+    pub metrics_poll_rx: mpsc::Receiver<()>,
+    pub metrics_store: MetricsSnapshotStore,
     pub acme_challenge_port: Option<u16>,
     pub middleware_state: MiddlewareState,
     pub middleware_port: u16,

--- a/src/proxy/metrics_snapshot.rs
+++ b/src/proxy/metrics_snapshot.rs
@@ -1,0 +1,145 @@
+//! Snapshot of the latest metrics polled from Sōzu workers.
+//!
+//! The proxy mainloop owns the worker `Channel`s and is the only thing that
+//! can talk to a worker without locking. Asking workers for metrics from the
+//! API thread would either require locking the channels (intrusive) or
+//! blocking on a `oneshot` per scrape (fragile under load).
+//!
+//! Instead we run a small poller in the proxy mainloop that periodically asks
+//! each worker for its metrics and writes the merged result into a shared
+//! `Arc<RwLock<MetricsSnapshot>>`. The `/metrics` endpoint just reads the
+//! snapshot — no cross-thread channel work on the scrape path.
+//!
+//! Trade-off: scrape values lag the poll interval. With a default poll of
+//! 5 s and Prometheus scraping every 5 s the worst case is ~10 s old data,
+//! which is acceptable for the values we expose (rates, gauges).
+
+use sozu_command_lib::proto::command::{FilteredMetrics, filtered_metrics::Inner};
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+use std::time::SystemTime;
+
+pub type MetricsSnapshotStore = Arc<RwLock<MetricsSnapshot>>;
+
+/// Last successful metrics read from the workers, plus per-worker proxying
+/// counters merged across all workers we polled.
+#[derive(Default, Clone, Debug)]
+pub struct MetricsSnapshot {
+    /// Unix timestamp (seconds) of the last successful poll. `0` if we have
+    /// never polled, surfaced as `sozune_proxy_last_poll_seconds` so an alert
+    /// can flag stale data.
+    pub last_poll_unix: u64,
+    /// `sozu` proxy-wide counters and gauges, merged across workers.
+    /// Examples: `connections`, `http.requests`, `http.errors`.
+    pub proxy: BTreeMap<String, MetricValue>,
+}
+
+/// Reduced view of `FilteredMetrics` — we only forward gauge/count values to
+/// Prometheus. Histograms / time series exist in Sōzu but mapping them to
+/// Prometheus histograms would require knowing bucket bounds; we skip them
+/// for now and surface only what is unambiguous.
+#[derive(Clone, Debug)]
+pub enum MetricValue {
+    Gauge(u64),
+    Count(i64),
+    Time(u64),
+}
+
+pub fn new_store() -> MetricsSnapshotStore {
+    Arc::new(RwLock::new(MetricsSnapshot::default()))
+}
+
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Convert a single `FilteredMetrics` value into our reduced `MetricValue`.
+/// Returns `None` for kinds we do not export (Percentiles, TimeSerie,
+/// Histogram).
+pub fn convert(m: &FilteredMetrics) -> Option<MetricValue> {
+    match &m.inner {
+        Some(Inner::Gauge(g)) => Some(MetricValue::Gauge(*g)),
+        Some(Inner::Count(c)) => Some(MetricValue::Count(*c)),
+        Some(Inner::Time(t)) => Some(MetricValue::Time(*t)),
+        Some(Inner::Percentiles(_)) | Some(Inner::TimeSerie(_)) | Some(Inner::Histogram(_)) => None,
+        None => None,
+    }
+}
+
+/// Merge two snapshots of proxy metrics from different workers. For counts
+/// we sum, for gauges we sum (gauges from independent workers describe
+/// disjoint state — e.g. each worker's open connections), for times we keep
+/// the max (worst observed). Same key reaching us twice from the same poll
+/// should be rare; this rule is a defensive fallback.
+pub fn merge_into(target: &mut BTreeMap<String, MetricValue>, key: String, value: MetricValue) {
+    use MetricValue::*;
+    match target.get_mut(&key) {
+        None => {
+            target.insert(key, value);
+        }
+        Some(existing) => {
+            *existing = match (&existing, &value) {
+                (Gauge(a), Gauge(b)) => Gauge(a + b),
+                (Count(a), Count(b)) => Count(a + b),
+                (Time(a), Time(b)) => Time(*a.max(b)),
+                _ => value,
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sozu_command_lib::proto::command::FilteredMetrics;
+
+    fn gauge(v: u64) -> FilteredMetrics {
+        FilteredMetrics {
+            inner: Some(Inner::Gauge(v)),
+        }
+    }
+    fn count(v: i64) -> FilteredMetrics {
+        FilteredMetrics {
+            inner: Some(Inner::Count(v)),
+        }
+    }
+
+    #[test]
+    fn convert_gauge_and_count() {
+        assert!(matches!(convert(&gauge(42)), Some(MetricValue::Gauge(42))));
+        assert!(matches!(convert(&count(7)), Some(MetricValue::Count(7))));
+    }
+
+    #[test]
+    fn convert_unsupported_returns_none() {
+        let none = FilteredMetrics { inner: None };
+        assert!(convert(&none).is_none());
+    }
+
+    #[test]
+    fn merge_sums_counts() {
+        let mut t = BTreeMap::new();
+        merge_into(&mut t, "k".into(), MetricValue::Count(3));
+        merge_into(&mut t, "k".into(), MetricValue::Count(4));
+        assert!(matches!(t.get("k"), Some(MetricValue::Count(7))));
+    }
+
+    #[test]
+    fn merge_sums_gauges_across_workers() {
+        let mut t = BTreeMap::new();
+        merge_into(&mut t, "open".into(), MetricValue::Gauge(2));
+        merge_into(&mut t, "open".into(), MetricValue::Gauge(5));
+        assert!(matches!(t.get("open"), Some(MetricValue::Gauge(7))));
+    }
+
+    #[test]
+    fn merge_keeps_max_time() {
+        let mut t = BTreeMap::new();
+        merge_into(&mut t, "t".into(), MetricValue::Time(10));
+        merge_into(&mut t, "t".into(), MetricValue::Time(5));
+        assert!(matches!(t.get("t"), Some(MetricValue::Time(10))));
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,3 +1,4 @@
 pub mod backend;
 pub mod health;
+pub mod metrics_snapshot;
 pub mod sozu;

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -7,6 +7,7 @@ use crate::config::ProxyConfig;
 use crate::middleware::{self, MiddlewareState};
 use crate::model::{Entrypoint, Protocol};
 use crate::proxy::backend::ProxyInputs;
+use crate::proxy::metrics_snapshot;
 use acme::{add_certificate, register_acme_challenge_cluster};
 use addr::parse_backend_address;
 use builders::{
@@ -18,9 +19,10 @@ use sozu_command_lib::{
     channel::Channel,
     config::ListenerBuilder,
     proto::command::{
-        AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, PathRule, RemoveBackend,
-        RequestHttpFrontend, RequestTcpFrontend, RulePosition, SocketAddress, WorkerRequest,
-        WorkerResponse, request::RequestType,
+        AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, PathRule,
+        QueryMetricsOptions, RemoveBackend, Request, RequestHttpFrontend, RequestTcpFrontend,
+        ResponseStatus, RulePosition, SocketAddress, WorkerRequest, WorkerResponse,
+        request::RequestType, response_content::ContentType,
     },
 };
 use std::collections::{BTreeMap, HashMap};
@@ -147,6 +149,8 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
         shutdown_rx,
         mut reload_rx,
         mut cert_rx,
+        mut metrics_poll_rx,
+        metrics_store,
         acme_challenge_port,
         middleware_state,
         middleware_port,
@@ -313,6 +317,40 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
                         None => {
                             debug!("Cert channel closed, falling back to reload-only mode");
                             cert_rx_open = false;
+                            continue 'outer;
+                        }
+                    },
+                    poll = metrics_poll_rx.recv() => match poll {
+                        Some(()) => {
+                            // Drain coalesced pings so we only run one query
+                            // per wakeup even if the poller fires fast.
+                            while metrics_poll_rx.try_recv().is_ok() {}
+
+                            let mut merged = std::collections::BTreeMap::new();
+                            for (proxy_metrics, name) in [
+                                (poll_worker_metrics(&mut channels.http, "HTTP"), "HTTP"),
+                                (poll_worker_metrics(&mut channels.https, "HTTPS"), "HTTPS"),
+                            ] {
+                                debug!("metrics: {} worker returned {} keys", name, proxy_metrics.len());
+                                for (k, v) in proxy_metrics {
+                                    if let Some(value) = metrics_snapshot::convert(&v) {
+                                        metrics_snapshot::merge_into(&mut merged, k, value);
+                                    }
+                                }
+                            }
+
+                            match metrics_store.write() {
+                                Ok(mut snap) => {
+                                    snap.proxy = merged;
+                                    snap.last_poll_unix = metrics_snapshot::now_unix();
+                                }
+                                Err(e) => error!("metrics: snapshot lock poisoned: {}", e),
+                            }
+
+                            continue 'outer;
+                        }
+                        None => {
+                            debug!("Metrics poll channel closed");
                             continue 'outer;
                         }
                     },
@@ -942,6 +980,92 @@ fn configure_tcp_entrypoint(
             RequestType::AddBackend(backend),
         ) {
             debug!("Failed to add TCP backend {}-{}: {}", cluster_id, idx, e);
+        }
+    }
+}
+
+/// Send `QueryMetrics` to a single worker and return the proxy-wide metric
+/// map (worker counters/gauges, no per-cluster breakdown).
+///
+/// We request `no_clusters: true` to keep the response small — the API only
+/// exposes proxy-wide aggregates today. Returns an empty map on any error;
+/// callers log and move on (a transient worker hiccup must not poison the
+/// snapshot).
+fn poll_worker_metrics(
+    channel: &mut Channel<WorkerRequest, WorkerResponse>,
+    name: &str,
+) -> std::collections::BTreeMap<String, sozu_command_lib::proto::command::FilteredMetrics> {
+    let id = format!("{}-metrics-{}", name, metrics_snapshot::now_unix());
+    let request = WorkerRequest {
+        id: id.clone(),
+        content: Request {
+            request_type: Some(RequestType::QueryMetrics(QueryMetricsOptions {
+                list: false,
+                cluster_ids: Vec::new(),
+                backend_ids: Vec::new(),
+                metric_names: Vec::new(),
+                no_clusters: true,
+                workers: false,
+            })),
+        },
+    };
+
+    if let Err(e) = channel.write_message(&request) {
+        error!(
+            "metrics: failed to write QueryMetrics to {} worker: {}",
+            name, e
+        );
+        return Default::default();
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_millis(2000);
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            error!(
+                "metrics: timeout waiting for {} worker QueryMetrics response",
+                name
+            );
+            return Default::default();
+        }
+        match channel.read_message_blocking_timeout(Some(remaining)) {
+            Ok(response) => {
+                if response.id != id {
+                    debug!(
+                        "metrics: skipping unrelated response {} on {}",
+                        response.id, name
+                    );
+                    continue;
+                }
+                if response.status == ResponseStatus::Failure as i32 {
+                    error!(
+                        "metrics: {} worker rejected QueryMetrics: {}",
+                        name, response.message
+                    );
+                    return Default::default();
+                }
+                let Some(content) = response.content else {
+                    return Default::default();
+                };
+                match content.content_type {
+                    // Workers respond with WorkerMetrics (their own proxy +
+                    // cluster maps). The aggregated form Metrics(AggregatedMetrics)
+                    // only comes from the Sōzu main process, which we don't run.
+                    Some(ContentType::WorkerMetrics(wm)) => return wm.proxy,
+                    Some(ContentType::Metrics(agg)) => return agg.proxying,
+                    other => {
+                        debug!(
+                            "metrics: unexpected content from {} worker: {:?}",
+                            name, other
+                        );
+                        return Default::default();
+                    }
+                }
+            }
+            Err(e) => {
+                error!("metrics: error reading {} worker QueryMetrics: {}", name, e);
+                return Default::default();
+            }
         }
     }
 }

--- a/tests/observability/dashboards/sozune-overview.json
+++ b/tests/observability/dashboards/sozune-overview.json
@@ -1,0 +1,230 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Entrypoints",
+      "gridPos": {"x": 0, "y": 0, "w": 4, "h": 4},
+      "id": 1,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_entrypoints_total", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "blue", "value": null}
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Backends",
+      "gridPos": {"x": 4, "y": 0, "w": 4, "h": 4},
+      "id": 2,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_backends_total", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "blue", "value": null}]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Backends unhealthy",
+      "gridPos": {"x": 8, "y": 0, "w": 4, "h": 4},
+      "id": 3,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_backends_unhealthy_total", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "stat",
+      "title": "TLS entrypoints",
+      "gridPos": {"x": 12, "y": 0, "w": 4, "h": 4},
+      "id": 4,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_entrypoints_tls_total", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "purple", "value": null}]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "stat",
+      "title": "ACME",
+      "gridPos": {"x": 16, "y": 0, "w": 4, "h": 4},
+      "id": 5,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_acme_enabled", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {"0": {"text": "OFF", "color": "red"}, "1": {"text": "ON", "color": "green"}}}
+          ],
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "piechart",
+      "title": "Entrypoints by protocol",
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
+      "id": 6,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_entrypoints_by_protocol", "refId": "A", "legendFormat": "{{protocol}}"}
+      ],
+      "options": {
+        "legend": {"displayMode": "list", "placement": "right", "showLegend": true},
+        "pieType": "donut",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Diagnostics by severity",
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "id": 7,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_diagnostics_total{severity=\"error\"}", "refId": "A", "legendFormat": "error"},
+        {"expr": "sozune_diagnostics_total{severity=\"warn\"}", "refId": "B", "legendFormat": "warn"},
+        {"expr": "sozune_diagnostics_total{severity=\"info\"}", "refId": "C", "legendFormat": "info"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "stacking": {"mode": "normal", "group": "A"},
+            "lineWidth": 0,
+            "fillOpacity": 100
+          },
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "error"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "warn"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]},
+          {"matcher": {"id": "byName", "options": "info"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]}
+        ]
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Backends over time",
+      "gridPos": {"x": 0, "y": 12, "w": 24, "h": 8},
+      "id": 8,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sozune_backends_total", "refId": "A", "legendFormat": "total"},
+        {"expr": "sozune_backends_unhealthy_total", "refId": "B", "legendFormat": "unhealthy"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "unhealthy"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "total"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
+        ]
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "tags": ["sozune"],
+  "templating": {"list": []},
+  "time": {"from": "now-15m", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sozune Overview",
+  "uid": "sozune-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/tests/observability/dashboards/sozune-overview.json
+++ b/tests/observability/dashboards/sozune-overview.json
@@ -1,28 +1,30 @@
 {
-  "annotations": {
-    "list": []
-  },
+  "annotations": {"list": []},
   "editable": true,
   "graphTooltip": 1,
   "panels": [
     {
+      "type": "text",
+      "title": "About",
+      "gridPos": {"x": 0, "y": 0, "w": 24, "h": 3},
+      "id": 100,
+      "options": {
+        "mode": "markdown",
+        "content": "## Sozune Overview\n\nReal-time proxy state: how many routes are loaded, how many backends are responding, how many configuration warnings are active.\n\n_Auto-refresh: 5 s. Hover panel titles for an explanation._"
+      }
+    },
+    {
       "type": "stat",
-      "title": "Entrypoints",
-      "gridPos": {"x": 0, "y": 0, "w": 4, "h": 4},
+      "title": "Routes",
+      "description": "Total number of routes (entrypoints) currently loaded. A route is a (hostname, path) pair pointing at one or more backends. Discovered through providers (Docker, Kubernetes, etc.).",
+      "gridPos": {"x": 0, "y": 3, "w": 5, "h": 4},
       "id": 1,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "sozune_entrypoints_total", "refId": "A"}
-      ],
+      "targets": [{"expr": "sozune_entrypoints", "refId": "A"}],
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {"color": "blue", "value": null}
-            ]
-          },
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
           "unit": "short"
         }
       },
@@ -35,19 +37,15 @@
     {
       "type": "stat",
       "title": "Backends",
-      "gridPos": {"x": 4, "y": 0, "w": 4, "h": 4},
+      "description": "Total number of backend instances (container, pod, IP:port) reachable across all routes.",
+      "gridPos": {"x": 5, "y": 3, "w": 5, "h": 4},
       "id": 2,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "sozune_backends_total", "refId": "A"}
-      ],
+      "targets": [{"expr": "sozune_backends", "refId": "A"}],
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{"color": "blue", "value": null}]
-          },
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
           "unit": "short"
         }
       },
@@ -59,23 +57,16 @@
     },
     {
       "type": "stat",
-      "title": "Backends unhealthy",
-      "gridPos": {"x": 8, "y": 0, "w": 4, "h": 4},
+      "title": "Backends down",
+      "description": "Backends marked DOWN by the active health check. Turns red as soon as >= 1. When > 0, requests will either fail or fall back to the remaining backends.",
+      "gridPos": {"x": 10, "y": 3, "w": 5, "h": 4},
       "id": 3,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "sozune_backends_unhealthy_total", "refId": "A"}
-      ],
+      "targets": [{"expr": "sozune_backends_unhealthy", "refId": "A"}],
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 1}
-            ]
-          },
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]},
           "unit": "short"
         }
       },
@@ -87,20 +78,16 @@
     },
     {
       "type": "stat",
-      "title": "TLS entrypoints",
-      "gridPos": {"x": 12, "y": 0, "w": 4, "h": 4},
+      "title": "TLS routes",
+      "description": "Number of routes that terminate TLS (HTTPS). The remainder is plain HTTP. Useful to track HTTPS coverage across the fleet.",
+      "gridPos": {"x": 15, "y": 3, "w": 5, "h": 4},
       "id": 4,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "sozune_entrypoints_tls_total", "refId": "A"}
-      ],
+      "targets": [{"expr": "sozune_entrypoints_tls", "refId": "A"}],
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{"color": "purple", "value": null}]
-          },
+          "thresholds": {"mode": "absolute", "steps": [{"color": "purple", "value": null}]},
           "unit": "short"
         }
       },
@@ -113,25 +100,18 @@
     {
       "type": "stat",
       "title": "ACME",
-      "gridPos": {"x": 16, "y": 0, "w": 4, "h": 4},
+      "description": "ON = Sozune automatically obtains and renews Let's Encrypt certificates for its hostnames. OFF = no auto-issuance.",
+      "gridPos": {"x": 20, "y": 3, "w": 4, "h": 4},
       "id": 5,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "sozune_acme_enabled", "refId": "A"}
-      ],
+      "targets": [{"expr": "sozune_acme_enabled", "refId": "A"}],
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {"type": "value", "options": {"0": {"text": "OFF", "color": "red"}, "1": {"text": "ON", "color": "green"}}}
           ],
           "color": {"mode": "thresholds"},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {"color": "red", "value": null},
-              {"color": "green", "value": 1}
-            ]
-          }
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
         }
       },
       "options": {
@@ -142,13 +122,12 @@
     },
     {
       "type": "piechart",
-      "title": "Entrypoints by protocol",
-      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
+      "title": "Routes by protocol",
+      "description": "How routes break down by protocol: HTTP (web traffic), TCP (raw proxying, e.g. Postgres), UDP (DNS, etc.).",
+      "gridPos": {"x": 0, "y": 7, "w": 12, "h": 8},
       "id": 6,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [
-        {"expr": "sozune_entrypoints_by_protocol", "refId": "A", "legendFormat": "{{protocol}}"}
-      ],
+      "targets": [{"expr": "sozune_entrypoints_by_protocol", "refId": "A", "legendFormat": "{{protocol}}"}],
       "options": {
         "legend": {"displayMode": "list", "placement": "right", "showLegend": true},
         "pieType": "donut",
@@ -158,13 +137,14 @@
     {
       "type": "timeseries",
       "title": "Diagnostics by severity",
-      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "description": "Diagnostics emitted by Sozune: invalid ports, route collisions, misconfigured ACME, etc. Error (red) = blocking. Warn (yellow) = needs fixing. Info (blue) = informational.",
+      "gridPos": {"x": 12, "y": 7, "w": 12, "h": 8},
       "id": 7,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "sozune_diagnostics_total{severity=\"error\"}", "refId": "A", "legendFormat": "error"},
-        {"expr": "sozune_diagnostics_total{severity=\"warn\"}", "refId": "B", "legendFormat": "warn"},
-        {"expr": "sozune_diagnostics_total{severity=\"info\"}", "refId": "C", "legendFormat": "info"}
+        {"expr": "sozune_diagnostics{severity=\"error\"}", "refId": "A", "legendFormat": "error"},
+        {"expr": "sozune_diagnostics{severity=\"warn\"}", "refId": "B", "legendFormat": "warn"},
+        {"expr": "sozune_diagnostics{severity=\"info\"}", "refId": "C", "legendFormat": "info"}
       ],
       "fieldConfig": {
         "defaults": {
@@ -190,28 +170,85 @@
     {
       "type": "timeseries",
       "title": "Backends over time",
-      "gridPos": {"x": 0, "y": 12, "w": 24, "h": 8},
+      "description": "Green = total backends. Red = backends down. Track when backends come and go (container start/stop, pod crash).",
+      "gridPos": {"x": 0, "y": 15, "w": 24, "h": 8},
       "id": 8,
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [
-        {"expr": "sozune_backends_total", "refId": "A", "legendFormat": "total"},
-        {"expr": "sozune_backends_unhealthy_total", "refId": "B", "legendFormat": "unhealthy"}
+        {"expr": "sozune_backends", "refId": "A", "legendFormat": "total"},
+        {"expr": "sozune_backends_unhealthy", "refId": "B", "legendFormat": "down"}
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 2,
-            "fillOpacity": 10
-          }
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10}
         },
         "overrides": [
-          {"matcher": {"id": "byName", "options": "unhealthy"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+          {"matcher": {"id": "byName", "options": "down"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
           {"matcher": {"id": "byName", "options": "total"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
         ]
       },
       "options": {
         "legend": {"displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      }
+    },
+    {
+      "type": "text",
+      "title": "Sōzu worker metrics",
+      "gridPos": {"x": 0, "y": 23, "w": 24, "h": 2},
+      "id": 9,
+      "options": {
+        "mode": "markdown",
+        "content": "## Live Sōzu worker metrics\n\nValues polled every 5 s from the HTTP and HTTPS workers (connection, request, and error counters). If `last_poll` stops moving the proxy is no longer answering the poll — check the logs."
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Worker poll freshness",
+      "description": "Seconds since the last successful Sōzu worker poll. If this climbs past ~30 s, the observability pipeline is broken (worker blocked, command-channel dead).",
+      "gridPos": {"x": 0, "y": 25, "w": 6, "h": 4},
+      "id": 10,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "time() - sozune_proxy_last_poll_seconds", "refId": "A"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 15},
+              {"color": "red", "value": 30}
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Worker counters (raw)",
+      "description": "Proxy-wide counters reported by Sōzu (connections, HTTP requests, 4xx/5xx errors, bytes in/out, etc.). Each line is one `key=` label. Wrap with `rate(...)` for per-second rates.",
+      "gridPos": {"x": 6, "y": 25, "w": 18, "h": 8},
+      "id": 11,
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "rate(sozune_proxy_metric[1m])", "refId": "A", "legendFormat": "{{key}}"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"]},
         "tooltip": {"mode": "multi"}
       }
     }
@@ -225,6 +262,6 @@
   "timezone": "",
   "title": "Sozune Overview",
   "uid": "sozune-overview",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/tests/observability/grafana-dashboards.yml
+++ b/tests/observability/grafana-dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: sozune
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/tests/observability/grafana-datasource.yml
+++ b/tests/observability/grafana-datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/tests/observability/prometheus.yml
+++ b/tests/observability/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: sozune
+    static_configs:
+      - targets: ["host.docker.internal:3035"]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary

Exposes a `/metrics` endpoint on the API listener (default `:3035`) that serves both Prometheus text exposition and a structured JSON variant from the same backing snapshot. Includes a turnkey Grafana stack and ships first-party documentation.

### What's new

- **Static gauges** for entrypoint count (overall, per-protocol, with TLS), backend count, backend health, diagnostics severity histogram, ACME enabled flag.
- **Sōzu worker bridge**: every 5 s the proxy main-loop polls each worker over the command-channel for proxy-wide counters (`connections`, `http.requests`, `http.errors_4xx`, `bytes_in`, …) and stages them under a shared snapshot. Exposed as `sozune_proxy_metric{key="..."}` plus `sozune_proxy_last_poll_seconds` so an alert can flag stale data.
- **`Accept`-based content negotiation**: default response is Prometheus text exposition `version=0.0.4`; clients sending `Accept: application/json` get a structured JSON document with the exact same values. Sōzune's own dashboard can read the JSON variant directly instead of parsing text.
- **Reference Grafana stack**: `compose.metrics.yaml` boots Prometheus + Grafana with the dashboard pre-provisioned.
- **`documentation/advanced/observability.md`** covers the endpoint, both formats, the polling trade-off, and the reference stack.

### Notes for reviewers

- Same `AppState` reads, no new background tasks beyond the Sōzu poller already required for the bridge.
- The Sōzu poller uses `no_clusters: true` to keep cardinality bounded — counters are proxy-wide aggregates, not per-cluster.
- JSON serialization re-uses the snapshot computed for the text renderer, so the two formats can never drift on values (locked down by `prom_and_json_agree_on_values` test).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --bin sozune` — 414 passed (21 in `api::metrics`)
- [x] `bash tests/e2e/run-all.sh` — 73 passed, 0 failed, 2 skipped (before JSON negotiation commit; that commit only adds Accept-header branching and is covered by 5 unit tests)
- [x] Manual scrape: `curl http://127.0.0.1:3035/metrics` returns Prom text, `curl -H "Accept: application/json" …` returns JSON
- [x] Grafana stack: `docker compose -f compose.metrics.yaml up -d`, dashboard "Sozune Overview" loads with live values