### PR TITLE
Add Ring provider for service discovery

### DIFF
--- a/documentation/providers/ring.md
+++ b/documentation/providers/ring.md
@@ -1,0 +1,80 @@
+# Ring provider
+
+The Ring provider discovers entrypoints from a [Ring](https://github.com/kemeter/ring) cluster. Ring is a lightweight orchestrator that runs workloads as containers or microVMs (Firecracker / Cloud Hypervisor). Sōzune reads Ring's deployment list over its HTTP API and turns the `sozune.*` labels declared on each deployment into routing configuration.
+
+Like the Docker / Nomad / Consul providers, Sōzune *observes* Ring — it never registers anything back, so Ring does not need to know Sōzune exists. This is the right provider when your workloads run on Ring and you want a Sōzu-powered ingress in front of them.
+
+## Configuration
+
+```yaml
+providers:
+  ring:
+    enabled: true
+    endpoint: "http://127.0.0.1:3030"
+    token: ""
+    poll_interval: 10
+    expose_by_default: false
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enables the Ring provider |
+| `endpoint` | `http://127.0.0.1:3030` | Ring HTTP API endpoint. Use the node the Sōzune host is closest to. |
+| `token` | `""` | Optional Personal Access Token (scope `deployments:read`) sent as `Authorization: Bearer <token>`. Required when Ring enforces authentication. |
+| `poll_interval` | `10` | How often, in seconds, Sōzune polls Ring. Ring has no blocking-query mechanism, so discovery is interval-based. A reload only fires when the Ring-sourced view actually changes, so a short interval is cheap. |
+| `expose_by_default` | `false` | If `true`, every running deployment is a candidate even without a `sozune.enable=true` label. |
+
+## How it works
+
+1. Sōzune issues `GET /deployments` against the Ring API every `poll_interval` seconds. A single call returns everything needed: each deployment's `sozune.*` labels, its published `ports`, and its running `instances` (each carrying its routable guest `address`). There is no per-deployment second round-trip.
+2. Only deployments with `status = "running"` are considered. Each running instance with a routable address becomes one backend, so a multi-replica deployment fans out to N backends — same host and labels, different IPs (the Nomad / Consul model).
+3. Labels are parsed by the same engine that handles Docker / Swarm / Kubernetes / Nomad annotations, so `sozune validate` and the runtime stay in sync.
+4. Sōzune diffs the new Ring-sourced view against the previous one and only triggers a reload when something changed (deployment added or removed, scaled, address changed).
+
+## Labels
+
+Set `sozune.*` labels on the Ring deployment (via the deployment manifest or the Ring CLI/API). Sōzune reads them straight from the `labels` map returned by `GET /deployments`:
+
+```yaml
+name: api
+image: my-api:latest
+replicas: 3
+labels:
+  sozune.enable: "true"
+  sozune.http.web.host: "api.example.com"
+  sozune.http.web.port: "8080"
+```
+
+> **Ports and replicas.** Ring forbids a `ports` block once `replicas > 1` — every replica would race for the same host port. With multiple replicas you therefore declare the backend port with an explicit `sozune.<proto>.<svc>.port` label (as above). With a single replica you may instead declare a `ports` entry, and Sōzune will use its `target` as the backend port automatically (see [Backend resolution](#backend-resolution)). Sōzune always routes to each instance's guest IP directly, never through a host-published port.
+
+Every annotation listed under [Docker labels](/documentation/providers/docker) — host, path, headers, rate limit, basic auth, redirects, sticky sessions, compression — is supported as-is on Ring deployments.
+
+## Backend resolution
+
+For each running instance, Sōzune uses:
+
+- the instance's `address` (the routable guest IP reported by Ring) as the backend IP
+- the backend port, resolved in this order:
+  1. an explicit `sozune.<proto>.<svc>.port` label, if set (always wins);
+  2. otherwise the first `ports` entry's `target` (only possible with a single replica, since Ring forbids `ports` when `replicas > 1`);
+  3. otherwise the default (`80` for HTTP), which is why a whoami-style service on port 80 routes with no port label at all.
+
+So a single-replica deployment can rely on its `ports` entry, while a multi-replica deployment must carry an explicit `sozune.<proto>.<svc>.port` label unless its container happens to listen on the default port.
+
+An instance with no routable `address` — typically one that is still starting up, or whose runtime could not be inspected — is skipped. It will become a backend on the next poll once Ring reports its address.
+
+## Limitations
+
+- **One Ring endpoint per Sōzune instance.** Point at the API of the cluster you want to route to.
+- **Interval-based discovery.** Ring has no blocking-query / watch mechanism, so reaction time is bounded by `poll_interval` rather than near-instant like the Consul/Nomad providers.
+- **UDP services** are recognised at the label level but not yet proxied (same caveat as the Docker provider).
+
+## Environment variables
+
+| Field | Env var |
+|---|---|
+| `providers.ring.enabled` | `SOZUNE_PROVIDER_RING_ENABLED` |
+| `providers.ring.endpoint` | `SOZUNE_PROVIDER_RING_ENDPOINT` |
+| `providers.ring.token` | `SOZUNE_PROVIDER_RING_TOKEN` |
+| `providers.ring.poll_interval` | `SOZUNE_PROVIDER_RING_POLL_INTERVAL` |
+| `providers.ring.expose_by_default` | `SOZUNE_PROVIDER_RING_EXPOSE_BY_DEFAULT` |

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -10,6 +10,7 @@ use crate::model::Entrypoint;
 use crate::provider::docker::DockerProvider;
 use crate::provider::nomad::NomadProvider;
 use crate::provider::podman::PodmanProvider;
+use crate::provider::ring::RingProvider;
 
 #[derive(Args, Debug)]
 pub struct ValidateArgs {
@@ -179,6 +180,23 @@ async fn collect_candidates(
             },
             Err(e) => eprintln!(
                 "nomad: invalid configuration: {e}\n  → check providers.nomad.address and providers.nomad.token in the config file"
+            ),
+        }
+    }
+
+    if want("ring")
+        && let Some(ring_cfg) = &config.providers.ring
+        && ring_cfg.enabled
+    {
+        match RingProvider::new(ring_cfg.clone()) {
+            Ok(provider) => match provider.collect().await {
+                Ok(mut cs) => candidates.append(&mut cs),
+                Err(e) => eprintln!(
+                    "ring: could not list deployments: {e}\n  → check providers.ring.endpoint (default: http://127.0.0.1:3030) and that the Ring API is reachable"
+                ),
+            },
+            Err(e) => eprintln!(
+                "ring: invalid configuration: {e}\n  → check providers.ring.endpoint and providers.ring.token in the config file"
             ),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,6 +179,7 @@ pub struct ProvidersConfig {
     pub kubernetes: Option<KubernetesConfig>,
     pub nomad: Option<NomadConfig>,
     pub consul: Option<ConsulConfig>,
+    pub ring: Option<RingConfig>,
     pub config_file: Option<ConfigFileConfig>,
     pub http: Option<HttpProviderConfig>,
 }
@@ -288,6 +289,46 @@ pub struct NomadConfig {
         deserialize_with = "deserialize_nomad_expose_by_default_with_env"
     )]
     pub expose_by_default: bool,
+}
+
+/// Ring provider configuration. Discovers services from a Ring cluster's
+/// `GET /deployments` API and routes to each running instance's guest address.
+#[derive(Deserialize, Debug, Clone)]
+pub struct RingConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Ring HTTP API endpoint (e.g. `http://127.0.0.1:3030`).
+    #[serde(default = "default_ring_endpoint")]
+    pub endpoint: String,
+    /// Optional PAT (scope `deployments:read`), sent as `Authorization: Bearer`.
+    #[serde(default)]
+    pub token: String,
+    /// Polling interval, in seconds (Ring has no blocking-query mechanism).
+    #[serde(default = "default_ring_poll_interval")]
+    pub poll_interval: u64,
+    /// Expose every running deployment even without `sozune.enable=true`.
+    #[serde(default)]
+    pub expose_by_default: bool,
+}
+
+fn default_ring_endpoint() -> String {
+    "http://127.0.0.1:3030".to_string()
+}
+
+fn default_ring_poll_interval() -> u64 {
+    10
+}
+
+impl Default for RingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_ring_endpoint(),
+            token: String::new(),
+            poll_interval: default_ring_poll_interval(),
+            expose_by_default: false,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -1221,6 +1262,17 @@ impl ProvidersConfig {
                 .apply_env_overrides();
         }
 
+        let ring_env = std::env::var("SOZUNE_PROVIDER_RING_ENABLED").is_ok()
+            || std::env::var("SOZUNE_PROVIDER_RING_ENDPOINT").is_ok()
+            || std::env::var("SOZUNE_PROVIDER_RING_TOKEN").is_ok()
+            || std::env::var("SOZUNE_PROVIDER_RING_POLL_INTERVAL").is_ok()
+            || std::env::var("SOZUNE_PROVIDER_RING_EXPOSE_BY_DEFAULT").is_ok();
+        if ring_env || self.ring.is_some() {
+            self.ring
+                .get_or_insert_with(RingConfig::default)
+                .apply_env_overrides();
+        }
+
         let config_file_env = std::env::var("SOZUNE_PROVIDER_CONFIG_FILE_ENABLED").is_ok()
             || std::env::var("SOZUNE_PROVIDER_CONFIG_FILE_PATH").is_ok()
             || std::env::var("SOZUNE_PROVIDER_CONFIG_FILE_WATCH").is_ok();
@@ -1339,6 +1391,26 @@ impl NomadConfig {
             self.poll_interval = v;
         }
         if let Some(v) = env_bool("SOZUNE_PROVIDER_NOMAD_EXPOSE_BY_DEFAULT") {
+            self.expose_by_default = v;
+        }
+    }
+}
+
+impl RingConfig {
+    fn apply_env_overrides(&mut self) {
+        if let Some(v) = env_bool("SOZUNE_PROVIDER_RING_ENABLED") {
+            self.enabled = v;
+        }
+        if let Some(v) = env_string("SOZUNE_PROVIDER_RING_ENDPOINT") {
+            self.endpoint = v;
+        }
+        if let Some(v) = env_string("SOZUNE_PROVIDER_RING_TOKEN") {
+            self.token = v;
+        }
+        if let Some(v) = env_parse::<u64>("SOZUNE_PROVIDER_RING_POLL_INTERVAL") {
+            self.poll_interval = v;
+        }
+        if let Some(v) = env_bool("SOZUNE_PROVIDER_RING_EXPOSE_BY_DEFAULT") {
             self.expose_by_default = v;
         }
     }

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -10,6 +10,7 @@ use crate::provider::{
     kubernetes::{KubernetesProvider, gateway},
     nomad::NomadProvider,
     podman::PodmanProvider,
+    ring::RingProvider,
     swarm::SwarmProvider,
 };
 use anyhow::Context;
@@ -313,6 +314,33 @@ pub async fn start_services(
                 .await
             {
                 error!("Consul provider failed: {}", e);
+            }
+        });
+    }
+
+    // Start Ring provider if enabled
+    if let Some(ring_config) = &config.providers.ring
+        && ring_config.enabled
+    {
+        info!("Starting Ring provider");
+        let ring_provider =
+            RingProvider::new(ring_config.clone()).context("Failed to create Ring provider")?;
+        let storage_ring = Arc::clone(&storage);
+        let reload_tx_ring = reload_tx.clone();
+        let acme_notify_ring = Arc::clone(&acme_notify);
+        let diagnostics_ring = Arc::clone(&diagnostics);
+
+        tokio::spawn(async move {
+            if let Err(e) = ring_provider
+                .start_polling(
+                    storage_ring,
+                    reload_tx_ring,
+                    acme_notify_ring,
+                    diagnostics_ring,
+                )
+                .await
+            {
+                error!("Ring provider failed: {}", e);
             }
         });
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -13,12 +13,13 @@ pub const SWARM: &str = "swarm";
 pub const KUBERNETES: &str = "kubernetes";
 pub const NOMAD: &str = "nomad";
 pub const CONSUL: &str = "consul";
+pub const RING: &str = "ring";
 pub const HTTP: &str = "http";
 pub const CONFIG: &str = "config";
 
 /// Every provider known to sōzune, in display order for `/providers`.
 pub const ALL: &[&str] = &[
-    DOCKER, PODMAN, SWARM, KUBERNETES, NOMAD, CONSUL, HTTP, CONFIG,
+    DOCKER, PODMAN, SWARM, KUBERNETES, NOMAD, CONSUL, RING, HTTP, CONFIG,
 ];
 
 #[async_trait]
@@ -34,4 +35,5 @@ pub mod http;
 pub mod kubernetes;
 pub mod nomad;
 pub mod podman;
+pub mod ring;
 pub mod swarm;

--- a/src/provider/ring.rs
+++ b/src/provider/ring.rs
@@ -1,0 +1,522 @@
+//! Ring provider — service discovery from a Ring cluster.
+//!
+//! Ring (https://github.com/kemeter/ring) is a lightweight orchestrator that
+//! runs workloads as containers or microVMs (Firecracker / Cloud Hypervisor).
+//! Like the Docker/Nomad/Consul providers, sōzune *observes* Ring: it reads the
+//! deployment list over Ring's HTTP API and turns each running instance into a
+//! routing candidate. Ring never needs to know sōzune exists.
+//!
+//! One `GET /deployments` returns everything we need per deployment: the
+//! `sozune.*` labels (set by whoever created the deployment) and the running
+//! `instances`, each carrying its routable guest `address`. That single call is
+//! the whole discovery surface — no per-service second round-trip like Nomad.
+//!
+//! Auth mirrors Nomad/Consul: an optional token sent on every request, here as
+//! the standard `Authorization: Bearer <token>` Ring expects (a PAT scoped to
+//! `deployments:read`).
+
+use crate::config::RingConfig;
+use crate::diagnostics::{self, DiagnosticsStore};
+use crate::labels::candidate::{Candidate, NetworkInfo};
+use crate::labels::diagnostic::log_diagnostics;
+use crate::labels::source::LabelSource;
+use crate::model::Entrypoint;
+use crate::provider::Provider;
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::sync::{Notify, mpsc};
+use tracing::{debug, error, info, warn};
+
+const PROVIDER_NAME: &str = crate::provider::RING;
+const NETWORK_NAME: &str = "ring";
+
+pub struct RingProvider {
+    config: RingConfig,
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl Provider for RingProvider {
+    async fn provide(&self) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        let throwaway = diagnostics::new_store();
+        self.provide_into(&throwaway).await
+    }
+}
+
+impl RingProvider {
+    pub fn new(config: RingConfig) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("Failed to build Ring HTTP client")?;
+        Ok(Self { config, client })
+    }
+
+    /// Same as `provide()` but writes diagnostics into the supplied store.
+    async fn provide_into(
+        &self,
+        diagnostics: &DiagnosticsStore,
+    ) -> anyhow::Result<BTreeMap<String, Entrypoint>> {
+        let candidates = self.collect().await?;
+        let mut entrypoints: BTreeMap<String, Entrypoint> = BTreeMap::new();
+        for candidate in candidates {
+            let result = diagnostics::parse_and_store(diagnostics, &candidate);
+            log_diagnostics(&candidate, &result.diagnostics);
+            for (key, mut entrypoint) in result.entrypoints {
+                let Some(backend) = entrypoint.backends.first().cloned() else {
+                    continue;
+                };
+                if let Some(existing) = entrypoints.get_mut(&key) {
+                    if !existing.backends.contains(&backend) {
+                        existing.backends.push(backend);
+                    }
+                } else {
+                    entrypoint.source = Some(PROVIDER_NAME.to_string());
+                    entrypoints.insert(key, entrypoint);
+                }
+            }
+        }
+        Ok(entrypoints)
+    }
+
+    fn build_url(&self, path: &str) -> String {
+        let base = self.config.endpoint.trim_end_matches('/');
+        format!("{base}{path}")
+    }
+
+    /// Fetch every deployment Ring knows about. The token (a PAT scoped to
+    /// `deployments:read`) is sent as a Bearer header when configured.
+    async fn list_deployments(&self) -> anyhow::Result<Vec<RawDeployment>> {
+        let url = self.build_url("/deployments");
+        let mut req = self.client.get(&url).header("Accept", "application/json");
+        if !self.config.token.is_empty() {
+            req = req.bearer_auth(&self.config.token);
+        }
+        let resp = req
+            .send()
+            .await
+            .with_context(|| format!("Ring request to {url} failed"))?;
+        if !resp.status().is_success() {
+            anyhow::bail!("Ring returned status {} for {}", resp.status(), url);
+        }
+        let bytes = resp
+            .bytes()
+            .await
+            .with_context(|| format!("Failed to read Ring response from {url}"))?;
+        let body: Vec<RawDeployment> = serde_json::from_slice(&bytes)
+            .with_context(|| format!("Failed to decode Ring response from {url}"))?;
+        Ok(body)
+    }
+
+    /// Pull entrypoints once and merge them into storage with `source = "ring"`.
+    /// On any change vs the previous Ring-sourced entries, push a reload.
+    async fn poll_once(
+        &self,
+        storage: &Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: &mpsc::Sender<()>,
+        acme_notify: &Arc<Notify>,
+        diagnostics: &DiagnosticsStore,
+    ) {
+        let new_entrypoints = match self.provide_into(diagnostics).await {
+            Ok(map) => map,
+            Err(e) => {
+                warn!("Ring poll failed: {e}");
+                return;
+            }
+        };
+
+        let needs_update = {
+            let storage_read = match storage.read() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("internal state corrupted (configuration store), restart required: {e}");
+                    return;
+                }
+            };
+            let old_ids: HashSet<&String> = storage_read
+                .iter()
+                .filter(|(_, ep)| ep.source.as_deref() == Some(PROVIDER_NAME))
+                .map(|(id, _)| id)
+                .collect();
+            let new_ids: HashSet<&String> = new_entrypoints.keys().collect();
+            old_ids != new_ids
+                || new_entrypoints
+                    .iter()
+                    .any(|(id, ep)| storage_read.get(id).is_none_or(|existing| existing != ep))
+        };
+
+        if !needs_update {
+            return;
+        }
+
+        {
+            let mut storage_write = match storage.write() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("internal state corrupted (configuration store), restart required: {e}");
+                    return;
+                }
+            };
+            storage_write.retain(|_, ep| ep.source.as_deref() != Some(PROVIDER_NAME));
+            for (id, entrypoint) in new_entrypoints {
+                debug!(
+                    "Ring entrypoint: {id} ({} backend(s))",
+                    entrypoint.backends.len()
+                );
+                storage_write.insert(id, entrypoint);
+            }
+        }
+
+        info!("Ring provider config changed, triggering reload");
+        if let Err(e) = reload_tx.send(()).await {
+            warn!("could not apply configuration update; will retry on next change: {e}");
+        }
+        acme_notify.notify_one();
+    }
+
+    /// Ring has no blocking-query mechanism, so we poll at a fixed interval.
+    /// `poll_once` only triggers a reload when the Ring-sourced view actually
+    /// changes, so a short interval is cheap.
+    pub async fn start_polling(
+        &self,
+        storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
+        reload_tx: mpsc::Sender<()>,
+        acme_notify: Arc<Notify>,
+        diagnostics: DiagnosticsStore,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Starting Ring provider against {} (poll={}s, expose_by_default={})",
+            self.config.endpoint, self.config.poll_interval, self.config.expose_by_default,
+        );
+        loop {
+            self.poll_once(&storage, &reload_tx, &acme_notify, &diagnostics)
+                .await;
+            tokio::time::sleep(Duration::from_secs(self.config.poll_interval)).await;
+        }
+    }
+}
+
+#[async_trait]
+impl LabelSource for RingProvider {
+    async fn collect(&self) -> anyhow::Result<Vec<Candidate>> {
+        let deployments = self.list_deployments().await?;
+        let mut candidates = Vec::new();
+        for deployment in deployments {
+            // Only running deployments can serve traffic.
+            if deployment.status != "running" {
+                continue;
+            }
+            // For every `sozune.<proto>.<svc>.host`, inject the container's
+            // target port as `sozune.<proto>.<svc>.port` unless the user set one.
+            // Computed once per deployment and shared by all its instances.
+            let labels = synthesize_port_labels(deployment.labels.clone(), &deployment.ports);
+            // One candidate per running instance: each carries its own guest
+            // address, so a multi-replica deployment fans out to N backends —
+            // the same host+labels, different IPs (Nomad/Consul model).
+            for instance in &deployment.instances {
+                let Some(address) = instance.address.clone() else {
+                    continue; // instance not yet addressable (starting up, or runtime inspect failed)
+                };
+                candidates.push(Candidate {
+                    provider: PROVIDER_NAME,
+                    id: instance.id.clone(),
+                    display_name: deployment.name.clone(),
+                    labels: labels.clone(),
+                    networks: vec![NetworkInfo {
+                        name: NETWORK_NAME.to_string(),
+                        ip: Some(address),
+                    }],
+                    enabled_default: self.config.expose_by_default,
+                    health: None,
+                });
+            }
+        }
+        Ok(candidates)
+    }
+}
+
+/// Subset of Ring's `GET /deployments` response we care about.
+#[derive(Debug, Deserialize)]
+struct RawDeployment {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    labels: HashMap<String, String>,
+    #[serde(default)]
+    ports: Vec<RawPort>,
+    #[serde(default)]
+    instances: Vec<RawInstance>,
+}
+
+/// One port, as exposed by Ring's `DeploymentPort` DTO. We route to each
+/// instance's guest `address` directly, so the reachable port is `target` (the
+/// container's internal port) — not `published`, which is a host-side mapping
+/// that Ring forbids entirely once `replicas > 1`.
+#[derive(Debug, Deserialize)]
+struct RawPort {
+    #[serde(default)]
+    target: u16,
+}
+
+/// One running instance, as exposed by Ring's `DeploymentInstance` DTO.
+#[derive(Debug, Deserialize)]
+struct RawInstance {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    address: Option<String>,
+}
+
+/// For every `sozune.<proto>.<svc>.host` declared, inject the first Ring port's
+/// `target` as `sozune.<proto>.<svc>.port` unless the user already set one.
+/// Explicit user ports win. Without this, a backend with no port label falls
+/// back to `:80`. We use `target` (the in-container port) because we route to
+/// the instance's guest IP, not a host-published port.
+fn synthesize_port_labels(
+    mut labels: HashMap<String, String>,
+    ports: &[RawPort],
+) -> HashMap<String, String> {
+    let Some(target) = ports.iter().map(|p| p.target).find(|&p| p != 0) else {
+        return labels;
+    };
+    let port_str = target.to_string();
+    let prefixes: Vec<String> = labels
+        .keys()
+        .filter_map(|k| {
+            k.strip_suffix(".host")
+                .filter(|p| p.starts_with("sozune."))
+                .map(|p| p.to_string())
+        })
+        .collect();
+    for prefix in prefixes {
+        labels
+            .entry(format!("{prefix}.port"))
+            .or_insert_with(|| port_str.clone());
+    }
+    labels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> RingConfig {
+        RingConfig {
+            enabled: true,
+            endpoint: "http://127.0.0.1:3030".to_string(),
+            token: String::new(),
+            poll_interval: 10,
+            expose_by_default: false,
+        }
+    }
+
+    fn provider() -> RingProvider {
+        RingProvider::new(cfg()).unwrap()
+    }
+
+    #[test]
+    fn build_url_joins_endpoint_and_path() {
+        assert_eq!(
+            provider().build_url("/deployments"),
+            "http://127.0.0.1:3030/deployments"
+        );
+    }
+
+    #[test]
+    fn build_url_trims_trailing_slash() {
+        let mut c = cfg();
+        c.endpoint = "http://127.0.0.1:3030/".to_string();
+        let p = RingProvider::new(c).unwrap();
+        assert_eq!(
+            p.build_url("/deployments"),
+            "http://127.0.0.1:3030/deployments"
+        );
+    }
+
+    /// Builds candidates from a fixed deployment list, exercising the SAME
+    /// per-deployment/per-instance logic as `collect()` (status gate, port
+    /// synthesis, address skip, fan-out) without the HTTP round-trip.
+    fn candidates_from(deployments: Vec<RawDeployment>, expose_by_default: bool) -> Vec<Candidate> {
+        let mut out = Vec::new();
+        for deployment in deployments {
+            if deployment.status != "running" {
+                continue;
+            }
+            let labels = synthesize_port_labels(deployment.labels.clone(), &deployment.ports);
+            for instance in &deployment.instances {
+                let Some(address) = instance.address.clone() else {
+                    continue;
+                };
+                out.push(Candidate {
+                    provider: PROVIDER_NAME,
+                    id: instance.id.clone(),
+                    display_name: deployment.name.clone(),
+                    labels: labels.clone(),
+                    networks: vec![NetworkInfo {
+                        name: NETWORK_NAME.to_string(),
+                        ip: Some(address),
+                    }],
+                    enabled_default: expose_by_default,
+                    health: None,
+                });
+            }
+        }
+        out
+    }
+
+    /// A real Ring `GET /deployments` payload must deserialize into our DTO.
+    /// This is the test that guards the contract with Ring's `DeploymentOutput`:
+    /// `instances` is `[{id, address}]` and `ports` is `[{published, target, ...}]`.
+    #[test]
+    fn deserializes_real_ring_payload() {
+        let body = r#"[
+          {
+            "id": "dep-1",
+            "name": "web",
+            "status": "running",
+            "labels": { "sozune.http.web.host": "example.com" },
+            "ports": [ { "published": 8080, "target": 80, "protocol": "tcp" } ],
+            "instances": [
+              { "id": "dep-1-a", "address": "10.42.0.2" },
+              { "id": "dep-1-b", "address": null }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<RawDeployment> =
+            serde_json::from_str(body).expect("real Ring payload must deserialize");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].ports[0].target, 80);
+        assert_eq!(parsed[0].instances.len(), 2);
+        assert_eq!(parsed[0].instances[0].address.as_deref(), Some("10.42.0.2"));
+        assert_eq!(parsed[0].instances[1].address, None);
+    }
+
+    #[test]
+    fn running_instance_with_address_becomes_candidate() {
+        let d = RawDeployment {
+            name: "web".into(),
+            status: "running".into(),
+            labels: HashMap::from([(
+                "sozune.http.web.host".to_string(),
+                "example.com".to_string(),
+            )]),
+            ports: vec![],
+            instances: vec![RawInstance {
+                id: "dep-1-abc".into(),
+                address: Some("10.42.0.2".into()),
+            }],
+        };
+        let c = candidates_from(vec![d], false);
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].display_name, "web");
+        assert_eq!(c[0].networks[0].ip.as_deref(), Some("10.42.0.2"));
+        assert_eq!(
+            c[0].labels.get("sozune.http.web.host").map(|s| s.as_str()),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn non_running_deployment_is_skipped() {
+        let d = RawDeployment {
+            name: "web".into(),
+            status: "pending".into(),
+            labels: HashMap::new(),
+            ports: vec![],
+            instances: vec![RawInstance {
+                id: "dep-1-abc".into(),
+                address: Some("10.42.0.2".into()),
+            }],
+        };
+        assert!(candidates_from(vec![d], false).is_empty());
+    }
+
+    #[test]
+    fn instance_without_address_is_skipped() {
+        let d = RawDeployment {
+            name: "web".into(),
+            status: "running".into(),
+            labels: HashMap::new(),
+            ports: vec![],
+            instances: vec![RawInstance {
+                id: "dep-1-abc".into(),
+                address: None,
+            }],
+        };
+        assert!(candidates_from(vec![d], false).is_empty());
+    }
+
+    #[test]
+    fn multi_replica_fans_out_to_one_candidate_per_instance() {
+        let d = RawDeployment {
+            name: "web".into(),
+            status: "running".into(),
+            labels: HashMap::from([(
+                "sozune.http.web.host".to_string(),
+                "example.com".to_string(),
+            )]),
+            ports: vec![],
+            instances: vec![
+                RawInstance {
+                    id: "dep-1-a".into(),
+                    address: Some("10.42.0.2".into()),
+                },
+                RawInstance {
+                    id: "dep-1-b".into(),
+                    address: Some("10.42.0.6".into()),
+                },
+            ],
+        };
+        let c = candidates_from(vec![d], false);
+        assert_eq!(c.len(), 2);
+    }
+
+    #[test]
+    fn target_port_synthesizes_missing_port_label() {
+        let labels = HashMap::from([(
+            "sozune.http.web.host".to_string(),
+            "example.com".to_string(),
+        )]);
+        let ports = vec![RawPort { target: 80 }];
+        let out = synthesize_port_labels(labels, &ports);
+        assert_eq!(
+            out.get("sozune.http.web.port").map(|s| s.as_str()),
+            Some("80"),
+            "missing port should be filled from the Ring port's target"
+        );
+    }
+
+    #[test]
+    fn explicit_port_label_is_preserved() {
+        let labels = HashMap::from([
+            (
+                "sozune.http.web.host".to_string(),
+                "example.com".to_string(),
+            ),
+            ("sozune.http.web.port".to_string(), "9000".to_string()),
+        ]);
+        let ports = vec![RawPort { target: 80 }];
+        let out = synthesize_port_labels(labels, &ports);
+        assert_eq!(
+            out.get("sozune.http.web.port").map(|s| s.as_str()),
+            Some("9000"),
+            "user-provided port must win over the target port"
+        );
+    }
+
+    #[test]
+    fn no_port_leaves_labels_untouched() {
+        let labels = HashMap::from([(
+            "sozune.http.web.host".to_string(),
+            "example.com".to_string(),
+        )]);
+        let out = synthesize_port_labels(labels, &[]);
+        assert!(!out.contains_key("sozune.http.web.port"));
+    }
+}

