### PR TITLE
Add error rate tracking by status class

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -256,6 +256,10 @@ export interface MetricsView {
       /** Total number of observed requests. */
       count: number;
     };
+    /** Middleware-layer response counts by HTTP status class
+     *  (`1xx`/`2xx`/`3xx`/`4xx`/`5xx`/`other`). Optional so older servers
+     *  don't break the dashboard. */
+    middleware_requests_by_status?: Record<string, number>;
   };
 }
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -74,7 +74,12 @@
   const liveRequests = $derived(
     metric('http_requests', 'http_requests_total', 'requests')
   );
-  const liveErrors5xx = $derived(metric('http_errors_5xx', 'http_5xx', 'errors_5xx'));
+  // Prefer Sōzune's own middleware status-class counter (always present,
+  // reliable); fall back to the Sōzu worker metrics for older servers.
+  const liveErrors5xx = $derived(
+    metrics?.proxy.middleware_requests_by_status?.['5xx'] ??
+      metric('http_errors_5xx', 'http_5xx', 'errors_5xx')
+  );
   const workerPollFresh = $derived(
     !!metrics && metrics.proxy.last_poll_seconds > 0
   );

--- a/documentation/advanced/observability.md
+++ b/documentation/advanced/observability.md
@@ -41,6 +41,9 @@ JSON example:
       "buckets": [["0.005", 812], ["0.01", 970], ["0.025", 1020]],
       "sum": 7.42,
       "count": 1042
+    },
+    "middleware_requests_by_status": {
+      "1xx": 0, "2xx": 1001, "3xx": 12, "4xx": 25, "5xx": 4, "other": 0
     }
   }
 }
@@ -91,6 +94,27 @@ So: think of this as *"how slow is my middleware path"*, not *"how slow is every
 **What is counted** (among middleware routes): every request, including those that end in a proxy-level error (no healthy backend, backend timeout, backend unreachable) — their latency is real and worth watching. **Not counted:** WebSocket upgrades (the tunnel lives for the whole connection, so its duration is not a request latency and would skew the distribution) and requests rejected before routing (missing/unknown Host).
 
 The histogram is global — there are no `method`, `status`, or `host` labels, keeping cardinality flat regardless of traffic shape.
+
+## Error rate
+
+Alongside the latency histogram, Sōzune counts middleware-layer responses by **HTTP status class**, so you can track error rates without parsing logs.
+
+| Metric | Type | Description |
+|---|---|---|
+| `sozune_middleware_requests_total{class="…"}` | counter | Responses served through the middleware layer, one series per class: `1xx`, `2xx`, `3xx`, `4xx`, `5xx`, `other` |
+
+Proxy-level failures (no healthy backend, backend timeout, backend unreachable) count under their real status — typically `5xx` — so they show up in the error rate.
+
+```promql
+# 5xx error ratio over the last 5 minutes
+sum(rate(sozune_middleware_requests_total{class="5xx"}[5m]))
+  / sum(rate(sozune_middleware_requests_total[5m]))
+
+# 4xx + 5xx request rate
+sum(rate(sozune_middleware_requests_total{class=~"4xx|5xx"}[5m]))
+```
+
+Same scope as the histogram above: only requests through the middleware layer are counted.
 
 ## Sōzu worker bridge
 

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -103,6 +103,10 @@ struct ProxyMetrics {
     /// routes are served directly by Sōzu and not counted here. Additive
     /// field — clients that don't know it simply ignore it.
     middleware_request_duration_seconds: RequestDurationMetrics,
+    /// Per-status-class response counts for the middleware layer, keyed by
+    /// class (`1xx`/`2xx`/`3xx`/`4xx`/`5xx`/`other`). Same scope caveat as the
+    /// latency histogram.
+    middleware_requests_by_status: HashMap<&'static str, u64>,
 }
 
 /// JSON shape of the request-latency histogram. The Prometheus renderer emits
@@ -231,10 +235,17 @@ impl ProxyMetrics {
             count: rd.count,
         };
 
+        let middleware_requests_by_status = crate::proxy::request_metrics::STATUS_CLASS_LABELS
+            .iter()
+            .zip(rd.status_classes)
+            .map(|(label, count)| (*label, count))
+            .collect();
+
         ProxyMetrics {
             last_poll_seconds: snap.last_poll_unix,
             metrics,
             middleware_request_duration_seconds,
+            middleware_requests_by_status,
         }
     }
 }
@@ -335,8 +346,29 @@ fn render_prom(snap: &Snapshot) -> String {
     }
 
     render_request_duration(&mut out, &snap.proxy.middleware_request_duration_seconds);
