### PR TITLE
Add OpenTelemetry distributed tracing (OTLP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,6 +2665,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2881,12 @@ name = "pool"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ac1531a0016945992b4e816e81538dfad0b9f00d280bcb707d711839f1536d"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"
@@ -3920,6 +3988,9 @@ dependencies = [
  "kube",
  "mime_guess",
  "notify",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rcgen",
  "reqwest",
  "rust-embed",
@@ -3937,6 +4008,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -4175,6 +4247,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4335,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4259,7 +4390,9 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -4343,6 +4476,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ ipnet = "2.11"
 serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+opentelemetry = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace"] }
+tracing-opentelemetry = "0.33"
 signal-hook = "0.4"
 signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
 futures-util = "0.3"

--- a/compose.metrics.yaml
+++ b/compose.metrics.yaml
@@ -10,6 +10,17 @@ services:
         extra_hosts:
             - "host.docker.internal:host-gateway"
 
+    # Traces backend. Receives Sōzune spans over OTLP/gRPC on :4317 and is
+    # queried by Grafana. Point `tracing.endpoint` at http://127.0.0.1:4317.
+    tempo:
+        image: grafana/tempo:latest
+        command: ["-config.file=/etc/tempo.yaml"]
+        ports:
+            - "3200:3200"   # Tempo query API (Grafana datasource)
+            - "4317:4317"   # OTLP/gRPC ingest
+        volumes:
+            - ./tests/observability/tempo.yaml:/etc/tempo.yaml:ro
+
     grafana:
         image: grafana/grafana:latest
         ports:
@@ -24,3 +35,4 @@ services:
             - ./tests/observability/dashboards:/var/lib/grafana/dashboards:ro
         depends_on:
             - prometheus
+            - tempo

--- a/documentation/advanced/observability.md
+++ b/documentation/advanced/observability.md
@@ -131,10 +131,53 @@ Then open:
 - Prometheus: `http://127.0.0.1:9090`
 - Grafana: `http://127.0.0.1:3000` — login `admin` / `admin`, dashboard "Sozune Overview" auto-loaded
 
-The dashboard JSON, Prometheus scrape config, and Grafana provisioning files live under `tests/observability/`. Copy them into your own stack to ingest Sōzune in production.
+The stack also ships **Grafana Tempo** (a traces backend) wired as a datasource, so the same `docker compose -f compose.metrics.yaml up -d` gives you both metrics and traces. Tempo listens for OTLP/gRPC on `:4317` — point Sōzune's `tracing.endpoint` there.
+
+The dashboard JSON, Prometheus scrape config, Tempo config, and Grafana provisioning files live under `tests/observability/`. Copy them into your own stack to ingest Sōzune in production.
+
+## Distributed tracing (OpenTelemetry)
+
+Beyond metrics, Sōzune can emit a **trace span per proxied request** and export it over **OTLP/gRPC** to a collector (Jaeger, Grafana Tempo, Zipkin via OTel, …). Disabled by default — no spans, no exporter, zero overhead.
+
+### Enable it
+
+```yaml
+tracing:
+  enabled: true
+  endpoint: "http://127.0.0.1:4317"   # OTLP/gRPC collector
+  service_name: "sozune"               # service.name on every span
+  sampler: "parent_based_always_on"    # see below
+```
+
+Every field has an environment override: `SOZUNE_TRACING_ENABLED`, `SOZUNE_TRACING_ENDPOINT`, `SOZUNE_TRACING_SERVICE_NAME`, `SOZUNE_TRACING_SAMPLER` (env wins over YAML).
+
+### What you get
+
+- **One span per request** named `proxy.request`, with attributes `http.request.method`, `server.address`, `url.path`, and `http.response.status_code`.
+- **W3C context propagation, both ways.** An incoming `traceparent` header is honoured as the span's parent (so Sōzune continues an upstream trace); an outgoing `traceparent` is injected toward the backend (so the backend joins the same trace).
+- **Trace correlation in logs.** Each access-log line carries the `trace_id` (a `trace=` field in text, a `"trace_id"` key in JSON), so you can jump from a log line to its trace. It is `-` when tracing is off.
+
+### Sampling
+
+The `sampler` controls which traces are recorded:
+
+| Value | Behaviour |
+|---|---|
+| `parent_based_always_on` (default) | Follow the upstream sampling decision; if there is none, sample. The right default for a proxy — if the caller is tracing, so are we. |
+| `parent_based_always_off` | Follow the upstream decision; otherwise drop. |
+| `always_on` / `always_off` | Force the decision regardless of parent. |
+| `ratio:<0..1>` | Parent-based ratio sampling, e.g. `ratio:0.1` records ~10% of root traces. |
+
+### Scope
+
+Like the latency histogram and access log, only requests that traverse the Sōzune **middleware layer** produce a span — middleware-less routes are served directly by Sōzu and are not traced here.
+
+### Try it with the demo stack
+
+`compose.metrics.yaml` includes Tempo. With it up, set `tracing.enabled: true` and `tracing.endpoint: http://127.0.0.1:4317`, send a request through Sōzune, then open Grafana → Explore → Tempo and search recent traces.
 
 ## What it does not do
 
-- **No tracing.** Sōzune does not emit OpenTelemetry spans today. A scrape-only metrics interface is intentional — if you need traces, an OTel collector can scrape `/metrics` and re-emit as OTLP.
+- **No span for middleware-less routes.** Requests served directly by the Sōzu workers (no auth/rate-limit/etc.) never reach the Axum handler that opens the span, so they are not traced. Same boundary as the access log and the latency histogram.
 - **No _per-route_ latency histograms.** Sōzune exposes one **global** histogram for the middleware path (`sozune_middleware_request_duration_seconds`, see above), but does not break it down per route, host, or method — that would explode cardinality. It also does not cover middleware-less routes (served directly by Sōzu). Sōzu's own `Histogram` and `Percentiles` worker metrics are still skipped on the bridge because their bucket bounds are not part of the protocol contract; only `Gauge`, `Count`, and `Time` worker values are forwarded.
 - **No metric labels for hostnames, paths, or clusters.** Adding them would explode cardinality on large parks. Use Sōzu's per-cluster query directly if you need that granularity.

--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -54,6 +54,8 @@ middleware:
 | `acme` | Let's Encrypt provisioning. |
 | `proxy` | Sōzu listeners and runtime tuning. |
 | `middleware` | Internal middleware proxy port. |
+| `log` | Log output format (`text` or `json`). |
+| `tracing` | OpenTelemetry distributed tracing (OTLP export). Off by default. See [Observability](../advanced/observability.md#distributed-tracing-opentelemetry). |
 
 ## Providers
 
@@ -174,6 +176,11 @@ Every field above can be overridden through an environment variable. The env var
 | `acme.staging` | `SOZUNE_ACME_STAGING` |
 | `acme.challenge_port` | `SOZUNE_ACME_CHALLENGE_PORT` |
 | `middleware.port` | `SOZUNE_MIDDLEWARE_PORT` |
+| `log.format` | `SOZUNE_LOG_FORMAT` |
+| `tracing.enabled` | `SOZUNE_TRACING_ENABLED` |
+| `tracing.endpoint` | `SOZUNE_TRACING_ENDPOINT` |
+| `tracing.service_name` | `SOZUNE_TRACING_SERVICE_NAME` |
+| `tracing.sampler` | `SOZUNE_TRACING_SAMPLER` |
 
 Booleans accept `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,10 +17,59 @@ pub struct AppConfig {
     /// Logging output configuration (text vs JSON).
     #[serde(default)]
     pub log: LogConfig,
+    /// Distributed tracing (OpenTelemetry OTLP export). Disabled by default.
+    #[serde(default)]
+    pub tracing: TracingConfig,
     /// WASM plugins declared by name. Each entry points at an http-wasm guest
     /// `.wasm`; entrypoints reference these by name to run them as middleware.
     #[serde(default)]
     pub plugins: HashMap<String, PluginConfig>,
+}
+
+/// Distributed-tracing configuration. When `enabled`, every proxied request
+/// opens an OpenTelemetry span, the incoming W3C `traceparent` is honoured as
+/// the parent, an outgoing `traceparent` is injected toward the backend, and
+/// spans are exported over OTLP to a collector (Jaeger, Tempo, Zipkin, …).
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct TracingConfig {
+    /// Master switch. Off by default — no spans, no exporter, zero overhead.
+    #[serde(default)]
+    pub enabled: bool,
+    /// OTLP/gRPC collector endpoint, e.g. `http://collector:4317`.
+    #[serde(default = "default_tracing_endpoint")]
+    pub endpoint: String,
+    /// `service.name` reported on every span.
+    #[serde(default = "default_tracing_service_name")]
+    pub service_name: String,
+    /// Sampler. `parent_based_always_on` (default) follows the upstream
+    /// decision and otherwise samples everything; `ratio:<0..1>` samples a
+    /// fraction (still parent-based), e.g. `ratio:0.1`; `always_on` /
+    /// `always_off` force the decision.
+    #[serde(default = "default_tracing_sampler")]
+    pub sampler: String,
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_tracing_endpoint(),
+            service_name: default_tracing_service_name(),
+            sampler: default_tracing_sampler(),
+        }
+    }
+}
+
+fn default_tracing_endpoint() -> String {
+    "http://127.0.0.1:4317".to_string()
+}
+
+fn default_tracing_service_name() -> String {
+    "sozune".to_string()
+}
+
+fn default_tracing_sampler() -> String {
+    "parent_based_always_on".to_string()
 }
 
 /// Logging output configuration. Controls the formatter used by the global
