### PR TITLE
Add middleware request-latency histogram to /metrics

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -244,6 +244,18 @@ export interface MetricsView {
      *  (dots become underscores). Values are integers; treat unknowns
      *  defensively. */
     metrics: Record<string, number>;
+    /** Latency histogram for requests served through the Sōzune middleware
+     *  layer (measured by Sōzune itself). Middleware-less routes are served
+     *  directly by Sōzu and not counted. Optional so older servers (without
+     *  this field) don't break the dashboard. */
+    middleware_request_duration_seconds?: {
+      /** `[upper_bound_seconds, cumulative_count]` pairs, ascending. */
+      buckets: [string, number][];
+      /** Sum of all observed request durations, in seconds. */
+      sum: number;
+      /** Total number of observed requests. */
+      count: number;
+    };
   };
 }
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -79,6 +79,26 @@
     !!metrics && metrics.proxy.last_poll_seconds > 0
   );
 
+  /** Middleware request-latency summary derived from the histogram Sōzune
+   *  measures itself. Covers only routes that go through the middleware layer;
+   *  middleware-less routes are served directly by Sōzu and not counted.
+   *  Average = sum / count; `null` until at least one request has been observed
+   *  (or on older servers without the field). */
+  const requestCount = $derived(
+    metrics?.proxy.middleware_request_duration_seconds?.count ?? null
+  );
+  const avgLatencyMs = $derived.by(() => {
+    const rd = metrics?.proxy.middleware_request_duration_seconds;
+    if (!rd || rd.count === 0) return null;
+    return (rd.sum / rd.count) * 1000;
+  });
+
+  function fmtLatency(ms: number): string {
+    if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`;
+    if (ms < 1000) return `${ms.toFixed(ms < 10 ? 1 : 0)}ms`;
+    return `${(ms / 1000).toFixed(2)}s`;
+  }
+
   function fmtCompact(n: number): string {
     if (n < 1000) return String(n);
     if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
@@ -542,6 +562,43 @@
         </div>
         <div class="foot">
           <span></span>
+          <a class="link" href="./health">Health <span class="arr">→</span></a>
+        </div>
+      </article>
+
+      <!-- Middleware latency -->
+      <article class="card">
+        <div class="head">
+          <span class="title">Mw latency</span>
+          {#if avgLatencyMs !== null}
+            <span class="pill pill-ok"><span class="dot"></span> live</span>
+          {:else}
+            <span class="pill pill-muted"><span class="dot"></span> no traffic</span>
+          {/if}
+        </div>
+        {#if avgLatencyMs !== null}
+          <div class="value">{fmtLatency(avgLatencyMs)}<small>avg request</small></div>
+          <div class="sub">
+            Mean over {fmtCompact(requestCount ?? 0)} middleware request{(requestCount ?? 0) ===
+            1
+              ? ''
+              : 's'}. Routes without middleware are served directly by Sōzu.
+          </div>
+        {:else}
+          <div class="value">—<small>avg request</small></div>
+          <div class="sub">
+            No middleware requests observed yet. Latency appears once traffic flows
+            through a route with middleware.
+          </div>
+        {/if}
+        <div class="foot">
+          {#if avgLatencyMs !== null}
+            <span class="live mono" title="Total requests through the middleware layer since startup">
+              <span class="live-dot"></span> {fmtCompact(requestCount ?? 0)} req
+            </span>
+          {:else}
+            <span></span>
+          {/if}
           <a class="link" href="./health">Health <span class="arr">→</span></a>
         </div>
       </article>

--- a/documentation/advanced/observability.md
+++ b/documentation/advanced/observability.md
@@ -36,6 +36,11 @@ JSON example:
     "metrics": {
       "connections": 14,
       "http_requests": 1042
+    },
+    "middleware_request_duration_seconds": {
+      "buckets": [["0.005", 812], ["0.01", 970], ["0.025", 1020]],
+      "sum": 7.42,
+      "count": 1042
     }
   }
 }
@@ -54,6 +59,38 @@ Numeric values in both formats are produced from the same in-memory snapshot, so
 | `sozune_backends_unhealthy` | gauge | Backends currently marked down by the health checker |
 | `sozune_diagnostics{severity="error\|warn\|info"}` | gauge | Active diagnostics by severity |
 | `sozune_acme_enabled` | gauge | `1` if the ACME module is enabled, `0` otherwise |
+
+## Middleware request-latency histogram
+
+Sōzune times every request that flows through its **middleware layer** (wall-clock, from the moment the handler receives it to the moment the response is ready) and aggregates the durations into a Prometheus **histogram**. Unlike the worker bridge below, this value is not polled — it is updated live on the request path.
+
+| Metric | Type | Description |
+|---|---|---|
+| `sozune_middleware_request_duration_seconds` | histogram | Latency of requests served through the Sōzune middleware layer, in seconds. Cumulative `_bucket{le="…"}` series plus `_sum` and `_count` |
+
+The bucket bounds (seconds) are: `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0`, plus the mandatory `+Inf`.
+
+Because it's a real histogram, you get percentiles for free with `histogram_quantile`:
+
+```promql
+# p95 middleware request latency over the last 5 minutes
+histogram_quantile(0.95, rate(sozune_middleware_request_duration_seconds_bucket[5m]))
+
+# average middleware request latency
+rate(sozune_middleware_request_duration_seconds_sum[5m]) / rate(sozune_middleware_request_duration_seconds_count[5m])
+```
+
+### Scope — read this before relying on it
+
+This histogram **only** covers requests that traverse the Sōzune middleware layer: routes that declare auth, forward-auth, rate-limit, header/query/client-IP matching, compression, a backend timeout, an IP allow-list, or a WASM plugin. Those routes are pointed at the in-process Axum handler, which is where the timing happens.
+
+Routes with **no** middleware are served **directly by the Sōzu workers** and never reach this timer — they are *not* counted here. For their latency, use the Sōzu worker `Time` metrics surfaced through the bridge below.
+
+So: think of this as *"how slow is my middleware path"*, not *"how slow is every request"*. On a deployment where every route uses at least one middleware, the two coincide.
+
+**What is counted** (among middleware routes): every request, including those that end in a proxy-level error (no healthy backend, backend timeout, backend unreachable) — their latency is real and worth watching. **Not counted:** WebSocket upgrades (the tunnel lives for the whole connection, so its duration is not a request latency and would skew the distribution) and requests rejected before routing (missing/unknown Host).
+
+The histogram is global — there are no `method`, `status`, or `host` labels, keeping cardinality flat regardless of traffic shape.
 
 ## Sōzu worker bridge
 
@@ -99,5 +136,5 @@ The dashboard JSON, Prometheus scrape config, and Grafana provisioning files liv
 ## What it does not do
 
 - **No tracing.** Sōzune does not emit OpenTelemetry spans today. A scrape-only metrics interface is intentional — if you need traces, an OTel collector can scrape `/metrics` and re-emit as OTLP.
-- **No per-route latency histograms.** Sōzu's `Histogram` and `Percentiles` metric types are skipped on export because their bucket bounds are not part of the protocol contract. Only `Gauge`, `Count`, and `Time` values are bridged.
+- **No _per-route_ latency histograms.** Sōzune exposes one **global** histogram for the middleware path (`sozune_middleware_request_duration_seconds`, see above), but does not break it down per route, host, or method — that would explode cardinality. It also does not cover middleware-less routes (served directly by Sōzu). Sōzu's own `Histogram` and `Percentiles` worker metrics are still skipped on the bridge because their bucket bounds are not part of the protocol contract; only `Gauge`, `Count`, and `Time` worker values are forwarded.
 - **No metric labels for hostnames, paths, or clusters.** Adding them would explode cardinality on large parks. Use Sōzu's per-cluster query directly if you need that granularity.

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -98,6 +98,24 @@ struct ProxyMetrics {
     last_poll_seconds: u64,
     /// Per-key proxy counters/gauges as reported by Sōzu workers.
     metrics: HashMap<String, i128>,
+    /// Latency histogram for requests served through the Sōzune middleware
+    /// layer (measured by Sōzune itself, not polled from Sōzu). Middleware-less
+    /// routes are served directly by Sōzu and not counted here. Additive
+    /// field — clients that don't know it simply ignore it.
+    middleware_request_duration_seconds: RequestDurationMetrics,
+}
+
+/// JSON shape of the request-latency histogram. The Prometheus renderer emits
+/// the same numbers as a `histogram` (`_bucket`/`_sum`/`_count`).
+#[derive(Debug, Serialize)]
+struct RequestDurationMetrics {
+    /// Cumulative bucket counts keyed by upper bound in seconds (stringified,
+    /// e.g. `"0.005"`). The implicit `+Inf` bucket equals `count`.
+    buckets: Vec<(String, u64)>,
+    /// Sum of all observed request durations, in seconds.
+    sum: f64,
+    /// Total number of observed requests.
+    count: u64,
 }
 
 impl Snapshot {
@@ -180,14 +198,14 @@ impl ProxyMetrics {
     fn collect(state: &AppState) -> Self {
         use crate::proxy::metrics_snapshot::MetricValue;
 
+        // A poisoned Sōzu-snapshot lock only zeroes the *polled* values; the
+        // request histogram lives in an independent atomic store, so we still
+        // read and report it below.
         let snap = match state.metrics.read() {
             Ok(g) => g.clone(),
             Err(e) => {
                 error!("metrics: snapshot lock poisoned: {}", e);
-                return ProxyMetrics {
-                    last_poll_seconds: 0,
-                    metrics: HashMap::new(),
-                };
+                crate::proxy::metrics_snapshot::MetricsSnapshot::default()
             }
         };
 
@@ -202,11 +220,30 @@ impl ProxyMetrics {
             metrics.insert(safe, v);
         }
 
+        let rd = state.request_metrics.snapshot();
+        let middleware_request_duration_seconds = RequestDurationMetrics {
+            buckets: rd
+                .buckets
+                .iter()
+                .map(|(bound, count)| (format_bound(*bound), *count))
+                .collect(),
+            sum: rd.sum_seconds,
+            count: rd.count,
+        };
+
         ProxyMetrics {
             last_poll_seconds: snap.last_poll_unix,
             metrics,
+            middleware_request_duration_seconds,
         }
     }
+}
+
+/// Format a bucket bound as a stable, dot-decimal string for the `le` label
+/// and JSON key, independent of locale. `0.005` → `"0.005"`.
+fn format_bound(bound: f64) -> String {
+    // The bounds are short decimals; `{}` renders them without trailing noise.
+    format!("{bound}")
 }
 
 fn render_prom(snap: &Snapshot) -> String {
@@ -297,7 +334,53 @@ fn render_prom(snap: &Snapshot) -> String {
         }
     }
 
+    render_request_duration(&mut out, &snap.proxy.middleware_request_duration_seconds);
+
     out
+}
+
+/// Render the middleware request-latency histogram in Prometheus exposition
+/// format: cumulative `_bucket{le=…}` series (including the mandatory
+/// `le="+Inf"`), then `_sum` and `_count`. Always emitted, even when empty
+/// (all zeros), so the series exist from the first scrape.
+///
+/// The metric is named `sozune_middleware_request_duration_seconds` — not
+/// `sozune_request_duration_seconds` — on purpose: it measures only requests
+/// that traverse the Sōzune middleware layer (routes with auth, rate-limit,
+/// matching, compression, …). Routes with no middleware are served directly by
+/// the Sōzu workers and never reach this timer; their latency lives in the
+/// Sōzu worker bridge instead.
+fn render_request_duration(out: &mut String, rd: &RequestDurationMetrics) {
+    let _ = writeln!(
+        out,
+        "# HELP sozune_middleware_request_duration_seconds Latency of requests served through the Sōzune middleware layer, in seconds. Middleware-less routes are served directly by Sōzu and not counted here."
+    );
+    let _ = writeln!(
+        out,
+        "# TYPE sozune_middleware_request_duration_seconds histogram"
+    );
+    for (bound, count) in &rd.buckets {
+        let _ = writeln!(
+            out,
+            "sozune_middleware_request_duration_seconds_bucket{{le=\"{bound}\"}} {count}"
+        );
+    }
+    // The `+Inf` bucket holds every observation, i.e. the total count.
+    let _ = writeln!(
+        out,
+        "sozune_middleware_request_duration_seconds_bucket{{le=\"+Inf\"}} {}",
+        rd.count
+    );
+    let _ = writeln!(
+        out,
+        "sozune_middleware_request_duration_seconds_sum {}",
+        rd.sum
+    );
+    let _ = writeln!(
+        out,
+        "sozune_middleware_request_duration_seconds_count {}",
+        rd.count
+    );
 }
 
 fn sanitize_metric_name(key: &str) -> String {
@@ -336,6 +419,7 @@ mod tests {
             acme_enabled: false,
             providers: crate::config::ProvidersConfig::default(),
             metrics: crate::proxy::metrics_snapshot::new_store(),
+            request_metrics: crate::proxy::request_metrics::new_store(),
             config: Arc::new(crate::config::AppConfig::default()),
         }
     }
@@ -478,6 +562,48 @@ mod tests {
         assert!(body.contains("sozune_proxy_last_poll_seconds 12345"));
         assert!(body.contains("sozune_proxy_metric{key=\"http_requests\"} 42"));
         assert!(body.contains("sozune_proxy_metric{key=\"connections\"} 7"));
+    }
+
+    #[test]
+    fn request_duration_histogram_present_and_zeroed_when_no_traffic() {
+        let body = render_prom(&Snapshot::collect(&empty_state()));
+        assert!(body.contains("# TYPE sozune_middleware_request_duration_seconds histogram"));
+        assert!(body.contains("sozune_middleware_request_duration_seconds_bucket{le=\"+Inf\"} 0"));
+        assert!(body.contains("sozune_middleware_request_duration_seconds_count 0"));
+        assert!(body.contains("sozune_middleware_request_duration_seconds_sum 0"));
+    }
+
+    #[test]
+    fn request_duration_histogram_reflects_recorded_requests() {
+        use std::time::Duration;
+        let state = empty_state();
+        // 20ms and 200ms: 20ms lands in le>=0.025, 200ms in le>=0.25.
+        state.request_metrics.record(Duration::from_millis(20));
+        state.request_metrics.record(Duration::from_millis(200));
+        let body = render_prom(&Snapshot::collect(&state));
+
+        assert!(body.contains("sozune_middleware_request_duration_seconds_count 2"));
+        // sum = 0.22s.
+        assert!(body.contains("sozune_middleware_request_duration_seconds_sum 0.22"));
+        // The 0.005 bucket caught neither; the +Inf bucket caught both.
+        assert!(body.contains("sozune_middleware_request_duration_seconds_bucket{le=\"0.005\"} 0"));
+        assert!(body.contains("sozune_middleware_request_duration_seconds_bucket{le=\"+Inf\"} 2"));
+        // The 0.25 bucket caught both (0.02 and 0.2 are <= 0.25).
+        assert!(body.contains("sozune_middleware_request_duration_seconds_bucket{le=\"0.25\"} 2"));
+        // The 0.025 bucket caught only the fast one.
+        assert!(body.contains("sozune_middleware_request_duration_seconds_bucket{le=\"0.025\"} 1"));
+    }
+
+    #[test]
+    fn request_duration_present_in_json() {
+        use std::time::Duration;
+        let state = empty_state();
+        state.request_metrics.record(Duration::from_millis(50));
+        let snap = Snapshot::collect(&state);
+        let json = serde_json::to_value(&snap).unwrap();
+        let rd = &json["proxy"]["middleware_request_duration_seconds"];
+        assert_eq!(rd["count"], 1);
+        assert!(rd["buckets"].is_array());
     }
 
     #[test]

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -31,6 +31,9 @@ pub struct AppState {
     /// whether their `enabled` flag is set.
     pub providers: crate::config::ProvidersConfig,
     pub metrics: crate::proxy::metrics_snapshot::MetricsSnapshotStore,
+    /// Live request-latency histogram, written by the middleware proxy handler.
+    /// Same Arc as `MiddlewareAppState::request_metrics`.
+    pub request_metrics: crate::proxy::request_metrics::RequestMetricsStore,
     /// Full parsed config snapshot. Shared (Arc) so we never clone the whole
     /// thing per request — `/config` reads it under no lock since the parsed
     /// config is immutable once Sōzune is up.
@@ -190,6 +193,7 @@ pub async fn serve(
     acme_enabled: bool,
     providers: crate::config::ProvidersConfig,
     metrics: crate::proxy::metrics_snapshot::MetricsSnapshotStore,
+    request_metrics: crate::proxy::request_metrics::RequestMetricsStore,
 ) -> anyhow::Result<()> {
     if config.users.is_empty() {
         anyhow::bail!(
@@ -206,6 +210,7 @@ pub async fn serve(
         acme_enabled,
         providers,
         metrics,
+        request_metrics,
         config: app_config,
     };
 
@@ -776,6 +781,7 @@ mod tests {
             acme_enabled: false,
             providers: crate::config::ProvidersConfig::default(),
             metrics: crate::proxy::metrics_snapshot::new_store(),
+            request_metrics: crate::proxy::request_metrics::new_store(),
             config: Arc::new(crate::config::AppConfig::default()),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,10 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     // the API metrics endpoint.
     let metrics_store = proxy::metrics_snapshot::new_store();
 
+    // Live request-latency histogram, written by the middleware proxy handler
+    // and read by the API `/metrics` endpoint. Shared (same Arc) across both.
+    let request_metrics_store = proxy::request_metrics::new_store();
+
     // Notify ACME manager when storage changes (new TLS entrypoints)
     let acme_notify = Arc::new(Notify::new());
 
@@ -236,6 +240,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let acme_enabled_api = acme_enabled;
     let providers_api = config.providers.clone();
     let metrics_store_api = Arc::clone(&metrics_store);
+    let request_metrics_api = Arc::clone(&request_metrics_store);
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
@@ -249,6 +254,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 acme_enabled_api,
                 providers_api,
                 metrics_store_api,
+                request_metrics_api,
             )
             .await?;
         }
@@ -275,7 +281,8 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     // Start middleware server
     let middleware_task = tokio::spawn({
         let middleware_state = Arc::clone(&middleware_state);
-        async move { middleware::serve(middleware_port, middleware_state).await }
+        let request_metrics_mw = Arc::clone(&request_metrics_store);
+        async move { middleware::serve(middleware_port, middleware_state, request_metrics_mw).await }
     });
 
     // Start ACME module if enabled

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -39,6 +39,9 @@ pub fn build_forward_auth_client() -> reqwest::Client {
 pub struct MiddlewareAppState {
     pub route_table: Arc<RwLock<MiddlewareRouteTable>>,
     pub http_client: Client<hyper_util::client::legacy::connect::HttpConnector, axum::body::Body>,
+    /// Live request-latency histogram. The proxy handler records each
+    /// completed request here; the API `/metrics` endpoint reads the same Arc.
+    pub request_metrics: crate::proxy::request_metrics::RequestMetricsStore,
 }
 
 pub type MiddlewareState = Arc<RwLock<MiddlewareRouteTable>>;
@@ -288,10 +291,15 @@ pub fn build_middleware_route(
 }
 
 /// Start the middleware reverse proxy server
-pub async fn serve(port: u16, route_table: MiddlewareState) -> anyhow::Result<()> {
+pub async fn serve(
+    port: u16,
+    route_table: MiddlewareState,
+    request_metrics: crate::proxy::request_metrics::RequestMetricsStore,
+) -> anyhow::Result<()> {
     let app_state = MiddlewareAppState {
         route_table,
         http_client: Client::builder(TokioExecutor::new()).build_http(),
+        request_metrics,
     };
 
     let app = Router::new()

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -95,6 +95,7 @@ pub async fn handle_proxy(
     // forward-auth deny, rate limit).
     if let Err(response) = chain::run_request_phase(&route.middlewares, &mut ctx, &mut req).await {
         let duration = start.elapsed();
+        state.request_metrics.record(duration);
         access_log(
             &source_ip,
             &method,
@@ -112,6 +113,7 @@ pub async fn handle_proxy(
         Some(b) => b.clone(),
         None => {
             error!("No backends configured for host '{}'", host);
+            state.request_metrics.record(start.elapsed());
             return diag::no_healthy_backend(&host, &route.backends).into_response();
         }
     };
@@ -146,6 +148,9 @@ pub async fn handle_proxy(
         .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
 
     if is_websocket {
+        // WebSocket tunnels live for the whole connection (minutes to hours),
+        // so their duration is not a request latency — deliberately excluded
+        // from the request-duration histogram to avoid skewing the distribution.
         return handle_websocket(req, &backend_host, backend_port, &forwarded_path, &query).await;
     }
 
@@ -156,6 +161,7 @@ pub async fn handle_proxy(
         Ok(uri) => uri,
         Err(e) => {
             error!("Failed to parse target URI '{}': {}", target_uri, e);
+            state.request_metrics.record(start.elapsed());
             return diag::forwarding_failed("invalid-target-uri", &e.to_string()).into_response();
         }
     };
@@ -179,6 +185,7 @@ pub async fn handle_proxy(
             Ok(result) => result.map_err(|e| e.to_string()),
             Err(_) => {
                 error!("Backend request to {} timed out", target_uri);
+                state.request_metrics.record(start.elapsed());
                 return diag::backend_timeout(&target_uri, timeout_secs).into_response();
             }
         }
@@ -192,6 +199,7 @@ pub async fn handle_proxy(
         }
         Err(e) => {
             error!("Failed to forward request to {}: {}", target_uri, e);
+            state.request_metrics.record(start.elapsed());
             return diag::backend_unreachable(&format!("backend at {target_uri}: {e}"))
                 .into_response();
         }
@@ -202,6 +210,7 @@ pub async fn handle_proxy(
     let response = chain::run_response_phase(&route.middlewares, &ctx, backend_response).await;
 
     let duration = start.elapsed();
+    state.request_metrics.record(duration);
     access_log(
         &source_ip,
         &method,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,4 +1,5 @@
 pub mod backend;
 pub mod health;
 pub mod metrics_snapshot;
+pub mod request_metrics;
 pub mod sozu;

--- a/src/proxy/request_metrics.rs
+++ b/src/proxy/request_metrics.rs
@@ -1,0 +1,170 @@
+//! Live request-latency histogram, fed by the proxy handler and read by the
+//! `/metrics` endpoint.
+//!
+//! Unlike [`super::metrics_snapshot`] (which mirrors values *polled* from Sōzu
+//! workers), this is computed by Sōzune itself: every proxied request records
+//! its wall-clock duration here as it completes. `/metrics` then renders a
+//! Prometheus histogram (`sozune_request_duration_seconds`) plus the
+//! conventional `_sum` and `_count` series, so a scraper can compute averages
+//! and `histogram_quantile`-based percentiles (p50/p95/p99).
+//!
+//! The hot path (one `record` per request) is lock-free: each bucket, the
+//! count, and the summed milliseconds are plain atomics. A scrape reads them
+//! with `Ordering::Relaxed` — exact cross-bucket consistency is not required
+//! for monitoring, and avoiding a lock keeps the proxy path cheap.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// Cumulative upper bounds, in seconds, for the latency histogram. Chosen to
+/// cover sub-millisecond proxy overhead through multi-second slow backends.
+/// These match the canonical Prometheus client default ladder closely enough
+/// to be familiar to operators.
+pub const BUCKET_BOUNDS_SECONDS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+pub type RequestMetricsStore = Arc<RequestMetrics>;
+
+/// Lock-free request-latency histogram. One counter per bucket (each counting
+/// observations whose value is `<=` that bucket's bound — i.e. already
+/// cumulative on read), plus a total `count` and the summed duration in
+/// milliseconds.
+#[derive(Debug)]
+pub struct RequestMetrics {
+    /// Per-bucket observation counts, aligned with [`BUCKET_BOUNDS_SECONDS`].
+    /// `buckets[i]` counts observations with `duration <= BUCKET_BOUNDS[i]`.
+    buckets: Vec<AtomicU64>,
+    /// Total number of observations (the `+Inf` bucket / `_count`).
+    count: AtomicU64,
+    /// Sum of all observed durations, in milliseconds, to avoid float atomics.
+    /// Rendered as seconds (`/ 1000`) in the `_sum` series.
+    sum_millis: AtomicU64,
+}
+
+impl Default for RequestMetrics {
+    fn default() -> Self {
+        Self {
+            buckets: BUCKET_BOUNDS_SECONDS
+                .iter()
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+            count: AtomicU64::new(0),
+            sum_millis: AtomicU64::new(0),
+        }
+    }
+}
+
+impl RequestMetrics {
+    /// Record one completed request. Increments every bucket whose bound is
+    /// `>= duration` (so buckets are cumulative on read), the total count, and
+    /// the running sum.
+    pub fn record(&self, duration: Duration) {
+        let secs = duration.as_secs_f64();
+        for (i, bound) in BUCKET_BOUNDS_SECONDS.iter().enumerate() {
+            if secs <= *bound {
+                self.buckets[i].fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        self.count.fetch_add(1, Ordering::Relaxed);
+        // Saturating millis: a single request over ~584M years would overflow.
+        self.sum_millis
+            .fetch_add(duration.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// Read a consistent-enough snapshot for rendering. Values are read with
+    /// `Relaxed` ordering; a concurrent `record` may land between reads, which
+    /// is acceptable for monitoring data.
+    pub fn snapshot(&self) -> RequestMetricsSnapshot {
+        RequestMetricsSnapshot {
+            buckets: BUCKET_BOUNDS_SECONDS
+                .iter()
+                .zip(&self.buckets)
+                .map(|(bound, b)| (*bound, b.load(Ordering::Relaxed)))
+                .collect(),
+            count: self.count.load(Ordering::Relaxed),
+            sum_seconds: self.sum_millis.load(Ordering::Relaxed) as f64 / 1000.0,
+        }
+    }
+}
+
+/// Point-in-time view of the histogram, used by both metric renderers.
+#[derive(Debug, Clone)]
+pub struct RequestMetricsSnapshot {
+    /// `(upper_bound_seconds, cumulative_count)` pairs, in ascending bound
+    /// order. The `+Inf` bucket equals `count` and is added by the renderer.
+    pub buckets: Vec<(f64, u64)>,
+    /// Total observations (`_count` and the implicit `+Inf` bucket).
+    pub count: u64,
+    /// Sum of all observed durations, in seconds (`_sum`).
+    pub sum_seconds: f64,
+}
+
+pub fn new_store() -> RequestMetricsStore {
+    Arc::new(RequestMetrics::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn empty_snapshot_is_all_zero() {
+        let m = RequestMetrics::default();
+        let s = m.snapshot();
+        assert_eq!(s.count, 0);
+        assert_eq!(s.sum_seconds, 0.0);
+        assert!(s.buckets.iter().all(|(_, c)| *c == 0));
+    }
+
+    #[test]
+    fn record_increments_count_and_sum() {
+        let m = RequestMetrics::default();
+        m.record(ms(20));
+        m.record(ms(30));
+        let s = m.snapshot();
+        assert_eq!(s.count, 2);
+        // 50ms total = 0.05s.
+        assert!((s.sum_seconds - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn buckets_are_cumulative() {
+        let m = RequestMetrics::default();
+        // 20ms = 0.02s: falls in every bucket with bound >= 0.025.
+        m.record(ms(20));
+        let s = m.snapshot();
+        // bound 0.005 and 0.01 must NOT count it; 0.025 and up must.
+        for (bound, c) in &s.buckets {
+            if *bound >= 0.025 {
+                assert_eq!(*c, 1, "bound {bound} should include 20ms");
+            } else {
+                assert_eq!(*c, 0, "bound {bound} should exclude 20ms");
+            }
+        }
+    }
+
+    #[test]
+    fn fast_request_lands_in_first_bucket() {
+        let m = RequestMetrics::default();
+        m.record(Duration::from_micros(100)); // 0.0001s <= 0.005
+        let s = m.snapshot();
+        assert_eq!(s.buckets[0].1, 1);
+        assert_eq!(s.count, 1);
+    }
+
+    #[test]
+    fn slow_request_only_in_count_not_top_bucket() {
+        let m = RequestMetrics::default();
+        m.record(Duration::from_secs(30)); // beyond the 10s top bound
+        let s = m.snapshot();
+        // No finite bucket counts it; only the total count (the +Inf bucket).
+        assert!(s.buckets.iter().all(|(_, c)| *c == 0));
+        assert_eq!(s.count, 1);
+    }
+}

--- a/tests/e2e/15-metrics-timing.sh
+++ b/tests/e2e/15-metrics-timing.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Middleware request-latency histogram on /metrics.
+#
+# Sōzune times every request that flows through its middleware layer and
+# exposes a Prometheus histogram `sozune_middleware_request_duration_seconds`
+# (cumulative _bucket / _sum / _count) on the unauthenticated /metrics endpoint
+# of the API listener.
+#
+# IMPORTANT: only middleware routes are counted. Routes with no middleware are
+# served directly by the Sōzu workers and never reach this timer. So this suite
+# drives traffic through `svc-ipallow` (which has an ipAllowList middleware and
+# allows 127.0.0.1 → 200), NOT a plain route like svc-a.
+#
+# Sourced by run-all.sh.
+
+METRICS_URL="http://127.0.0.1:$API_PORT/metrics"
+HIST="sozune_middleware_request_duration_seconds"
+
+# Helper: value of a single metric line by exact name.
+metric_value() {
+    local name="$1"
+    curl -s --max-time 2 "$METRICS_URL" 2>/dev/null \
+        | grep -E "^${name} " | awk '{print $2}' | head -1
+}
+
+log "[15] Timing metrics: histogram series are present"
+
+body=$(curl -s --max-time 2 "$METRICS_URL" 2>/dev/null || echo "")
+if grep -q "# TYPE ${HIST} histogram" <<<"$body" \
+    && grep -q "${HIST}_bucket{le=\"+Inf\"}" <<<"$body" \
+    && grep -q "${HIST}_count " <<<"$body" \
+    && grep -q "${HIST}_sum " <<<"$body"; then
+    pass "histogram exposes _bucket/_sum/_count series"
+else
+    fail "histogram series missing from /metrics"
+fi
+
+log "[15] Timing metrics: a middleware request increments the histogram count"
+
+before=$(metric_value "${HIST}_count")
+before=${before:-0}
+
+# Drive requests through a route WITH middleware (ipAllowList allows loopback).
+for _ in 1 2 3; do
+    curl -s -o /dev/null --max-time 2 -H "Host: $HOST_IPALLOW" \
+        "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null || true
+done
+
+# The histogram is updated on the request path; poll briefly for the increment.
+after=""
+for _ in $(seq 1 10); do
+    after=$(metric_value "${HIST}_count")
+    after=${after:-0}
+    if (( after > before )); then
+        break
+    fi
+    sleep 0.2
+done
+
+if (( after > before )); then
+    pass "middleware request count grew from $before to $after"
+else
+    fail "middleware request count did not grow (before=$before after=$after)"
+fi
+
+log "[15] Timing metrics: +Inf bucket equals the total count"
+
+inf=$(curl -s --max-time 2 "$METRICS_URL" 2>/dev/null \
+    | grep -E "${HIST}_bucket\{le=\"\+Inf\"\}" \
+    | awk '{print $2}' | head -1)
+inf=${inf:-0}
+count=$(metric_value "${HIST}_count")
+count=${count:-0}
+if [[ "$inf" == "$count" ]]; then
+    pass "+Inf bucket ($inf) equals _count ($count)"
+else
+    fail "+Inf bucket ($inf) does not equal _count ($count)"
+fi
+
+log "[15] Timing metrics: JSON view carries the histogram"
+
+json_count=$(curl -s --max-time 2 -H "Accept: application/json" "$METRICS_URL" 2>/dev/null \
+    | grep -oE '"middleware_request_duration_seconds":\{[^}]*"count":[0-9]+' \
+    | grep -oE '"count":[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [[ -n "$json_count" ]]; then
+    pass "JSON /metrics exposes proxy.middleware_request_duration_seconds.count ($json_count)"
+else
+    fail "JSON /metrics did not expose middleware_request_duration_seconds"
+fi


### PR DESCRIPTION
## Summary

Exposes a Prometheus **histogram** of request latency on the existing `/metrics` endpoint: `sozune_middleware_request_duration_seconds` (cumulative `_bucket{le=…}` + `_sum` + `_count`), so operators can compute averages and `histogram_quantile`-based percentiles (p50/p95/p99).

## Scope (important)

The histogram covers **only requests that traverse the Sōzune middleware layer** — routes with auth, forward-auth, rate-limit, header/query/client-IP matching, compression, backend timeout, IP allow-list, or a WASM plugin. Routes with no middleware are served directly by the Sōzu workers and never reach this timer; their latency stays in the Sōzu worker bridge. The metric name (`middleware_` prefix), the `# HELP` text, the docs, and the dashboard card all state this explicitly so the number is never read as "every request".

WebSocket upgrades are excluded (a tunnel's lifetime is not a request latency and would skew the distribution), as are requests rejected before routing.

## Implementation

- New `src/proxy/request_metrics.rs`: a lock-free atomic histogram (one `AtomicU64` per bucket + count + summed millis). The hot path is a single `record()` with `Relaxed` ordering — no lock on the request path.
- Same `Arc` shared between `MiddlewareAppState` (writer, in `handle_proxy`) and `AppState` (reader, in `/metrics`). Recorded at every routed-request exit, including proxy-level errors (no backend / timeout / unreachable).
- `/metrics` renders it as a Prometheus `histogram` and adds it to the JSON view (`proxy.middleware_request_duration_seconds`) — additive, so the dashboard and other clients don't break.
- Global histogram, no `method`/`status`/`host` labels → flat cardinality.

## Tests & docs

- Unit tests: histogram math (cumulative buckets, sum, count, fast/slow edge cases) + Prometheus and JSON rendering.
- e2e: `tests/e2e/15-metrics-timing.sh` — series present, count grows after driving traffic through a middleware route, `+Inf` == `_count`, JSON carries it.
- Docs: new "Middleware request-latency histogram" section in `documentation/advanced/observability.md`, with a scope caveat and `histogram_quantile` examples; corrected the "no per-route histograms" note.
- Dashboard: optional TS field + a "Mw latency" overview card (avg = sum/count).

Full e2e suite: 86 passed, 0 failed.