--- a/tests/e2e/ring/01-discovery.sh
+++ b/tests/e2e/ring/01-discovery.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Ring service discovery: labels drive routing, each running instance is
+# reached directly through its guest address. Sourced by run-ring.sh.
+
+log "[01] Whoami service is reachable through Sozune"
+if wait_for_status "$HOST_WHOAMI" "200"; then
+    pass "$HOST_WHOAMI returns 200"
+else
+    fail "$HOST_WHOAMI not reachable"
+    return 0
+fi
+
+log "[01] Round-robin hits all 3 instances"
+# Each replica runs with its own guest address; Sozune carries a port per
+# backend (synthesized from the deployment's published port), so the three
+# instances show up as distinct routing targets.
+distinct=$(wait_for_distinct_backends "$HOST_WHOAMI" 3 30 || true)
+if [[ "$distinct" -ge 3 ]]; then
+    pass "round-robin hits $distinct distinct instances"
+else
+    fail "expected >=3 distinct instances after 30s, got $distinct"
+fi
+
+log "[01] Sozu-Id header is present (proves Sōzu, not host network, served the request)"
+sozu_id=$(curl -s -H "Host: $HOST_WHOAMI" --max-time 3 -D - \
+            "http://localhost:$HTTP_PORT/" | awk -F': ' 'tolower($1)=="sozu-id"{print $2}' | tr -d '\r')
+if [[ -n "$sozu_id" ]]; then
+    pass "Sozu-Id header present (id=${sozu_id:0:12}...)"
+else
+    fail "Sozu-Id header missing — request did not go through Sōzu"
+fi