@@ -1097,6 +1146,7 @@ impl AppConfig {
         self.middleware.apply_env_overrides();
         self.dashboard.apply_env_overrides();
         self.log.apply_env_overrides();
+        self.tracing.apply_env_overrides();
 
         let acme_env_present = std::env::var("SOZUNE_ACME_ENABLED").is_ok()
             || std::env::var("SOZUNE_ACME_EMAIL").is_ok()
@@ -1386,6 +1436,23 @@ impl LogConfig {
                     let _ = other;
                 }
             }
+        }
+    }
+}
+
+impl TracingConfig {
+    fn apply_env_overrides(&mut self) {
+        if let Some(v) = env_bool("SOZUNE_TRACING_ENABLED") {
+            self.enabled = v;
+        }
+        if let Some(v) = env_string("SOZUNE_TRACING_ENDPOINT") {
+            self.endpoint = v;
+        }
+        if let Some(v) = env_string("SOZUNE_TRACING_SERVICE_NAME") {
+            self.service_name = v;
+        }
+        if let Some(v) = env_string("SOZUNE_TRACING_SAMPLER") {
+            self.sampler = v;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod middleware;
 mod model;
 mod provider;
 mod proxy;
+mod tracing_otel;
 mod util;
 
 /// Shared lock serialising every test that mutates `std::env`. Tests across
@@ -43,10 +44,13 @@ async fn main() -> anyhow::Result<()> {
 
     let config_path = cli::resolve_config_path(cli.config.as_deref());
 
-    // Resolve the log format before installing the tracing subscriber: the
-    // subscriber is global and set once, so the access log's text/JSON shape
-    // has to be known up front. Env wins over YAML wins over the default.
-    init_tracing(resolve_log_format(&config_path).await);
+    // Resolve enough config before installing the tracing subscriber: it is
+    // global and set once, so the log format (text/JSON) and the optional OTLP
+    // tracing layer have to be known up front. Env wins over YAML wins over
+    // defaults. The returned guard keeps the OTLP exporter alive and flushes it
+    // on drop — bind it for the whole process.
+    let early_cfg = resolve_early_config(&config_path).await;
+    let _tracing_guard = init_tracing(&early_cfg.log, &early_cfg.tracing);
 
     match cli.command.unwrap_or(Command::Serve) {
         Command::Serve => serve(&config_path).await,
@@ -84,36 +88,71 @@ fn log_env_filter() -> tracing_subscriber::EnvFilter {
         .add_directive("tower=warn".parse().expect("valid log directive"))
 }
 
-fn init_tracing(format: config::LogFormat) {
-    let builder = tracing_subscriber::fmt().with_env_filter(log_env_filter());
-    match format {
-        config::LogFormat::Text => builder.init(),
-        // JSON: one object per line, with structured fields (e.g. the access
-        // log's `client_ip`, `status`, `duration_ms`) as top-level keys.
-        config::LogFormat::Json => builder.json().flatten_event(true).init(),
+/// Install the global tracing subscriber: a fmt layer (text or JSON) plus,
+/// when `tracing.enabled`, an OpenTelemetry OTLP layer. Returns the OTLP guard
+/// (kept alive by the caller, flushed on drop) or `None` when tracing is off or
+/// the exporter failed to build (in which case we degrade to logs-only).
+fn init_tracing(
+    log: &config::LogConfig,
+    tracing_cfg: &config::TracingConfig,
+) -> Option<tracing_otel::TracingGuard> {
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    // The fmt layer mirrors the previous behaviour: text by default, or
+    // newline-delimited JSON with flattened fields.
+    let fmt_layer = match log.format {
+        config::LogFormat::Text => tracing_subscriber::fmt::layer().boxed(),
+        config::LogFormat::Json => tracing_subscriber::fmt::layer()
+            .json()
+            .flatten_event(true)
+            .boxed(),
+    };
+
+    let registry = tracing_subscriber::registry()
+        .with(log_env_filter())
+        .with(fmt_layer);
+
+    if !tracing_cfg.enabled {
+        registry.init();
+        return None;
+    }
+
+    match tracing_otel::build_layer(tracing_cfg) {
+        Ok((otel_layer, guard)) => {
+            registry.with(otel_layer).init();
+            info!(
+                "Distributed tracing enabled, exporting OTLP to {}",
+                tracing_cfg.endpoint
+            );
+            Some(guard)
+        }
+        Err(e) => {
+            // Don't crash on a bad collector endpoint — run logs-only.
+            registry.init();
+            error!("tracing: failed to initialise OTLP exporter, continuing without traces: {e}");
+            None
+        }
     }
 }
 
-/// Best-effort resolution of the log format before the config is fully loaded
-/// and validated. Env (`SOZUNE_LOG_FORMAT`) wins; otherwise we peek at the YAML
-/// `log.format` if a config file is present; otherwise the default (text). Any
-/// read/parse error is swallowed — the real validation happens in `serve`, and
-/// the default keeps logging working regardless.
-async fn resolve_log_format(config_path: &str) -> config::LogFormat {
-    if let Ok(v) = std::env::var("SOZUNE_LOG_FORMAT") {
-        match v.trim().to_ascii_lowercase().as_str() {
-            "json" => return config::LogFormat::Json,
-            "text" => return config::LogFormat::Text,
-            _ => {}
-        }
-    }
-    if tokio::fs::try_exists(config_path).await.unwrap_or(false)
+/// Best-effort early config used only to set up tracing before the real config
+/// is loaded and validated in `serve`. Env wins over YAML wins over defaults;
+/// any read/parse error is swallowed and defaults stand (logging still works).
+async fn resolve_early_config(config_path: &str) -> config::AppConfig {
+    let mut cfg = if tokio::fs::try_exists(config_path).await.unwrap_or(false)
         && let Ok(content) = tokio::fs::read_to_string(config_path).await
-        && let Ok(cfg) = config_load::parse_yaml(std::path::Path::new(config_path), &content)
+        && let Ok(parsed) = config_load::parse_yaml(std::path::Path::new(config_path), &content)
     {
-        return cfg.log.format;
-    }
-    config::LogFormat::Text
+        parsed
+    } else {
+        config::AppConfig::default()
+    };
+    // Apply env overrides so SOZUNE_LOG_FORMAT / SOZUNE_TRACING_* win, exactly
+    // as they will in `serve`.
+    cfg.apply_env_overrides();
+    cfg
 }
 
 async fn serve(config_path: &str) -> anyhow::Result<()> {
@@ -423,8 +462,13 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 Ok(Ok(Err(e))) => error!("Proxy shut down with error: {}", e),
                 Ok(Err(e)) => error!("Proxy task panicked: {:?}", e),
                 Err(_) => {
-                    warn!("Graceful shutdown timed out, forcing exit");
-                    std::process::exit(1);
+                    // Don't `process::exit` here: that would skip `main`'s
+                    // tracing guard drop and lose the last span batch. Returning
+                    // the error unwinds cleanly so the guard flushes on the way
+                    // out, then `main` reports the failure.
+                    warn!("Graceful shutdown timed out");
+                    metrics_poll_task.abort();
+                    anyhow::bail!("graceful shutdown timed out after 10s");
                 }
             }
         }

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -8,6 +8,9 @@ use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, error, info, warn};
 
+use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
 use super::MiddlewareAppState;
 use super::chain::{self, RequestCtx};
 use super::diag;
@@ -50,178 +53,206 @@ pub async fn handle_proxy(
         }
     };
 
-    let (route, known_hosts) = {
-        let table = match state.route_table.read() {
-            Ok(guard) => guard,
-            Err(e) => {
-                error!(
-                    "internal state corrupted (middleware routing), restart required: {}",
-                    e
+    // One span per proxied request. The incoming W3C `traceparent` (if any) is
+    // attached as the parent so this request continues an upstream trace; the
+    // span's `trace_id` is logged and propagated to the backend below. When
+    // tracing is disabled the span is cheap and simply never exported.
+    let span = tracing::info_span!(
+        "proxy.request",
+        otel.name = %format!("{method} {host}"),
+        http.request.method = %method,
+        server.address = %host,
+        url.path = %path,
+        http.response.status_code = tracing::field::Empty,
+    );
+    // `set_parent` only errors if the otel context can't be attached (no
+    // active otel subscriber, i.e. tracing disabled) — harmless to ignore.
+    let _ = span.set_parent(crate::tracing_otel::extract_parent(req.headers()));
+
+    let fut = async move {
+        let (route, known_hosts) = {
+            let table = match state.route_table.read() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!(
+                        "internal state corrupted (middleware routing), restart required: {}",
+                        e
+                    );
+                    return diag::internal_error("middleware-routing-corrupted").into_response();
+                }
+            };
+            (table.get_route_by_host(&host), table.known_hosts())
+        };
+
+        let route = match route {
+            Some(r) => r,
+            None => {
+                info!(
+                    "no route for host '{}' (known: {})",
+                    host,
+                    known_hosts.len()
                 );
-                return diag::internal_error("middleware-routing-corrupted").into_response();
+                return diag::no_route_for_host(&host, &known_hosts).into_response();
             }
         };
-        (table.get_route_by_host(&host), table.known_hosts())
-    };
 
-    let route = match route {
-        Some(r) => r,
-        None => {
-            info!(
-                "no route for host '{}' (known: {})",
-                host,
-                known_hosts.len()
+        // Build the per-request context shared across middlewares.
+        let mut ctx = RequestCtx {
+            host: host.clone(),
+            client_addr,
+            is_tls: req
+                .headers()
+                .get("x-forwarded-proto")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.eq_ignore_ascii_case("https"))
+                .unwrap_or(false),
+            client_encoding: None,
+            pending_response_headers: Vec::new(),
+        };
+
+        // Request phase: run the middleware stack in order. A middleware may mutate
+        // the request (e.g. forward-auth stamping headers) or short-circuit (e.g.
+        // forward-auth deny, rate limit).
+        if let Err(response) =
+            chain::run_request_phase(&route.middlewares, &mut ctx, &mut req).await
+        {
+            let duration = start.elapsed();
+            state.request_metrics.record(duration);
+            access_log(
+                &source_ip,
+                &method,
+                &host,
+                &path,
+                response.status().as_u16(),
+                duration,
+                "middleware",
             );
-            return diag::no_route_for_host(&host, &known_hosts).into_response();
+            return response.into_response();
         }
-    };
 
-    // Build the per-request context shared across middlewares.
-    let mut ctx = RequestCtx {
-        host: host.clone(),
-        client_addr,
-        is_tls: req
+        // Pick a backend using round-robin.
+        let (backend_host, backend_port) = match route.next_backend() {
+            Some(b) => b.clone(),
+            None => {
+                error!("No backends configured for host '{}'", host);
+                state.request_metrics.record(start.elapsed());
+                return diag::no_healthy_backend(&host, &route.backends).into_response();
+            }
+        };
+
+        // Build the forwarded URI.
+        let original_path = req.uri().path().to_string();
+        let query = req
+            .uri()
+            .query()
+            .map(|q| format!("?{}", q))
+            .unwrap_or_default();
+
+        let forwarded_path = original_path.clone();
+
+        let target_uri = format!(
+            "http://{}:{}{}{}",
+            backend_host, backend_port, forwarded_path, query
+        );
+
+        debug!(
+            "Proxying {} {} -> {}",
+            req.method(),
+            original_path,
+            target_uri
+        );
+
+        // Check for WebSocket upgrade.
+        let is_websocket = req
             .headers()
-            .get("x-forwarded-proto")
+            .get("upgrade")
             .and_then(|v| v.to_str().ok())
-            .map(|s| s.eq_ignore_ascii_case("https"))
-            .unwrap_or(false),
-        client_encoding: None,
-        pending_response_headers: Vec::new(),
-    };
+            .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
 
-    // Request phase: run the middleware stack in order. A middleware may mutate
-    // the request (e.g. forward-auth stamping headers) or short-circuit (e.g.
-    // forward-auth deny, rate limit).
-    if let Err(response) = chain::run_request_phase(&route.middlewares, &mut ctx, &mut req).await {
+        if is_websocket {
+            // WebSocket tunnels live for the whole connection (minutes to hours),
+            // so their duration is not a request latency — deliberately excluded
+            // from the request-duration histogram to avoid skewing the distribution.
+            return handle_websocket(req, &backend_host, backend_port, &forwarded_path, &query)
+                .await;
+        }
+
+        // Build the forwarded request.
+        let (mut parts, body) = req.into_parts();
+
+        // Propagate the trace downstream: write this span's context as the
+        // outgoing `traceparent` so the backend joins the same trace. No-op when
+        // tracing is disabled (the context is invalid/empty).
+        crate::tracing_otel::inject_context(
+            &tracing::Span::current().context(),
+            &mut parts.headers,
+        );
+
+        parts.uri = match target_uri.parse::<Uri>() {
+            Ok(uri) => uri,
+            Err(e) => {
+                error!("Failed to parse target URI '{}': {}", target_uri, e);
+                state.request_metrics.record(start.elapsed());
+                return diag::forwarding_failed("invalid-target-uri", &e.to_string())
+                    .into_response();
+            }
+        };
+
+        let forwarded_req = Request::from_parts(parts, body);
+
+        // Send the request to the real backend.
+        let timeout_secs = route.backend_timeout.unwrap_or(30);
+
+        let response_future = state.http_client.request(forwarded_req);
+
+        let result = if timeout_secs == 0 {
+            response_future.await.map_err(|e| e.to_string())
+        } else {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(timeout_secs),
+                response_future,
+            )
+            .await
+            {
+                Ok(result) => result.map_err(|e| e.to_string()),
+                Err(_) => {
+                    error!("Backend request to {} timed out", target_uri);
+                    state.request_metrics.record(start.elapsed());
+                    return diag::backend_timeout(&target_uri, timeout_secs).into_response();
+                }
+            }
+        };
+
+        let backend_response = match result {
+            Ok(resp) => {
+                let (parts, body) = resp.into_parts();
+                let body = Body::new(body.map_err(|e| axum::Error::new(std::io::Error::other(e))));
+                Response::from_parts(parts, body)
+            }
+            Err(e) => {
+                error!("Failed to forward request to {}: {}", target_uri, e);
+                state.request_metrics.record(start.elapsed());
+                return diag::backend_unreachable(&format!("backend at {target_uri}: {e}"))
+                    .into_response();
+            }
+        };
+
+        // Response phase: run the middleware stack in reverse (onion model). This is
+        // where compression applies.
+        let response = chain::run_response_phase(&route.middlewares, &ctx, backend_response).await;
+
         let duration = start.elapsed();
         state.request_metrics.record(duration);
+        let status = response.status().as_u16();
+        tracing::Span::current().record("http.response.status_code", status);
         access_log(
-            &source_ip,
-            &method,
-            &host,
-            &path,
-            response.status().as_u16(),
-            duration,
-            "middleware",
+            &source_ip, &method, &host, &path, status, duration, "backend",
         );
-        return response.into_response();
-    }
 
-    // Pick a backend using round-robin.
-    let (backend_host, backend_port) = match route.next_backend() {
-        Some(b) => b.clone(),
-        None => {
-            error!("No backends configured for host '{}'", host);
-            state.request_metrics.record(start.elapsed());
-            return diag::no_healthy_backend(&host, &route.backends).into_response();
-        }
+        response.into_response()
     };
 
-    // Build the forwarded URI.
-    let original_path = req.uri().path().to_string();
-    let query = req
-        .uri()
-        .query()
-        .map(|q| format!("?{}", q))
-        .unwrap_or_default();
-
-    let forwarded_path = original_path.clone();
-
-    let target_uri = format!(
-        "http://{}:{}{}{}",
-        backend_host, backend_port, forwarded_path, query
-    );
-
-    debug!(
-        "Proxying {} {} -> {}",
-        req.method(),
-        original_path,
-        target_uri
-    );
-
-    // Check for WebSocket upgrade.
-    let is_websocket = req
-        .headers()
-        .get("upgrade")
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
-
-    if is_websocket {
-        // WebSocket tunnels live for the whole connection (minutes to hours),
-        // so their duration is not a request latency — deliberately excluded
-        // from the request-duration histogram to avoid skewing the distribution.
-        return handle_websocket(req, &backend_host, backend_port, &forwarded_path, &query).await;
-    }
-
-    // Build the forwarded request.
-    let (mut parts, body) = req.into_parts();
-
-    parts.uri = match target_uri.parse::<Uri>() {
-        Ok(uri) => uri,
-        Err(e) => {
-            error!("Failed to parse target URI '{}': {}", target_uri, e);
-            state.request_metrics.record(start.elapsed());
-            return diag::forwarding_failed("invalid-target-uri", &e.to_string()).into_response();
-        }
-    };
-
-    let forwarded_req = Request::from_parts(parts, body);
-
-    // Send the request to the real backend.
-    let timeout_secs = route.backend_timeout.unwrap_or(30);
-
-    let response_future = state.http_client.request(forwarded_req);
-
-    let result = if timeout_secs == 0 {
-        response_future.await.map_err(|e| e.to_string())
-    } else {
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(timeout_secs),
-            response_future,
-        )
-        .await
-        {
-            Ok(result) => result.map_err(|e| e.to_string()),
-            Err(_) => {
-                error!("Backend request to {} timed out", target_uri);
-                state.request_metrics.record(start.elapsed());
-                return diag::backend_timeout(&target_uri, timeout_secs).into_response();
-            }
-        }
-    };
-
-    let backend_response = match result {
-        Ok(resp) => {
-            let (parts, body) = resp.into_parts();
-            let body = Body::new(body.map_err(|e| axum::Error::new(std::io::Error::other(e))));
-            Response::from_parts(parts, body)
-        }
-        Err(e) => {
-            error!("Failed to forward request to {}: {}", target_uri, e);
-            state.request_metrics.record(start.elapsed());
-            return diag::backend_unreachable(&format!("backend at {target_uri}: {e}"))
-                .into_response();
-        }
-    };
-
-    // Response phase: run the middleware stack in reverse (onion model). This is
-    // where compression applies.
-    let response = chain::run_response_phase(&route.middlewares, &ctx, backend_response).await;
-
-    let duration = start.elapsed();
-    state.request_metrics.record(duration);
-    access_log(
-        &source_ip,
-        &method,
-        &host,
-        &path,
-        response.status().as_u16(),
-        duration,
-        "backend",
-    );
-
-    response.into_response()
+    fut.instrument(span).await
 }
 
 /// Emit one access-log line for a completed request.
@@ -235,6 +266,10 @@ pub async fn handle_proxy(
 ///
 /// `phase` is `"backend"` for a normally-proxied response or `"middleware"`
 /// when a middleware short-circuited the request (auth deny, rate limit, …).
+///
+/// `trace_id` is the current request span's OpenTelemetry trace id (32 hex
+/// chars), or `"-"` when tracing is disabled / the trace id is invalid — so log
+/// pipelines can join an access line to its trace.
 fn access_log(
     client_ip: &str,
     method: &str,
@@ -245,6 +280,7 @@ fn access_log(
     phase: &'static str,
 ) {
     let duration_ms = duration.as_millis();
+    let trace_id = current_trace_id();
     info!(
         target: "access",
         client_ip,
@@ -254,8 +290,25 @@ fn access_log(
         status,
         duration_ms,
         phase,
-        "{client_ip} {method} {host} {path} {status} {duration_ms}ms ({phase})",
+        trace_id = %trace_id,
+        "{client_ip} {method} {host} {path} {status} {duration_ms}ms ({phase}) trace={trace_id}",
     );
+}
+
+/// Trace id of the current span as 32 lowercase hex chars, or `"-"` when there
+/// is no valid (sampled) trace context — e.g. tracing disabled. Returns a
+/// borrowed `"-"` on the hot path when tracing is off, so the disabled case
+/// allocates nothing.
+fn current_trace_id() -> std::borrow::Cow<'static, str> {
+    use opentelemetry::trace::TraceContextExt;
+    let cx = tracing::Span::current().context();
+    let span_ref = cx.span();
+    let sc = span_ref.span_context();
+    if sc.is_valid() {
+        std::borrow::Cow::Owned(sc.trace_id().to_string())
+    } else {
+        std::borrow::Cow::Borrowed("-")
+    }
 }
 
 /// Handle WebSocket upgrade by establishing a TCP tunnel to the backend

--- a/src/tracing_otel.rs
+++ b/src/tracing_otel.rs
@@ -1,0 +1,223 @@
+//! OpenTelemetry distributed-tracing pipeline.
+//!
+//! When `tracing.enabled`, this builds an OTLP/gRPC span exporter, wires it
+//! into an [`SdkTracerProvider`] with a configurable sampler, installs the W3C
+//! `TraceContextPropagator` as the global propagator, and returns a
+//! `tracing_subscriber` layer that turns every `tracing` span into an
+//! OpenTelemetry span. The proxy handler opens one span per request (see
+//! `middleware::proxy`), so each proxied request becomes a trace that a
+//! collector (Jaeger, Tempo, Zipkin, …) can display.
+//!
+//! Spans are batch-exported on the Tokio runtime. [`TracingGuard`] holds the
+//! provider so the caller can flush on shutdown — dropping it without a flush
+//! would lose the last, unexported batch.
+
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig as _;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use tracing::error;
+
+use crate::config::TracingConfig;
+
+/// Adapts an `axum::http::HeaderMap` so the W3C propagator can read incoming
+/// `traceparent`/`tracestate` headers.
+pub struct HeaderExtractor<'a>(pub &'a axum::http::HeaderMap);
+
+impl Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+/// Adapts an `axum::http::HeaderMap` so the W3C propagator can write the outgoing
+/// `traceparent`/`tracestate` headers toward the backend.
+pub struct HeaderInjector<'a>(pub &'a mut axum::http::HeaderMap);
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(name), Ok(val)) = (
+            axum::http::header::HeaderName::from_bytes(key.as_bytes()),
+            axum::http::header::HeaderValue::from_str(&value),
+        ) {
+            self.0.insert(name, val);
+        }
+    }
+}
+
+/// Extract a remote span context from incoming request headers using the
+/// globally-installed W3C propagator. Returns the otel `Context` to attach as
+/// the parent of the request span.
+pub fn extract_parent(headers: &axum::http::HeaderMap) -> opentelemetry::Context {
+    opentelemetry::global::get_text_map_propagator(|prop| prop.extract(&HeaderExtractor(headers)))
+}
+
+/// Inject the given span context into outgoing headers as `traceparent`
+/// (W3C), so the backend continues the same trace.
+pub fn inject_context(cx: &opentelemetry::Context, headers: &mut axum::http::HeaderMap) {
+    opentelemetry::global::get_text_map_propagator(|prop| {
+        prop.inject_context(cx, &mut HeaderInjector(headers));
+    });
+}
+
+/// Keeps the tracer provider alive for the process lifetime and flushes
+/// pending spans on shutdown. Drop (or call [`TracingGuard::shutdown`]) to
+/// force-flush the last batch.
+pub struct TracingGuard {
+    provider: SdkTracerProvider,
+}
+
+impl TracingGuard {
+    /// Flush and stop the exporter. Safe to call once; idempotent enough for
+    /// a shutdown path.
+    pub fn shutdown(&self) {
+        if let Err(e) = self.provider.shutdown() {
+            error!("tracing: failed to flush spans on shutdown: {e}");
+        }
+    }
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Parse the `sampler` config string into an OpenTelemetry [`Sampler`].
+///
+/// - `parent_based_always_on` (default): follow the upstream decision, else
+///   sample. The right default for a proxy — if the caller is tracing, we are.
+/// - `always_on` / `always_off`: force the decision.
+/// - `ratio:<0..1>`: parent-based ratio sampler, e.g. `ratio:0.1` = 10%.
+///
+/// An unrecognised value falls back to parent-based-always-on and logs once.
+fn parse_sampler(spec: &str) -> Sampler {
+    match spec.trim().to_ascii_lowercase().as_str() {
+        "always_on" => Sampler::AlwaysOn,
+        "always_off" => Sampler::AlwaysOff,
+        "parent_based_always_on" => Sampler::ParentBased(Box::new(Sampler::AlwaysOn)),
+        "parent_based_always_off" => Sampler::ParentBased(Box::new(Sampler::AlwaysOff)),
+        other => {
+            if let Some(rest) = other.strip_prefix("ratio:")
+                && let Ok(r) = rest.parse::<f64>()
+            {
+                let r = r.clamp(0.0, 1.0);
+                return Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(r)));
+            }
+            error!("tracing: unknown sampler '{spec}', using parent_based_always_on");
+            Sampler::ParentBased(Box::new(Sampler::AlwaysOn))
+        }
+    }
+}
+
+/// Build the OTLP tracing pipeline and return `(layer, guard)`.
+///
+/// The layer must be added to the `tracing_subscriber` registry; the guard
+/// must be kept alive for the process and flushed on shutdown. Returns `Err`
+/// if the OTLP exporter can't be built (bad endpoint, etc.) so the caller can
+/// fall back to logs-only rather than crash.
+pub fn build_layer<S>(
+    cfg: &TracingConfig,
+) -> anyhow::Result<(
+    tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::SdkTracer>,
+    TracingGuard,
+)>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    // W3C Trace Context propagation, both directions (extract incoming
+    // `traceparent`, inject outgoing).
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(cfg.endpoint.clone())
+        .build()?;
+
+    let resource = Resource::builder()
+        .with_service_name(cfg.service_name.clone())
+        .build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_sampler(parse_sampler(&cfg.sampler))
+        .with_resource(resource)
+        .build();
+
+    let tracer = provider.tracer("sozune");
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    Ok((layer, TracingGuard { provider }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sampler_parsing() {
+        assert!(matches!(parse_sampler("always_on"), Sampler::AlwaysOn));
+        assert!(matches!(parse_sampler("always_off"), Sampler::AlwaysOff));
+        assert!(matches!(
+            parse_sampler("parent_based_always_on"),
+            Sampler::ParentBased(_)
+        ));
+        assert!(matches!(
+            parse_sampler("ratio:0.1"),
+            Sampler::ParentBased(_)
+        ));
+        // Unknown → parent-based fallback.
+        assert!(matches!(parse_sampler("nonsense"), Sampler::ParentBased(_)));
+    }
+
+    #[test]
+    fn ratio_out_of_range_is_clamped_not_panicking() {
+        // Just must not panic; clamping happens internally.
+        let _ = parse_sampler("ratio:5.0");
+        let _ = parse_sampler("ratio:-1");
+    }
+
+    #[test]
+    fn w3c_traceparent_round_trips_through_extract_and_inject() {
+        use opentelemetry::trace::TraceContextExt;
+
+        // Install the W3C propagator (idempotent across tests).
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+        // A valid, sampled W3C traceparent: version-traceid-spanid-flags.
+        let trace_id = "0af7651916cd43dd8448eb211c80319c";
+        let span_id = "b7ad6b7169203331";
+        let mut incoming = axum::http::HeaderMap::new();
+        incoming.insert(
+            "traceparent",
+            format!("00-{trace_id}-{span_id}-01").parse().unwrap(),
+        );
+
+        // Extract the remote context, then inject it into a fresh header map.
+        let cx = extract_parent(&incoming);
+        assert!(
+            cx.span().span_context().is_valid(),
+            "extracted context must be a valid span"
+        );
+        assert_eq!(cx.span().span_context().trace_id().to_string(), trace_id);
+
+        let mut outgoing = axum::http::HeaderMap::new();
+        inject_context(&cx, &mut outgoing);
+
+        // The propagated traceparent must carry the SAME trace id (the span id
+        // changes — the parent of the next hop — but the trace is continuous).
+        let tp = outgoing
+            .get("traceparent")
+            .and_then(|v| v.to_str().ok())
+            .expect("traceparent injected");
+        assert!(
+            tp.contains(trace_id),
+            "outgoing traceparent {tp} must keep trace id {trace_id}"
+        );
+    }
+}

--- a/tests/e2e/18-request-tracing.sh
+++ b/tests/e2e/18-request-tracing.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Distributed tracing boot (`tracing.enabled`).
+#
+# Autonomous test (own short-lived Sōzune on dedicated ports, no backend, no
+# collector). Verifies that enabling OTLP tracing wires up cleanly:
+#   - the process logs that tracing is enabled,
+#   - it keeps running even though the configured collector is unreachable
+#     (export errors must degrade gracefully, never crash the proxy).
+#
+# The W3C extract/inject round-trip is covered by unit tests in
+# `src/tracing_otel.rs`; real OTLP export is demonstrated via the Tempo demo
+# stack (compose.metrics.yaml), not here — the e2e suite ships no collector.
+#
+# Sourced by run-all.sh. Relies on $SOZUNE_BIN and helpers from lib.sh.
+
+log "[18] Tracing: process boots with tracing.enabled and stays up"
+
+TR_CFG=$(mktemp /tmp/sozune-trace-XXXXXX.yaml)
+TR_OUT=$(mktemp /tmp/sozune-trace-out-XXXXXX.log)
+
+# Dedicated ports (19xxx), clear of the main suite. The OTLP endpoint points at
+# a closed port on purpose: export must fail silently, not bring Sōzune down.
+cat >"$TR_CFG" <<'YAML'
+log:
+  format: json
+tracing:
+  enabled: true
+  endpoint: "http://127.0.0.1:14317"
+  service_name: "sozune-e2e"
+  sampler: "always_on"
+providers:
+  docker:
+    enabled: false
+api:
+  enabled: true
+  listen_address: "127.0.0.1:19888"
+  users:
+    - name: "admin"
+      hash: "0000000000000000000000000000000000000000000000000000000000000000"
+      role: admin
+proxy:
+  http:
+    listen_address: 19080
+  https:
+    listen_address: 19443
+middleware:
+  port: 19081
+dashboard:
+  enabled: false
+YAML
+
+CONFIG_PATH="$TR_CFG" "$SOZUNE_BIN" >"$TR_OUT" 2>&1 &
+TR_PID=$!
+sleep 2
+
+# Is it still alive after trying to reach an unreachable collector?
+still_up=0
+if kill -0 "$TR_PID" 2>/dev/null; then
+    still_up=1
+fi
+
+# Kill the process and its worker children (no blocking wait — orphan trap).
+pkill -9 -P "$TR_PID" 2>/dev/null || true
+kill -9 "$TR_PID" 2>/dev/null || true
+sleep 0.3
+
+if [[ "$still_up" == "1" ]]; then
+    pass "Sōzune stays up with tracing enabled and an unreachable collector"
+else
+    fail "Sōzune died on startup with tracing enabled; see $TR_OUT"
+fi
+
+log "[18] Tracing: startup log confirms tracing is enabled"
+
+# init_tracing logs "Distributed tracing enabled, exporting OTLP to <endpoint>".
+if grep -qi "tracing enabled" "$TR_OUT" 2>/dev/null; then
+    pass "startup log reports tracing enabled"
+else
+    fail "did not find the 'tracing enabled' startup log; see $TR_OUT"
+fi
+
+rm -f "$TR_CFG" "$TR_OUT"

--- a/tests/observability/grafana-datasource.yml
+++ b/tests/observability/grafana-datasource.yml
@@ -8,3 +8,10 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: true
+
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: true

--- a/tests/observability/tempo.yaml
+++ b/tests/observability/tempo.yaml
@@ -1,0 +1,20 @@
+# Minimal single-binary Tempo for the demo stack: accept OTLP/gRPC on :4317,
+# store traces locally. Not production-tuned — just enough to view Sōzune
+# traces in Grafana.
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal


### PR DESCRIPTION
## Summary

Adds OpenTelemetry distributed tracing: every proxied request opens a span, exported over **OTLP/gRPC** to a collector (Jaeger, Grafana Tempo, Zipkin via OTel). Off by default — no spans, no exporter, zero overhead until `tracing.enabled`.

## What you get

- **One span per request** (`proxy.request`) with `http.request.method`, `server.address`, `url.path`, `http.response.status_code`.
- **W3C context propagation both ways**: an incoming `traceparent` becomes the span's parent (continue an upstream trace); an outgoing `traceparent` is injected toward the backend (backend joins the same trace).
- **Trace ↔ log correlation**: each access-log line carries the `trace_id` (`trace=` in text, `"trace_id"` key in JSON), or `-` when tracing is off.

## Configuration

```yaml
tracing:
  enabled: true
  endpoint: "http://127.0.0.1:4317"   # OTLP/gRPC
  service_name: "sozune"
  sampler: "parent_based_always_on"    # or always_on/always_off, parent_based_always_off, ratio:0.1
```

All four fields have env overrides (`SOZUNE_TRACING_*`, env wins over YAML).

## Implementation

- New `src/tracing_otel.rs`: OTLP pipeline (exporter + `SdkTracerProvider` + configurable sampler), the global W3C `TraceContextPropagator`, header extractor/injector, and a `TracingGuard` that flushes the batch on shutdown.
- `init_tracing` composes the fmt layer (text/JSON) with the OTLP layer when enabled, and **degrades to logs-only** (never crashes) if the exporter can't be built. The guard is held for the process lifetime in `main`.
- `handle_proxy` opens the request span, attaches the extracted parent, injects the outgoing `traceparent` before forwarding, records the status, and logs the trace id.
- Sampler default `parent_based_always_on`: if the caller is tracing, so are we — the right default for a proxy.

## Scope

Like the latency histogram and access log, only requests through the Sōzune middleware layer are traced — middleware-less routes are served directly by Sōzu (documented).

## Tests & docs

- Unit: sampler parsing (all modes + ratio clamp) and a **W3C extract→inject round-trip** proving propagation keeps the trace id.
- e2e: `tests/e2e/18-request-tracing.sh` — boots with `tracing.enabled`, stays up against an unreachable collector, logs that tracing is enabled.
- Demo stack: `compose.metrics.yaml` now ships **Grafana Tempo** (OTLP `:4317`) + a provisioned datasource, turnkey alongside the existing Prometheus/Grafana.
- Docs: new "Distributed tracing" section in `observability.md` + `tracing` rows in `configuration/overview.md`.

Full e2e suite: 97 passed, 0 failed.
