### PR TITLE
Add JSON log format with structured access logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,6 +4346,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,12 +4365,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1.89"
 ipnet = "2.11"
 serde_yaml = "0.9"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 signal-hook = "0.4"
 signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
 futures-util = "0.3"

--- a/documentation/advanced/access-logs.md
+++ b/documentation/advanced/access-logs.md
@@ -1,6 +1,6 @@
 # Access logs
 
-Sōzune logs every request that flows through its internal middleware proxy (compress, rate limit, backend timeout) via the standard `tracing` infrastructure. There is no separate access log file — logs go to stdout.
+Sōzune logs every request that flows through its internal middleware proxy (compress, rate limit, backend timeout) via the standard `tracing` infrastructure, on a dedicated `access` target. Output is plain text by default or structured JSON (`log.format: json`). There is no separate access log file — logs go to stdout.
 
 ## What is and isn't logged
 
@@ -8,28 +8,39 @@ The Sōzune access log is emitted by the middleware proxy. A request reaches tha
 
 ## Format
 
-Each logged request emits one line at `info` level:
+Each logged request emits one `info`-level event on the dedicated `access` target, carrying **structured fields** (`client_ip`, `method`, `host`, `path`, `status`, `duration_ms`, `phase`). How those fields are rendered depends on `log.format` (see below).
+
+### Text (default)
 
 ```
-<source-ip> <method> <host> <path> <status> <duration>ms
+<client_ip> <method> <host> <path> <status> <duration_ms>ms (<phase>)
 ```
 
 Example:
 
 ```
-2026-04-27T17:45:07.300344Z  INFO sozune::middleware::proxy: 192.0.2.10 GET api.example.com /v1/users 200 12ms
+2026-04-27T17:45:07.300344Z  INFO access: 192.0.2.10 GET api.example.com /v1/users 200 12ms (backend)
+```
+
+### JSON
+
+With `log.format: json`, the same event is emitted as one JSON object per line, with every field as a top-level key — no regex parsing needed downstream:
+
+```json
+{"timestamp":"2026-04-27T17:45:07.300344Z","level":"INFO","target":"access","client_ip":"192.0.2.10","method":"GET","host":"api.example.com","path":"/v1/users","status":200,"duration_ms":12,"phase":"backend","message":"192.0.2.10 GET api.example.com /v1/users 200 12ms (backend)"}
 ```
 
 ## Fields
 
 | Field | Source |
 |---|---|
-| `source-ip` | First entry of `X-Forwarded-For`, or the literal `-` if absent |
+| `client_ip` | First entry of `X-Forwarded-For`, or the literal `-` if absent |
 | `method` | HTTP method |
 | `host` | `Host` header from the incoming request |
 | `path` | Request path (before any `stripPrefix` rewrite) |
 | `status` | Response status code returned to the client |
-| `duration` | Total time to serve the request, milliseconds |
+| `duration_ms` | Total time to serve the request, milliseconds |
+| `phase` | `backend` for a normally-proxied response, or `middleware` when a middleware short-circuited it (auth deny, rate limit, …) |
 
 ## What's logged additionally
 
@@ -37,9 +48,33 @@ Example:
 - Backend timeouts and connection failures log `ERROR` lines with the target URI.
 - WebSocket upgrades log `DEBUG` lines (only visible at debug level).
 
-## Configuring log output
+## Choosing text or JSON
 