+    render_requests_by_status(&mut out, &snap.proxy.middleware_requests_by_status);
 
     out
+}
+
+/// Render the per-status-class request counter as a labelled Prometheus
+/// counter. One series per class (`1xx`…`5xx`, `other`); divide a class by the
+/// total for an error rate, e.g.
+/// `rate(sozune_middleware_requests_total{class="5xx"}[5m])`.
+fn render_requests_by_status(out: &mut String, by_status: &HashMap<&'static str, u64>) {
+    let _ = writeln!(
+        out,
+        "# HELP sozune_middleware_requests_total Requests served through the Sōzune middleware layer, by HTTP status class."
+    );
+    let _ = writeln!(out, "# TYPE sozune_middleware_requests_total counter");
+    // Stable label order so scrapes are deterministic.
+    for class in crate::proxy::request_metrics::STATUS_CLASS_LABELS {
+        let count = by_status.get(class).copied().unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "sozune_middleware_requests_total{{class=\"{class}\"}} {count}"
+        );
+    }
 }
 
 /// Render the middleware request-latency histogram in Prometheus exposition
@@ -580,8 +612,10 @@ mod tests {
         use std::time::Duration;
         let state = empty_state();
         // 20ms and 200ms: 20ms lands in le>=0.025, 200ms in le>=0.25.
-        state.request_metrics.record(Duration::from_millis(20));
-        state.request_metrics.record(Duration::from_millis(200));
+        state.request_metrics.record(Duration::from_millis(20), 200);
+        state
+            .request_metrics
+            .record(Duration::from_millis(200), 200);
         let body = render_prom(&Snapshot::collect(&state));
 
         assert!(body.contains("sozune_middleware_request_duration_seconds_count 2"));
@@ -600,12 +634,38 @@ mod tests {
     fn request_duration_present_in_json() {
         use std::time::Duration;
         let state = empty_state();
-        state.request_metrics.record(Duration::from_millis(50));
+        state.request_metrics.record(Duration::from_millis(50), 200);
         let snap = Snapshot::collect(&state);
         let json = serde_json::to_value(&snap).unwrap();
         let rd = &json["proxy"]["middleware_request_duration_seconds"];
         assert_eq!(rd["count"], 1);
         assert!(rd["buckets"].is_array());
+    }
+
+    #[test]
+    fn requests_by_status_counters_rendered() {
+        use std::time::Duration;
+        let state = empty_state();
+        state.request_metrics.record(Duration::from_millis(5), 200);
+        state.request_metrics.record(Duration::from_millis(5), 200);
+        state.request_metrics.record(Duration::from_millis(5), 404);
+        state.request_metrics.record(Duration::from_millis(5), 503);
+        let body = render_prom(&Snapshot::collect(&state));
+        assert!(body.contains("# TYPE sozune_middleware_requests_total counter"));
+        assert!(body.contains("sozune_middleware_requests_total{class=\"2xx\"} 2"));
+        assert!(body.contains("sozune_middleware_requests_total{class=\"4xx\"} 1"));
+        assert!(body.contains("sozune_middleware_requests_total{class=\"5xx\"} 1"));
+        assert!(body.contains("sozune_middleware_requests_total{class=\"1xx\"} 0"));
+    }
+
+    #[test]
+    fn requests_by_status_present_in_json() {
+        use std::time::Duration;
+        let state = empty_state();
+        state.request_metrics.record(Duration::from_millis(5), 500);
+        let snap = Snapshot::collect(&state);
+        let json = serde_json::to_value(&snap).unwrap();
+        assert_eq!(json["proxy"]["middleware_requests_by_status"]["5xx"], 1);
     }
 
     #[test]

--- a/src/middleware/proxy.rs
+++ b/src/middleware/proxy.rs
@@ -117,13 +117,14 @@ pub async fn handle_proxy(
             chain::run_request_phase(&route.middlewares, &mut ctx, &mut req).await
         {
             let duration = start.elapsed();
-            state.request_metrics.record(duration);
+            let status = response.status().as_u16();
+            state.request_metrics.record(duration, status);
             access_log(
                 &source_ip,
                 &method,
                 &host,
                 &path,
-                response.status().as_u16(),
+                status,
                 duration,
                 "middleware",
             );
@@ -135,8 +136,11 @@ pub async fn handle_proxy(
             Some(b) => b.clone(),
             None => {
                 error!("No backends configured for host '{}'", host);
-                state.request_metrics.record(start.elapsed());
-                return diag::no_healthy_backend(&host, &route.backends).into_response();
+                let resp = diag::no_healthy_backend(&host, &route.backends).into_response();
+                state
+                    .request_metrics
+                    .record(start.elapsed(), resp.status().as_u16());
+                return resp;
             }
         };
 
@@ -192,9 +196,12 @@ pub async fn handle_proxy(
             Ok(uri) => uri,
             Err(e) => {
                 error!("Failed to parse target URI '{}': {}", target_uri, e);
-                state.request_metrics.record(start.elapsed());
-                return diag::forwarding_failed("invalid-target-uri", &e.to_string())
-                    .into_response();
+                let resp =
+                    diag::forwarding_failed("invalid-target-uri", &e.to_string()).into_response();
+                state
+                    .request_metrics
+                    .record(start.elapsed(), resp.status().as_u16());
+                return resp;
             }
         };
 
@@ -217,8 +224,11 @@ pub async fn handle_proxy(
                 Ok(result) => result.map_err(|e| e.to_string()),
                 Err(_) => {
                     error!("Backend request to {} timed out", target_uri);
-                    state.request_metrics.record(start.elapsed());
-                    return diag::backend_timeout(&target_uri, timeout_secs).into_response();
+                    let resp = diag::backend_timeout(&target_uri, timeout_secs).into_response();
+                    state
+                        .request_metrics
+                        .record(start.elapsed(), resp.status().as_u16());
+                    return resp;
                 }
             }
         };
@@ -231,9 +241,12 @@ pub async fn handle_proxy(
             }
             Err(e) => {
                 error!("Failed to forward request to {}: {}", target_uri, e);
-                state.request_metrics.record(start.elapsed());
-                return diag::backend_unreachable(&format!("backend at {target_uri}: {e}"))
+                let resp = diag::backend_unreachable(&format!("backend at {target_uri}: {e}"))
                     .into_response();
+                state
+                    .request_metrics
+                    .record(start.elapsed(), resp.status().as_u16());
+                return resp;
             }
         };
 
@@ -242,8 +255,8 @@ pub async fn handle_proxy(
         let response = chain::run_response_phase(&route.middlewares, &ctx, backend_response).await;
 
         let duration = start.elapsed();
-        state.request_metrics.record(duration);
         let status = response.status().as_u16();
+        state.request_metrics.record(duration, status);
         tracing::Span::current().record("http.response.status_code", status);
         access_log(
             &source_ip, &method, &host, &path, status, duration, "backend",

--- a/src/proxy/request_metrics.rs
+++ b/src/proxy/request_metrics.rs
@@ -41,6 +41,25 @@ pub struct RequestMetrics {
     /// Sum of all observed durations, in milliseconds, to avoid float atomics.
     /// Rendered as seconds (`/ 1000`) in the `_sum` series.
     sum_millis: AtomicU64,
+    /// Per-status-class response counters: index 0 = 1xx, 1 = 2xx, 2 = 3xx,
+    /// 3 = 4xx, 4 = 5xx, 5 = other (status < 100 or > 599, shouldn't happen).
+    status_classes: [AtomicU64; 6],
+}
+
+/// Labels for the six status-class counters, aligned with
+/// `RequestMetrics::status_classes` / `RequestMetricsSnapshot::status_classes`.
+pub const STATUS_CLASS_LABELS: [&str; 6] = ["1xx", "2xx", "3xx", "4xx", "5xx", "other"];
+
+/// Map an HTTP status code to its `status_classes` index.
+fn status_class_index(status: u16) -> usize {
+    match status {
+        100..=199 => 0,
+        200..=299 => 1,
+        300..=399 => 2,
+        400..=499 => 3,
+        500..=599 => 4,
+        _ => 5,
+    }
 }
 
 impl Default for RequestMetrics {
@@ -52,15 +71,17 @@ impl Default for RequestMetrics {
                 .collect(),
             count: AtomicU64::new(0),
             sum_millis: AtomicU64::new(0),
+            status_classes: Default::default(),
         }
     }
 }
 
 impl RequestMetrics {
-    /// Record one completed request. Increments every bucket whose bound is
-    /// `>= duration` (so buckets are cumulative on read), the total count, and
-    /// the running sum.
-    pub fn record(&self, duration: Duration) {
+    /// Record one completed request: its latency (into the histogram) and its
+    /// response status class (into the per-class counters). Increments every
+    /// bucket whose bound is `>= duration`, the total count, the running sum,
+    /// and the matching status-class counter.
+    pub fn record(&self, duration: Duration, status: u16) {
         let secs = duration.as_secs_f64();
         for (i, bound) in BUCKET_BOUNDS_SECONDS.iter().enumerate() {
             if secs <= *bound {
@@ -71,6 +92,7 @@ impl RequestMetrics {
         // Saturating millis: a single request over ~584M years would overflow.
         self.sum_millis
             .fetch_add(duration.as_millis() as u64, Ordering::Relaxed);
+        self.status_classes[status_class_index(status)].fetch_add(1, Ordering::Relaxed);
     }
 
     /// Read a consistent-enough snapshot for rendering. Values are read with
@@ -85,6 +107,7 @@ impl RequestMetrics {
                 .collect(),
             count: self.count.load(Ordering::Relaxed),
             sum_seconds: self.sum_millis.load(Ordering::Relaxed) as f64 / 1000.0,
+            status_classes: std::array::from_fn(|i| self.status_classes[i].load(Ordering::Relaxed)),
         }
     }
 }
@@ -99,6 +122,9 @@ pub struct RequestMetricsSnapshot {
     pub count: u64,
     /// Sum of all observed durations, in seconds (`_sum`).
     pub sum_seconds: f64,
+    /// Response counts per status class, aligned with [`STATUS_CLASS_LABELS`]
+    /// (`1xx, 2xx, 3xx, 4xx, 5xx, other`).
+    pub status_classes: [u64; 6],
 }
 
 pub fn new_store() -> RequestMetricsStore {
@@ -120,13 +146,14 @@ mod tests {
         assert_eq!(s.count, 0);
         assert_eq!(s.sum_seconds, 0.0);
         assert!(s.buckets.iter().all(|(_, c)| *c == 0));
+        assert_eq!(s.status_classes, [0; 6]);
     }
 
     #[test]
     fn record_increments_count_and_sum() {
         let m = RequestMetrics::default();
-        m.record(ms(20));
-        m.record(ms(30));
+        m.record(ms(20), 200);
+        m.record(ms(30), 200);
         let s = m.snapshot();
         assert_eq!(s.count, 2);
         // 50ms total = 0.05s.
@@ -137,7 +164,7 @@ mod tests {
     fn buckets_are_cumulative() {
         let m = RequestMetrics::default();
         // 20ms = 0.02s: falls in every bucket with bound >= 0.025.
-        m.record(ms(20));
+        m.record(ms(20), 200);
         let s = m.snapshot();
         // bound 0.005 and 0.01 must NOT count it; 0.025 and up must.
         for (bound, c) in &s.buckets {
@@ -152,7 +179,7 @@ mod tests {
     #[test]
     fn fast_request_lands_in_first_bucket() {
         let m = RequestMetrics::default();
-        m.record(Duration::from_micros(100)); // 0.0001s <= 0.005
+        m.record(Duration::from_micros(100), 200); // 0.0001s <= 0.005
         let s = m.snapshot();
         assert_eq!(s.buckets[0].1, 1);
         assert_eq!(s.count, 1);
@@ -161,10 +188,34 @@ mod tests {
     #[test]
     fn slow_request_only_in_count_not_top_bucket() {
         let m = RequestMetrics::default();
-        m.record(Duration::from_secs(30)); // beyond the 10s top bound
+        m.record(Duration::from_secs(30), 200); // beyond the 10s top bound
         let s = m.snapshot();
         // No finite bucket counts it; only the total count (the +Inf bucket).
         assert!(s.buckets.iter().all(|(_, c)| *c == 0));
         assert_eq!(s.count, 1);
+    }
+
+    #[test]
+    fn status_classes_are_bucketed_by_first_digit() {
+        let m = RequestMetrics::default();
+        m.record(ms(1), 200);
+        m.record(ms(1), 204);
+        m.record(ms(1), 301);
+        m.record(ms(1), 404);
+        m.record(ms(1), 500);
+        m.record(ms(1), 503);
+        let s = m.snapshot();
+        // [1xx, 2xx, 3xx, 4xx, 5xx, other]
+        assert_eq!(s.status_classes, [0, 2, 1, 1, 2, 0]);
+        assert_eq!(s.count, 6);
+    }
+
+    #[test]
+    fn out_of_range_status_goes_to_other() {
+        let m = RequestMetrics::default();
+        m.record(ms(1), 99);
+        m.record(ms(1), 700);
+        let s = m.snapshot();
+        assert_eq!(s.status_classes[5], 2); // "other"
     }
 }

--- a/tests/e2e/20-error-rate.sh
+++ b/tests/e2e/20-error-rate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Error-rate tracking: per-status-class counters on /metrics.
+#
+# Sōzune counts middleware-layer responses by HTTP status class and exposes
+# `sozune_middleware_requests_total{class="…"}`. A request that a middleware
+# short-circuits with 404 (here: the client-IP matcher denying loopback on
+# `svc-clientip-deny`) is counted under the `4xx` class. We drive a few of
+# those and assert the counter grows.
+#
+# Sourced by run-all.sh.
+
+METRICS_URL="http://127.0.0.1:$API_PORT/metrics"
+SERIES='sozune_middleware_requests_total{class="4xx"}'
+
+# Value of the 4xx counter (0 if the line is absent).
+count_4xx() {
+    curl -s --max-time 2 "$METRICS_URL" 2>/dev/null \
+        | grep -F "$SERIES" | awk '{print $2}' | head -1
+}
+
+log "[20] Error rate: status-class counters are exposed"
+
+body=$(curl -s --max-time 2 "$METRICS_URL" 2>/dev/null || echo "")
+if grep -q "# TYPE sozune_middleware_requests_total counter" <<<"$body" \
+    && grep -qF 'sozune_middleware_requests_total{class="5xx"}' <<<"$body" \
+    && grep -qF 'sozune_middleware_requests_total{class="2xx"}' <<<"$body"; then
+    pass "per-status-class counters are present"
+else
+    fail "sozune_middleware_requests_total series missing from /metrics"
+fi
+
+log "[20] Error rate: a middleware 4xx increments the 4xx class"
+
+before=$(count_4xx); before=${before:-0}
+
+# `svc-clientip-deny` 404s loopback via the client-IP matcher (a middleware
+# short-circuit), so each request bumps the 4xx class.
+for _ in 1 2 3; do
+    curl -s -o /dev/null --max-time 2 -H "Host: $HOST_CLIENTIP_DENY" \
+        "http://127.0.0.1:$HTTP_PORT/" 2>/dev/null || true
+done
+
+after=""
+for _ in $(seq 1 10); do
+    after=$(count_4xx); after=${after:-0}
+    if (( after > before )); then
+        break
+    fi
+    sleep 0.2
+done
+
+if (( after > before )); then
+    pass "4xx counter grew from $before to $after after middleware 404s"
+else
+    fail "4xx counter did not grow (before=$before after=$after)"
+fi
+
+log "[20] Error rate: JSON view carries the per-status map"
+
+json=$(curl -s --max-time 2 -H "Accept: application/json" "$METRICS_URL" 2>/dev/null \
+    | grep -oE '"middleware_requests_by_status":\{[^}]*\}' | head -1 || true)
+if [[ "$json" == *'"4xx"'* ]]; then
+    pass "JSON /metrics exposes proxy.middleware_requests_by_status"
+else
+    fail "JSON /metrics did not expose middleware_requests_by_status"
+fi


### PR DESCRIPTION
## Summary

Counts middleware-layer responses by HTTP status class and exposes them on `/metrics`, so error rates are trackable without parsing logs.

## What you get

A new Prometheus counter, one series per class:

```
sozune_middleware_requests_total{class="1xx|2xx|3xx|4xx|5xx|other"}
```

Proxy-level failures (no healthy backend, backend timeout, backend unreachable) are counted under their real status (typically `5xx`), so they appear in the error rate.

```promql
# 5xx error ratio over 5 minutes
sum(rate(sozune_middleware_requests_total{class="5xx"}[5m]))
  / sum(rate(sozune_middleware_requests_total[5m]))
```

Also available in the JSON view as `proxy.middleware_requests_by_status`.

## Implementation

- Extended `RequestMetrics::record(duration, status)` with a lock-free per-class atomic counter, alongside the existing latency histogram.
- The proxy handler passes the final status at every exit; error exits capture the status from the diagnostic response so the metric never drifts from what the client received.
- Same scope as the latency histogram: only requests through the middleware layer are counted (documented).

## Tests & docs

- Unit: status-class bucketing (1xx–5xx + out-of-range → `other`), Prometheus + JSON rendering.
- e2e: `tests/e2e/20-error-rate.sh` — series present, the `4xx` class grows after middleware 404s, JSON map present.
- Dashboard: the overview's 5xx figure now reads this counter (reliable, always present) with a fallback to the Sōzu worker metrics.
- Docs: new "Error rate" section in `observability.md` with PromQL examples.

Full e2e suite: 100 passed, 0 failed.
