### PR TITLE
Make CI linting strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
 
+      - name: Type-check dashboard
+        run: cd dashboard && bun run check
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -36,7 +39,7 @@ jobs:
         run: cargo test --bin sozune
 
       - name: Clippy
-        run: cargo clippy -- -W warnings
+        run: cargo clippy --bin sozune --all-targets -- -D warnings
 
       - name: Format
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,42 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Static checks only — formatting and linters, Rust and dashboard. No tests,
+  # no release build. This is the "is it clean?" gate.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - uses: oven-sh/setup-bun@v2
+
+      # The binary embeds the dashboard build (rust-embed), so clippy needs the
+      # dashboard assets present to compile.
+      - name: Build dashboard
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
+
+      - name: Dashboard type-check
+        run: cd dashboard && bun run check
+
+      - name: Dashboard lint (biome)
+        run: cd dashboard && bun run lint
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Rust format
+        run: cargo fmt -- --check
+
+      - name: Rust clippy
+        run: cargo clippy --bin sozune --all-targets -- -D warnings
+
+  # The actual test suite.
   test:
     runs-on: ubuntu-latest
     steps:
@@ -23,23 +59,30 @@ jobs:
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
 
-      - name: Type-check dashboard
-        run: cd dashboard && bun run check
-
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Check
-        run: cargo check
-
-      - name: Test
+      - name: Cargo test
         run: cargo test --bin sozune
 