-Sōzune respects the `RUST_LOG` environment variable.
+The formatter is global (it applies to every log line, not just the access log) and is selected with `log.format` in `config.yaml`:
+
+```yaml
+log:
+  format: json   # or `text` (the default)
+```
+
+Or via environment variable, which takes precedence over the file:
+
+```bash
+SOZUNE_LOG_FORMAT=json sozune
+```
+
+Unknown values are ignored and the default (`text`) stands.
+
+## Configuring log verbosity
+
+Sōzune respects the `RUST_LOG` environment variable. To capture **only** the access log, filter on its target:
+
+```bash
+# Access log only, nothing else
+RUST_LOG=access=info,sozune=warn sozune
+```
+
+More generally:
 
 ```bash
 # Default — info for sozune, warn for noisy deps
@@ -63,6 +98,6 @@ sozune=info, bollard=warn, hyper=warn, rustls=warn
 
 ## Limitations
 
-- **No format customisation.** The access log line layout is hardcoded; no JSON, no Apache combined, no LTSV.
+- **Two layouts only.** `text` or `json` — no Apache combined, no LTSV, no per-field custom templates. The field set is fixed.
 - **No log file rotation.** Stdout only. If you need persistence, capture stdout in your container orchestrator (Docker, systemd, k8s) and apply rotation there.
 - **No sampling.** Every request is logged; high-traffic services produce one log line per request.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,10 +14,33 @@ pub struct AppConfig {
     pub middleware: MiddlewareConfig,
     #[serde(default)]
     pub dashboard: DashboardConfig,
+    /// Logging output configuration (text vs JSON).
+    #[serde(default)]
+    pub log: LogConfig,
     /// WASM plugins declared by name. Each entry points at an http-wasm guest
     /// `.wasm`; entrypoints reference these by name to run them as middleware.
     #[serde(default)]
     pub plugins: HashMap<String, PluginConfig>,
+}
+
+/// Logging output configuration. Controls the formatter used by the global
+/// tracing subscriber — this affects *all* logs, including the per-request
+/// access log (emitted on the `access` target).
+#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct LogConfig {
+    /// `text` (default, human-readable) or `json` (one JSON object per line,
+    /// machine-parseable). JSON renders structured fields like `client_ip`,
+    /// `status`, and `duration_ms` as top-level keys.
+    #[serde(default)]
+    pub format: LogFormat,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    #[default]
+    Text,
+    Json,
 }
 
 /// Declaration of one WASM plugin artifact. The `config` blob is opaque to
@@ -1073,6 +1096,7 @@ impl AppConfig {
         self.proxy.apply_env_overrides();
         self.middleware.apply_env_overrides();
         self.dashboard.apply_env_overrides();
+        self.log.apply_env_overrides();
 
         let acme_env_present = std::env::var("SOZUNE_ACME_ENABLED").is_ok()
             || std::env::var("SOZUNE_ACME_EMAIL").is_ok()
@@ -1345,6 +1369,23 @@ impl MiddlewareConfig {
     fn apply_env_overrides(&mut self) {
         if let Some(v) = env_parse::<u16>("SOZUNE_MIDDLEWARE_PORT") {
             self.port = v;
+        }
+    }
+}
+
+impl LogConfig {
+    fn apply_env_overrides(&mut self) {
+        if let Some(v) = env_string("SOZUNE_LOG_FORMAT") {
+            match v.trim().to_ascii_lowercase().as_str() {
+                "json" => self.format = LogFormat::Json,
+                "text" => self.format = LogFormat::Text,
+                other => {
+                    // Unknown value: keep the current format. A warning here
+                    // would predate tracing init, so we stay silent and let the
+                    // documented default stand.
+                    let _ = other;
+                }
+            }
         }
     }
 }
@@ -1776,5 +1817,46 @@ https:
 "#;
         let config: ProxyConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(config.tcp.is_empty());
+    }
+
+    #[test]
+    fn log_format_defaults_to_text() {
+        assert_eq!(LogConfig::default().format, LogFormat::Text);
+        // An AppConfig with no `log:` block also defaults to text.
+        let cfg: AppConfig = serde_yaml::from_str("{}").unwrap_or_default();
+        assert_eq!(cfg.log.format, LogFormat::Text);
+    }
+
+    #[test]
+    fn log_format_parses_json_from_yaml() {
+        let cfg: LogConfig = serde_yaml::from_str("format: json").unwrap();
+        assert_eq!(cfg.format, LogFormat::Json);
+        let cfg: LogConfig = serde_yaml::from_str("format: text").unwrap();
+        assert_eq!(cfg.format, LogFormat::Text);
+    }
+
+    #[test]
+    fn log_format_env_override_wins() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut cfg = LogConfig::default();
+        {
+            let _env = EnvGuard::new(&[("SOZUNE_LOG_FORMAT", "json")]);
+            cfg.apply_env_overrides();
+        }
+        assert_eq!(cfg.format, LogFormat::Json);
+    }
+
+    #[test]
+    fn log_format_env_unknown_value_keeps_current() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut cfg = LogConfig {
+            format: LogFormat::Json,
+        };
+        {
+            let _env = EnvGuard::new(&[("SOZUNE_LOG_FORMAT", "garbage")]);
+            cfg.apply_env_overrides();
+        }
+        // Unknown value must not silently flip the format.
+        assert_eq!(cfg.format, LogFormat::Json);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,12 @@ pub use model::*;
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    init_tracing();
-
     let config_path = cli::resolve_config_path(cli.config.as_deref());
+
+    // Resolve the log format before installing the tracing subscriber: the
+    // subscriber is global and set once, so the access log's text/JSON shape
+    // has to be known up front. Env wins over YAML wins over the default.
+    init_tracing(resolve_log_format(&config_path).await);
 
     match cli.command.unwrap_or(Command::Serve) {
         Command::Serve => serve(&config_path).await,
@@ -62,27 +65,55 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-fn init_tracing() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("sozune=info".parse().expect("valid log directive"))
-                .add_directive("bollard=warn".parse().expect("valid log directive"))
-                .add_directive("hyper=warn".parse().expect("valid log directive"))
-                .add_directive("hyper_util=warn".parse().expect("valid log directive"))
-                .add_directive("rustls=warn".parse().expect("valid log directive"))
-                .add_directive("sozu_lib=warn".parse().expect("valid log directive"))
-                .add_directive(
-                    "sozu_command_lib=warn"
-                        .parse()
-                        .expect("valid log directive"),
-                )
-                .add_directive("mio=warn".parse().expect("valid log directive"))
-                .add_directive("h2=warn".parse().expect("valid log directive"))
-                .add_directive("kube=warn".parse().expect("valid log directive"))
-                .add_directive("tower=warn".parse().expect("valid log directive")),
+fn log_env_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive("sozune=info".parse().expect("valid log directive"))
+        .add_directive("bollard=warn".parse().expect("valid log directive"))
+        .add_directive("hyper=warn".parse().expect("valid log directive"))
+        .add_directive("hyper_util=warn".parse().expect("valid log directive"))
+        .add_directive("rustls=warn".parse().expect("valid log directive"))
+        .add_directive("sozu_lib=warn".parse().expect("valid log directive"))
+        .add_directive(
+            "sozu_command_lib=warn"
+                .parse()
+                .expect("valid log directive"),
         )
-        .init();
+        .add_directive("mio=warn".parse().expect("valid log directive"))
+        .add_directive("h2=warn".parse().expect("valid log directive"))
+        .add_directive("kube=warn".parse().expect("valid log directive"))
+        .add_directive("tower=warn".parse().expect("valid log directive"))
+}
+
+fn init_tracing(format: config::LogFormat) {
+    let builder = tracing_subscriber::fmt().with_env_filter(log_env_filter());
+    match format {
+        config::LogFormat::Text => builder.init(),
+        // JSON: one object per line, with structured fields (e.g. the access
+        // log's `client_ip`, `status`, `duration_ms`) as top-level keys.
+        config::LogFormat::Json => builder.json().flatten_event(true).init(),
+    }
+}
+
+/// Best-effort resolution of the log format before the config is fully loaded
+/// and validated. Env (`SOZUNE_LOG_FORMAT`) wins; otherwise we peek at the YAML
+/// `log.format` if a config file is present; otherwise the default (text). Any
+/// read/parse error is swallowed — the real validation happens in `serve`, and
+/// the default keeps logging working regardless.
+async fn resolve_log_format(config_path: &str) -> config::LogFormat {
+    if let Ok(v) = std::env::var("SOZUNE_LOG_FORMAT") {
+        match v.trim().to_ascii_lowercase().as_str() {
+            "json" => return config::LogFormat::Json,
+            "text" => return config::LogFormat::Text,
+            _ => {}
+        }
+    }
+    if tokio::fs::try_exists(config_path).await.unwrap_or(false)
+        && let Ok(content) = tokio::fs::read_to_string(config_path).await
+        && let Ok(cfg) = config_load::parse_yaml(std::path::Path::new(config_path), &content)
+    {
+        return cfg.log.format;
+    }
+    config::LogFormat::Text
 }
 
 async fn serve(config_path: &str) -> anyhow::Result<()> {

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -95,14 +95,14 @@ pub async fn handle_proxy(
     // forward-auth deny, rate limit).
     if let Err(response) = chain::run_request_phase(&route.middlewares, &mut ctx, &mut req).await {
         let duration = start.elapsed();
-        info!(
-            "{} {} {} {} {} {}ms (middleware)",
-            source_ip,
-            method,
-            host,
-            path,
+        access_log(
+            &source_ip,
+            &method,
+            &host,
+            &path,
             response.status().as_u16(),
-            duration.as_millis()
+            duration,
+            "middleware",
         );
         return response.into_response();
     }
@@ -202,17 +202,51 @@ pub async fn handle_proxy(
     let response = chain::run_response_phase(&route.middlewares, &ctx, backend_response).await;
 
     let duration = start.elapsed();
-    info!(
-        "{} {} {} {} {} {}ms",
-        source_ip,
-        method,
-        host,
-        path,
+    access_log(
+        &source_ip,
+        &method,
+        &host,
+        &path,
         response.status().as_u16(),
-        duration.as_millis()
+        duration,
+        "backend",
     );
 
     response.into_response()
+}
+
+/// Emit one access-log line for a completed request.
+///
+/// The event carries **structured fields** (`client_ip`, `method`, `host`,
+/// `path`, `status`, `duration_ms`, `phase`) on the `access` target. With the
+/// text formatter these render as the familiar
+/// `<ip> <method> <host> <path> <status> <ms>ms` line; with the JSON formatter
+/// (`log.format: json`) each field becomes a top-level key, so log pipelines
+/// can filter and aggregate without regex-parsing the message.
+///
+/// `phase` is `"backend"` for a normally-proxied response or `"middleware"`
+/// when a middleware short-circuited the request (auth deny, rate limit, …).
+fn access_log(
+    client_ip: &str,
+    method: &str,
+    host: &str,
+    path: &str,
+    status: u16,
+    duration: std::time::Duration,
+    phase: &'static str,
+) {
+    let duration_ms = duration.as_millis();
+    info!(
+        target: "access",
+        client_ip,
+        method,
+        host,
+        path,
+        status,
+        duration_ms,
+        phase,
+        "{client_ip} {method} {host} {path} {status} {duration_ms}ms ({phase})",
+    );
 }
 
 /// Handle WebSocket upgrade by establishing a TCP tunnel to the backend

--- a/tests/e2e/16-access-logs-json.sh
+++ b/tests/e2e/16-access-logs-json.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Structured JSON logging (`log.format: json`).
+#
+# Validates the format→subscriber wiring end-to-end: a Sōzune process started
+# with JSON logging must emit its log lines as valid JSON objects carrying the
+# tracing fields (`timestamp`, `level`, `target`). This is an autonomous test —
+# it starts its OWN short-lived Sōzune on dedicated ports so it never collides
+# with the main suite's instance, and needs no backend.
+#
+# Sourced by run-all.sh. Relies on $SOZUNE_BIN and helpers from lib.sh.
+
+log "[16] JSON logs: process started with log.format=json emits JSON lines"
+
+JSON_CFG=$(mktemp /tmp/sozune-jsonlog-XXXXXX.yaml)
+JSON_OUT=$(mktemp /tmp/sozune-jsonlog-out-XXXXXX.log)
+
+# Dedicated ports, well clear of the main suite's (HTTP 18080 / API 18888).
+cat >"$JSON_CFG" <<'YAML'
+log:
+  format: json
+providers:
+  docker:
+    enabled: false
+api:
+  enabled: true
+  listen_address: "127.0.0.1:19888"
+  users:
+    - name: "admin"
+      hash: "0000000000000000000000000000000000000000000000000000000000000000"
+      role: admin
+proxy:
+  http:
+    listen_address: 19080
+  https:
+    listen_address: 19443
+middleware:
+  port: 19081
+dashboard:
+  enabled: false
+YAML
+
+# Start it directly in the background. SOZUNE_LOG_FORMAT is left unset so we
+# exercise the YAML `log.format` path specifically. Logs are captured to a
+# file, so we read them after a short sleep without ever `wait`-ing on the
+# process (a blocking wait on the embedded Sōzu workers can hang the suite —
+# the orphan-sozune trap).
+CONFIG_PATH="$JSON_CFG" "$SOZUNE_BIN" >"$JSON_OUT" 2>&1 &
+JSON_PID=$!
+sleep 2
+# SIGKILL the process and any worker children it spawned. No graceful SIGTERM
+# (workers linger), no wait (would block). pkill -P reaps the direct children.
+pkill -9 -P "$JSON_PID" 2>/dev/null || true
+kill -9 "$JSON_PID" 2>/dev/null || true
+sleep 0.3
+
+# Sōzune's own logs must all be JSON objects with the tracing fields. Note:
+# the embedded Sōzu workers log through their own logger (not our tracing
+# subscriber) and may emit a couple of plain-text lines at shutdown — those are
+# out of our control, so we don't fail on them. What we DO require:
+#   1. at least one Sōzune log line, rendered as JSON, and
+#   2. no Sōzune log line leaking in the text format (`INFO sozune...`).
+json_lines=0
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if jq -e 'has("timestamp") and has("level") and has("target") and (.target | startswith("sozune"))' \
+        >/dev/null 2>&1 <<<"$line"; then
+        json_lines=$((json_lines + 1))
+    fi
+done <"$JSON_OUT"
+
+# A Sōzune log line in TEXT format would look like `<ts>  INFO sozune...`.
+# `grep -c` returns 1 when there are no matches; under `set -e`/`pipefail` that
+# would abort the suite, so guard with `|| true`.
+text_leak=$(grep -cE '[0-9]Z[[:space:]]+(INFO|WARN|ERROR|DEBUG)[[:space:]]+sozune' "$JSON_OUT" 2>/dev/null || true)
+text_leak=${text_leak:-0}
+
+if (( json_lines > 0 )) && (( text_leak == 0 )); then
+    pass "Sōzune logs render as JSON ($json_lines lines), none leaked as text"
+else
+    fail "expected JSON Sōzune logs with no text leak (json=$json_lines text_leak=$text_leak); see $JSON_OUT"
+fi
+
+log "[16] JSON logs: a known startup line is present as JSON"
+
+# "Starting Sozune proxy" is logged at boot; in JSON its message field carries it.
+if grep -F '"message"' "$JSON_OUT" 2>/dev/null | jq -e 'select(.message | test("Starting Sozune proxy"))' >/dev/null 2>&1; then
+    pass "startup message present as a JSON message field"
+else
+    fail "could not find the startup message as JSON in $JSON_OUT"
+fi
+
+rm -f "$JSON_CFG" "$JSON_OUT"


### PR DESCRIPTION
## Summary

Adds an opt-in JSON log format and turns the per-request access log into a structured event, so log pipelines can ingest Sōzune without regex-parsing text.

## What changed

- **`log.format` config** (`text` default, or `json`), with a `SOZUNE_LOG_FORMAT` env override that wins over the file. Unknown values are ignored and the default stands.
- **`init_tracing`** installs the global subscriber as either the text formatter (unchanged default) or `.json().flatten_event(true)`. The format is resolved early (env → YAML → default) so it's known before the subscriber is set.
- **Access logs are now structured**: the two per-request `info!` lines in `proxy.rs` become a single `access_log()` event on the dedicated `access` target, carrying named fields — `client_ip`, `method`, `host`, `path`, `status`, `duration_ms`, `phase`. In text mode they render as the familiar `<ip> <method> <host> <path> <status> <ms>ms (<phase>)` line; in JSON mode each field is a top-level key.
- `phase` distinguishes a normally-proxied response (`backend`) from a middleware short-circuit (`middleware`, e.g. auth deny / rate limit).

## Notes

- As with the request-latency histogram, only requests through the Sōzune middleware layer produce a Sōzune access line; middleware-less routes are served directly by Sōzu (documented).
- The embedded Sōzu workers use their own logger; a couple of plain-text lines at shutdown are out of scope.

## Tests & docs

- Unit tests: `LogFormat` YAML parsing, env override precedence, unknown-value handling, default.
- e2e: `tests/e2e/16-access-logs-json.sh` — boots an isolated Sōzune with `log.format: json` on dedicated ports and asserts its logs render as JSON with tracing fields and no text leak.
- Docs: `documentation/advanced/access-logs.md` updated with the text/JSON formats, the field table, `log.format` config + env, target-based filtering, and corrected limitations.

Full e2e suite: 84 passed, 0 failed.