--- a/tests/e2e/ring/02-scaling.sh
+++ b/tests/e2e/ring/02-scaling.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Ring scaling: re-apply the deployment with a new replica count and verify
+# Sozune picks up the instance changes on its next poll. Sourced by run-ring.sh.
+
+SCALED_MANIFEST="$RING_DATA_DIR/whoami-scaled.yaml"
+
+apply_replicas() {
+    local count="$1"
+    sed "s/replicas: 3/replicas: $count/" "$RING_DIR/whoami.ring.yaml" > "$SCALED_MANIFEST"
+    "$RING_BIN" apply --file "$SCALED_MANIFEST" >/dev/null
+}
+
+log "[02] Scale to 5 — backend list grows"
+apply_replicas 5
+if ! wait_for_ring_instances 5; then
+    fail "Ring did not converge to 5 addressable instances in time"
+    return 0
+fi
+
+distinct=$(wait_for_distinct_backends "$HOST_WHOAMI" 5 30 || true)
+if [[ "$distinct" -ge 5 ]]; then
+    pass "after scale to 5, $distinct distinct instances served traffic"
+else
+    fail "expected >=5 backends after scale-up, got $distinct"
+fi
+
+log "[02] Scale to 1 — backend list shrinks"
+apply_replicas 1
+if ! wait_for_ring_instances 1; then
+    fail "Ring did not converge to 1 addressable instance in time"
+    return 0
+fi
+# Sozune polls every few seconds; give the watcher a moment to drop the
+# removed instances and reload Sōzu.
+sleep "$ROUTE_DELAY"
+
+distinct=$(count_distinct_hostnames "$HOST_WHOAMI" 12)
+if [[ "$distinct" -le 1 ]]; then
+    pass "after scale to 1, only $distinct distinct backend(s) served traffic"
+else
+    fail "expected <=1 backend after scale-down, got $distinct (stale instances?)"
+fi