-      - name: Clippy
-        run: cargo clippy --bin sozune --all-targets -- -D warnings
+  # Verify a clean release build (also catches embed/asset issues).
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-      - name: Format
-        run: cargo fmt -- --check
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build dashboard
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cargo build (release)
+        run: cargo build --release --locked

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -198,15 +198,13 @@ export function health(): Promise<unknown> {
 export interface ConfigView {
   version: string;
   listeners: { http: { port: number }; https: { port: number } };
-  acme:
-    | {
-        enabled: boolean;
-        email: string;
-        staging: boolean;
-        challenge_port: number;
-        resolvers: Record<string, unknown>;
-      }
-    | null;
+  acme: {
+    enabled: boolean;
+    email: string;
+    staging: boolean;
+    challenge_port: number;
+    resolvers: Record<string, unknown>;
+  } | null;
   providers: {
     docker?: { enabled: boolean; endpoint: string; expose_by_default: boolean } | null;
     podman?: { enabled: boolean; endpoint: string; expose_by_default: boolean } | null;

--- a/dashboard/src/lib/theme.ts
+++ b/dashboard/src/lib/theme.ts
@@ -14,19 +14,27 @@ export type Theme = 'dark' | 'light';
 const STORAGE_KEY = 'sozune.theme';
 
 function systemPreference(): Theme {
-  if (typeof window === 'undefined' || !window.matchMedia) return 'dark';
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return 'dark';
+  }
   return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
 }
 
 export function loadTheme(): Theme {
-  if (typeof localStorage === 'undefined') return 'dark';
+  if (typeof localStorage === 'undefined') {
+    return 'dark';
+  }
   const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored === 'dark' || stored === 'light') return stored;
+  if (stored === 'dark' || stored === 'light') {
+    return stored;
+  }
   return systemPreference();
 }
 
 export function applyTheme(theme: Theme): void {
-  if (typeof document === 'undefined') return;
+  if (typeof document === 'undefined') {
+    return;
+  }
   if (theme === 'light') {
     document.documentElement.setAttribute('data-theme', 'light');
   } else {
@@ -35,6 +43,8 @@ export function applyTheme(theme: Theme): void {
 }
 
 export function saveTheme(theme: Theme): void {
-  if (typeof localStorage === 'undefined') return;
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
   localStorage.setItem(STORAGE_KEY, theme);
 }

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -401,7 +401,7 @@ fn write_gauge(out: &mut String, name: &str, help: &str, value: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ApiUser, Role};
+    use crate::config::ApiUser;
     use crate::model::{Backend, Entrypoint, EntrypointConfig, Protocol};
     use crate::proxy::health::{UnhealthyKind, UnhealthyReason};
     use std::collections::{BTreeMap, HashMap};

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -183,36 +183,14 @@ fn forbidden(message: &str) -> Response {
         .into_response()
 }
 
-pub async fn serve(
-    config: ApiConfig,
-    app_config: Arc<crate::config::AppConfig>,
-    storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
-    reload_tx: mpsc::Sender<()>,
-    unhealthy_backends: Arc<RwLock<UnhealthyMap>>,
-    diagnostics: crate::diagnostics::DiagnosticsStore,
-    acme_enabled: bool,
-    providers: crate::config::ProvidersConfig,
-    metrics: crate::proxy::metrics_snapshot::MetricsSnapshotStore,
-    request_metrics: crate::proxy::request_metrics::RequestMetricsStore,
-) -> anyhow::Result<()> {
-    if config.users.is_empty() {
+/// Run the API server. The caller assembles the [`AppState`] (it owns all the
+/// shared stores); `config` carries the listener address and CORS origins.
+pub async fn serve(config: ApiConfig, state: AppState) -> anyhow::Result<()> {
+    if state.users.is_empty() {
         anyhow::bail!(
             "API enabled but no users configured. Add at least one entry under `api.users`."
         );
     }
-
-    let state = AppState {
-        storage,
-        reload_tx,
-        users: config.users.clone(),
-        unhealthy_backends,
-        diagnostics,
-        acme_enabled,
-        providers,
-        metrics,
-        request_metrics,
-        config: app_config,
-    };
 
     let protected = Router::new()
         .route(

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,15 +27,6 @@ mod proxy;
 mod tracing_otel;
 mod util;
 
-/// Shared lock serialising every test that mutates `std::env`. Tests across
-/// modules race on the global environment otherwise (and edition 2024 marks
-/// `set_var`/`remove_var` `unsafe` for exactly this reason).
-#[cfg(test)]
-pub(crate) mod test_env {
-    use std::sync::Mutex;
-    pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
-}
-
 pub use model::*;
 
 #[tokio::main]
@@ -271,31 +262,23 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let unhealthy_backends = health_checker.unhealthy_backends();
 
     let storage_server = storage.clone();
-    let reload_tx_api = reload_tx.clone();
     let api_config = config.api.clone();
-    let app_config_api = Arc::new(config.clone());
-    let unhealthy_api = Arc::clone(&unhealthy_backends);
-    let diagnostics_api = Arc::clone(&diagnostics_store);
-    let acme_enabled_api = acme_enabled;
-    let providers_api = config.providers.clone();
-    let metrics_store_api = Arc::clone(&metrics_store);
-    let request_metrics_api = Arc::clone(&request_metrics_store);
+    let api_state = api::server::AppState {
+        storage: storage_server,
+        reload_tx: reload_tx.clone(),
+        users: config.api.users.clone(),
+        unhealthy_backends: Arc::clone(&unhealthy_backends),
+        diagnostics: Arc::clone(&diagnostics_store),
+        acme_enabled,
+        providers: config.providers.clone(),
+        metrics: Arc::clone(&metrics_store),
+        request_metrics: Arc::clone(&request_metrics_store),
+        config: Arc::new(config.clone()),
+    };
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
-            api::server::serve(
-                api_config,
-                app_config_api,
-                storage_server,
-                reload_tx_api,
-                unhealthy_api,
-                diagnostics_api,
-                acme_enabled_api,
-                providers_api,
-                metrics_store_api,
-                request_metrics_api,
-            )
-            .await?;
+            api::server::serve(api_config, api_state).await?;
         }
 
         Ok::<(), anyhow::Error>(())
@@ -478,4 +461,14 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
 
     debug!("All tasks completed");
     Ok(())
+}
+
+/// Shared lock serialising every test that mutates `std::env`. Tests across
+/// modules race on the global environment otherwise (and edition 2024 marks
+/// `set_var`/`remove_var` `unsafe` for exactly this reason). Kept at the end of
+/// the file so no non-test item follows a `#[cfg(test)]` module.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::Mutex;
+    pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
 }

--- a/src/middleware/ip_allow_list.rs
+++ b/src/middleware/ip_allow_list.rs
@@ -118,9 +118,7 @@ pub fn resolve_client_ip(
     if trusted.is_empty() {
         return peer;
     }
-    let Some(peer_ip) = peer else {
-        return None;
-    };
+    let peer_ip = peer?;
     if !trusted.contains(peer_ip) {
         return Some(peer_ip);
     }
@@ -134,10 +132,10 @@ pub fn resolve_client_ip(
     {
         for token in value.split(',').rev() {
             let token = token.trim();
-            if let Ok(ip) = IpAddr::from_str(token) {
-                if !trusted.contains(ip) {
-                    return Some(ip);
-                }
+            if let Ok(ip) = IpAddr::from_str(token)
+                && !trusted.contains(ip)
+            {
+                return Some(ip);
             }
         }
     }

--- a/src/provider/kubernetes/gateway.rs
+++ b/src/provider/kubernetes/gateway.rs
@@ -1260,7 +1260,6 @@ mod tests {
                 } else {
                     Some(parent_refs)
                 },
-                ..Default::default()
             },
             status: Default::default(),
         }

--- a/src/provider/kubernetes/mod.rs
+++ b/src/provider/kubernetes/mod.rs
@@ -1079,6 +1079,12 @@ mod tests {
     use k8s_openapi::api::core::v1::ServiceSpec;
     use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
     use kube::api::ObjectMeta;
+
+    /// One HTTP path under a host in a test Ingress: `(path, path_type,
+    /// service_name, service_port)`.
+    type TestIngressPath<'a> = (&'a str, &'a str, &'a str, i32);
+    /// One host rule: `(Some(host) | None, [paths])`.
+    type TestIngressRule<'a> = (Option<&'a str>, Vec<TestIngressPath<'a>>);
     use std::collections::BTreeMap;
 
     fn make_provider(expose_by_default: bool) -> KubernetesProvider {
@@ -1358,7 +1364,7 @@ mod tests {
         name: &str,
         namespace: &str,
         class: Option<&str>,
-        rules: Vec<(Option<&str>, Vec<(&str, &str, &str, i32)>)>,
+        rules: Vec<TestIngressRule>,
         tls_hosts: Vec<&str>,
     ) -> Ingress {
         use k8s_openapi::api::networking::v1::{


### PR DESCRIPTION
## Summary

Makes CI linting actually enforce, and restructures the single catch-all job into three clearly-named jobs. Previously one job named `test` did everything (build + lint + test), clippy ran non-blocking (`-W warnings`), and the dashboard had no lint or type-check in CI.

## CI structure — three jobs

- **`lint`** — static checks only: `cargo fmt --check`, `cargo clippy --bin sozune --all-targets -- -D warnings` (blocking), dashboard `bun run check` (svelte-check), and dashboard `bun run lint` (**biome**).
- **`test`** — `cargo test --bin sozune`.
- **`build`** — `cargo build --release --locked` (also catches embed/asset issues).

Each job builds the dashboard first because the binary embeds it (rust-embed). The old job name `test` was misleading — it gated on far more than tests.

## Pre-existing lint errors fixed (so the gates are green from the first run)

- Rust clippy (`-D warnings`, incl. `--all-targets`): `let-else`→`?` and collapsed `if` in `ip_allow_list.rs`; `serve` had 10 args → refactored to `serve(config, AppState)` with `main` assembling the state; plus test-only fixes (unused import, items-after-test-module in `main.rs`, no-op struct-update, complex tuple type aliased).
- Biome (dashboard): 6 `useBlockStatements` / formatting issues in `theme.ts` and `api.ts`.

## Verification (all green locally)

- `cargo fmt --check`, `cargo clippy --bin sozune --all-targets -- -D warnings`, `cargo test --bin sozune` (493 passed), `cargo build --release --locked`.
- `cd dashboard && bun run check` and `bun run lint` (biome) both exit 0.
- Full e2e suite: 97 passed, 0 failed (confirms the `serve` refactor didn't break API startup).
