### PR TITLE
Speed up Docker build and start the 0.14 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0-dev]
+
 ### TLS / ACME
 
 - DNS-01 challenge support via named resolvers — declare `acme.resolvers` with `challenge: dns-01` and a provider (Cloudflare, OVH, Gandi, Scaleway), then point an entrypoint at it with `acme.resolver: <name>`. Provider credentials are read from environment variables, never inlined in YAML. DNS-01 solving is delegated to [cheti](https://github.com/kemeter/cheti).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "sozune"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sozune"
-version = "0.13.0"
+version = "0.14.0-dev"
 authors = ["mlanawo Mbechezi mlanawo.mbechezi@kemeter.io"]
 edition = "2024"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM oven/bun:1-debian AS dashboard
 WORKDIR /dashboard
 COPY dashboard/package.json dashboard/bun.lock ./
@@ -5,27 +7,28 @@ RUN bun install --frozen-lockfile
 COPY dashboard/ ./
 RUN bun run build
 
-FROM rust:1-bookworm AS chef
+# Pinned to 1.95.0: rustc 1.96 SIGSEGVs in thin-LTO codegen on this dependency set.
+FROM rust:1.95.0-bookworm AS builder
+# protobuf-compiler: sozu's build.rs runs protoc to generate command.rs.
+# rustfmt: that same build.rs calls prost_build with .format(true), which shells
+# out to rustfmt — absent from the base image, so the generated module is never
+# written (E0583 "file not found for module command").
 RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
-RUN cargo install cargo-chef --locked
+    && rm -rf /var/lib/apt/lists/* \
+    && rustup component add rustfmt
 WORKDIR /app
-
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 COPY --from=dashboard /dashboard/build ./dashboard/build
-RUN cargo build --release
+# Cache mounts keep the cargo registry, git checkouts and build artifacts warm
+# across builds, so only changed crates recompile. target/ is a mount, so the
+# binary must be copied out within the same RUN before the mount is unmounted.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release && cp target/release/sozune /sozune
 
 FROM gcr.io/distroless/cc-debian12:nonroot
-COPY --from=builder /app/target/release/sozune /sozune
-
-USER root
+COPY --from=builder /sozune /sozune
 
 EXPOSE 80 443
 ENTRYPOINT ["/sozune"]


### PR DESCRIPTION
## Docker build

Reworks the image build, which was slow and produced incorrect output:

- **BuildKit cache mounts** on the cargo registry, git checkouts and `target/` — only changed crates recompile, so a code-only rebuild drops from a full recompile to a few seconds.
- **Pinned rust to `1.95.0`** — rustc 1.96 SIGSEGVs during thin-LTO codegen on this dependency set.
- **`rustup component add rustfmt`** — sozu's `build.rs` shells out to rustfmt via `prost_build(.format(true))` to emit the generated protobuf module; without it the build fails with `E0583 file not found for module command`.
- Dropped cargo-chef (it stubs sources and breaks sozu's protoc/prost codegen) in favour of the cache mounts above.

## Version

The 0.13.0 release is published, and `main` carries 104 commits on top of it, so this opens the next cycle:

- `Cargo.toml` / `Cargo.lock` bumped to `0.14.0-dev` — the binary now reports `sozune 0.14.0-dev`, making dev builds distinguishable from the released 0.13.0.
- `CHANGELOG.md` gains a `## [0.14.0-dev]` heading over the in-progress entries.