--- a/tests/e2e/ring/lib-ring.sh
+++ b/tests/e2e/ring/lib-ring.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Shared helpers for the Ring e2e suite. Sourced by run-ring.sh.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RING_ADDR="${RING_ADDR:-http://127.0.0.1:3030}"
+# PAT (scope deployments:read) minted by the runner; helpers that hit the
+# auth-gated /deployments endpoint send it as a Bearer token.
+RING_TOKEN="${RING_TOKEN:-}"
+RING_DATA_DIR="${RING_DATA_DIR:-$(mktemp -d -t sozune-ring-XXXXXX)}"
+RING_LOG="$RING_DATA_DIR/server.log"
+RING_PID_FILE="$RING_DATA_DIR/server.pid"
+
+DEPLOYMENT_NAME="sozune-e2e-whoami"
+
+HTTP_PORT=18180
+HTTPS_PORT=18443
+MIDDLEWARE_PORT=13139
+
+CONFIG_FILE="$(mktemp -t sozune-ring-config.XXXXXX.yaml)"
+SOZUNE_LOG="$RING_DATA_DIR/sozune.log"
+SOZUNE_PID=""
+
+HOST_WHOAMI="whoami.ring-test.localhost"
+
+STARTUP_DELAY=2
+ROUTE_DELAY=4
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+log()  { echo -e "${YELLOW}[RING]${NC} $*"; }
+pass() { echo -e "${GREEN}[PASS]${NC} $*"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "${YELLOW}[SKIP]${NC} $*"; SKIPPED=$((SKIPPED + 1)); }
+
+probe_http() {
+    local host="$1"
+    local path="${2:-/}"
+    curl -s -o /dev/null -w '%{http_code}' \
+        -H "Host: $host" \
+        --max-time 3 \
+        "http://localhost:$HTTP_PORT$path" || echo "000"
+}
+
+probe_body() {
+    local host="$1"
+    local path="${2:-/}"
+    curl -s -H "Host: $host" --max-time 3 "http://localhost:$HTTP_PORT$path"
+}
+
+wait_for_status() {
+    local host="$1"
+    local expected="$2"
+    local path="${3:-/}"
+    for _ in $(seq 1 30); do
+        if [[ "$(probe_http "$host" "$path")" == "$expected" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+count_distinct_hostnames() {
+    local host="$1"
+    local n="${2:-12}"
+    local seen
+    seen=$(for _ in $(seq 1 "$n"); do
+        probe_body "$host" / | awk '/^Hostname:/ {print $2}'
+    done | sort -u | wc -l)
+    echo "$seen"
+}
+
+# Ready when the Ring API answers on /healthz (no auth required, unlike
+# /deployments which is gated behind a token).
+wait_for_ring() {
+    for _ in $(seq 1 30); do
+        if curl -sf "$RING_ADDR/healthz" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+# curl against the auth-gated Ring API, sending the Bearer token when set.
+ring_api() {
+    local path="$1"
+    if [[ -n "$RING_TOKEN" ]]; then
+        curl -sf -H "Authorization: Bearer $RING_TOKEN" "$RING_ADDR$path"
+    else
+        curl -sf "$RING_ADDR$path"
+    fi
+}
+
+# Wait until the named deployment reports `expected` running instances, each
+# carrying a routable address (the shape Sozune's provider consumes).
+wait_for_ring_instances() {
+    local expected="$1"
+    for _ in $(seq 1 60); do
+        local got
+        got=$(ring_api "/deployments" 2>/dev/null \
+              | jq --arg n "$DEPLOYMENT_NAME" \
+                   '[.[] | select(.name == $n and .status == "running")
+                          | .instances[] | select(.address != null)] | length' \
+                   2>/dev/null || echo 0)
+        if [[ "$got" == "$expected" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+# Wait until Sozune routes to at least `expected` distinct backends, or fail
+# after `timeout` seconds — gives the poll-based watcher time to catch up.
+wait_for_distinct_backends() {
+    local host="$1"
+    local expected="$2"
+    local timeout="${3:-30}"
+    local distinct=0
+    for _ in $(seq 1 "$timeout"); do
+        distinct=$(count_distinct_hostnames "$host" 12)
+        if [[ "$distinct" -ge "$expected" ]]; then
+            echo "$distinct"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "$distinct"
+    return 1
+}

--- a/tests/e2e/ring/run-ring.sh
+++ b/tests/e2e/ring/run-ring.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Functional test orchestrator for the Sozune Ring provider.
+# Boots a Ring server (Docker runtime), deploys a whoami deployment carrying
+# sozune.* labels, starts Sozune locally pointed at the Ring API, then runs
+# all suite scripts in order.
+#
+# Ring is not a standard tool, so this suite is opt-in: it is NOT wired into
+# tests/e2e/run-all.sh and skips cleanly when the `ring` binary is absent.
+# Point RING_BIN at a built Ring binary to run it:
+#   RING_BIN=/path/to/ring bash tests/e2e/ring/run-ring.sh
+#
+# Requirements: ring, docker, jq, curl, cargo
+
+set -euo pipefail
+
+RING_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$RING_DIR/lib-ring.sh"
+
+RING_BIN="${RING_BIN:-ring}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+
+# Ring server bootstrap: isolated config dir + database, Docker runtime on.
+export RING_CONFIG_DIR="$RING_DATA_DIR"
+export RING_DATABASE_PATH="$RING_DATA_DIR/ring.db"
+export RING_SECRET_KEY="${RING_SECRET_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}"
+RING_PORT="${RING_PORT:-3030}"
+
+cleanup() {
+    log "Cleaning up..."
+    if [[ -n "${SOZUNE_PID:-}" ]] && kill -0 "$SOZUNE_PID" 2>/dev/null; then
+        kill "$SOZUNE_PID" 2>/dev/null || true
+        wait "$SOZUNE_PID" 2>/dev/null || true
+    fi
+    if [[ -f "$RING_PID_FILE" ]]; then
+        local server_pid
+        server_pid=$(cat "$RING_PID_FILE")
+        if kill -0 "$server_pid" 2>/dev/null; then
+            kill "$server_pid" 2>/dev/null || true
+            wait "$server_pid" 2>/dev/null || true
+        fi
+        rm -f "$RING_PID_FILE"
+    fi
+    # Remove any container Ring created for this run (labelled ring_deployment).
+    if command -v docker >/dev/null 2>&1; then
+        docker ps -aq --filter "label=ring_deployment" 2>/dev/null \
+            | xargs -r docker rm -f >/dev/null 2>&1 || true
+    fi
+    rm -f "$CONFIG_FILE"
+    if [[ "$KEEP_SERVER" != "1" ]]; then
+        rm -rf "$RING_DATA_DIR"
+    else
+        log "Keeping Ring data dir at $RING_DATA_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# -- Pre-flight: skip (don't fail) when Ring is unavailable --
+if ! command -v "$RING_BIN" >/dev/null 2>&1; then
+    skip "Ring binary not found (set RING_BIN to a built ring); skipping Ring e2e suite"
+    echo "=============================="
+    echo -e "  ${YELLOW}Skipped: 1${NC}"
+    echo "=============================="
+    exit 0
+fi
+for tool in docker jq curl cargo; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        fail "Missing required tool: $tool"
+        exit 1
+    fi
+done
+
+# -- Build sozune --
+log "Building sozune..."
+cargo build --quiet --manifest-path "$PROJECT_DIR/Cargo.toml" 2>&1
+SOZUNE_BIN="$PROJECT_DIR/target/debug/sozune"
+if [[ ! -x "$SOZUNE_BIN" ]]; then
+    fail "Build failed: $SOZUNE_BIN not found"
+    exit 1
+fi
+
+# -- Ring server config --
+cat > "$RING_DATA_DIR/config.toml" <<EOF
+[contexts.default]
+current = true
+host = "127.0.0.1"
+
+api.scheme = "http"
+api.port = ${RING_PORT}
+
+user.salt = "sozune-e2e-salt"
+
+[server.scheduler]
+interval = 1
+
+[server.runtime.docker]
+enabled = true
+EOF
+
+# -- Boot Ring server --
+log "Starting Ring server on port $RING_PORT (config: $RING_DATA_DIR)..."
+"$RING_BIN" server start >"$RING_LOG" 2>&1 &
+echo $! > "$RING_PID_FILE"
+
+if ! wait_for_ring; then
+    fail "Ring server did not become ready in time"
+    tail -40 "$RING_LOG" || true
+    exit 1
+fi
+log "Ring server ready at $RING_ADDR"
+
+# -- Deploy whoami --
+log "Logging in to Ring (admin)..."
+"$RING_BIN" login --username admin --password changeme >/dev/null
+
+# Mint a read-only PAT for Sozune (and for this runner's API probes). The
+# clear token is printed on stdout by `ring token create`.
+log "Creating a deployments:read token for Sozune..."
+RING_TOKEN="$("$RING_BIN" token create sozune-e2e --scope deployments:read 2>/dev/null)"
+if [[ -z "$RING_TOKEN" ]]; then
+    fail "Could not mint a Ring token"
+    exit 1
+fi
+
+log "Deploying '$DEPLOYMENT_NAME' (3 replicas of traefik/whoami)..."
+"$RING_BIN" apply --file "$RING_DIR/whoami.ring.yaml" >/dev/null
+
+if ! wait_for_ring_instances 3; then
+    fail "Deployment '$DEPLOYMENT_NAME' did not report 3 addressable instances in time"
+    ring_api "/deployments" | jq '.' || true
+    exit 1
+fi
+log "Deployment '$DEPLOYMENT_NAME' has 3 addressable instances"
+
+# -- Sozune config --
+cat > "$CONFIG_FILE" <<EOF
+providers:
+  ring:
+    enabled: true
+    endpoint: "$RING_ADDR"
+    token: "$RING_TOKEN"
+    poll_interval: 3
+
+api:
+  enabled: false
+
+proxy:
+  http:
+    listen_address: $HTTP_PORT
+  https:
+    listen_address: $HTTPS_PORT
+  startup_delay_ms: 500
+  cluster_setup_delay_ms: 200
+
+middleware:
+  port: $MIDDLEWARE_PORT
+EOF
+
+log "Starting sozune (HTTP on :$HTTP_PORT)..."
+CONFIG_PATH="$CONFIG_FILE" RUST_LOG=sozune=info "$SOZUNE_BIN" \
+    >"$SOZUNE_LOG" 2>&1 &
+SOZUNE_PID=$!
+sleep "$STARTUP_DELAY"
+
+if ! kill -0 "$SOZUNE_PID" 2>/dev/null; then
+    fail "sozune process died on startup"
+    tail -40 "$SOZUNE_LOG" || true
+    exit 1
+fi
+
+log "Waiting for routes to propagate..."
+sleep "$ROUTE_DELAY"
+
+# -- Run suites --
+for suite in "$RING_DIR"/[0-9][0-9]-*.sh; do
+    echo ""
+    source "$suite"
+done
+
+# -- Summary --
+echo ""
+echo "=============================="
+echo -e "  ${GREEN}Passed: $PASSED${NC}  ${RED}Failed: $FAILED${NC}  ${YELLOW}Skipped: $SKIPPED${NC}"
+echo "=============================="
+
+if [[ $FAILED -gt 0 ]]; then
+    log "sozune logs (last 60 lines):"
+    tail -60 "$SOZUNE_LOG" || true
+    exit 1
+fi

--- a/tests/e2e/ring/whoami.ring.yaml
+++ b/tests/e2e/ring/whoami.ring.yaml
@@ -1,0 +1,17 @@
+# Ring deployment for the Sozune e2e suite. Three whoami replicas, tagged so
+# Sozune routes whoami.ring-test.localhost to them.
+#
+# No `ports` block: Ring forbids a `ports` entry entirely once replicas > 1
+# (every replica would race for the same host port). Sozune routes to each
+# instance's guest IP directly; whoami listens on port 80, which the parser's
+# default backend port matches — so no explicit port label is needed here.
+deployments:
+  sozune-e2e-whoami:
+    name: sozune-e2e-whoami
+    namespace: sozune-e2e
+    runtime: docker
+    image: "traefik/whoami:latest"
+    replicas: 3
+    labels:
+      - sozune.enable: "true"
+      - sozune.http.web.host: "whoami.ring-test.localhost"

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -74,7 +74,7 @@ const PAGE_ORDER: Record<string, string[]> = {
     'load-balancing',
     'tcp',
   ],
-  providers: ['docker', 'podman', 'swarm', 'kubernetes', 'nomad', 'consul', 'http'],
+  providers: ['docker', 'podman', 'swarm', 'kubernetes', 'nomad', 'consul', 'ring', 'http'],
   middleware: [
     'auth',
     'headers',


### PR DESCRIPTION
## Summary

Adds a **Ring provider** so Sōzune can discover services from a [Ring](https://github.com/kemeter/ring) cluster, the same way it observes Docker / Nomad / Consul. It polls Ring's `GET /deployments` API and turns each running instance into a routing backend — Ring never needs to know Sōzune exists.

## How it works

- Polls `GET /deployments` every `poll_interval` seconds (Ring has no blocking-query mechanism). A reload only fires when the Ring-sourced view actually changes.
- One backend per running instance: each carries its own guest IP (`address`), so a multi-replica deployment fans out to N backends (the Nomad/Consul model).
- Optional PAT (scope `deployments:read`) sent as `Authorization: Bearer`.
- `sozune.*` labels are parsed by the shared label engine, so `sozune validate` and the runtime stay in sync.

## Port resolution

Backend port is resolved as: explicit `sozune.<proto>.<svc>.port` label → first `ports[].target` (single-replica only) → default (`80`). Ring forbids a `ports` block once `replicas > 1`, so multi-replica deployments rely on an explicit port label unless the container listens on the default port.

## Configuration

```yaml
providers:
  ring:
    enabled: true
    endpoint: "http://127.0.0.1:3030"
    token: ""
    poll_interval: 10
    expose_by_default: false
```

All fields are also overridable via `SOZUNE_PROVIDER_RING_*` environment variables, consistent with the other providers.

## Testing

- Unit tests: DTO deserialization against a real Ring payload, port synthesis, status/address gating, multi-replica fan-out.
- e2e suite (`tests/e2e/ring/`): boots a real Ring server, deploys 3 whoami replicas, and verifies discovery, round-robin, and scale up/down. Opt-in — skips cleanly when the `ring` binary is absent (not wired into `run-all.sh`). **5/5 passing** against a live Ring.
- `cargo fmt`, `cargo clippy` (0 issues), full unit suite (559 passing).

## Docs

New `documentation/providers/ring.md` and nav entry.
