### PR TITLE
fix(proxy): stop a slow metrics poll from freezing all proxying

### DIFF
--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -118,6 +118,8 @@ providers:
 | `proxy.buffer_size` | `16384` | Buffer size, in bytes |
 | `proxy.startup_delay_ms` | `1000` | Delay before applying the initial config (gives Sōzu workers time to boot) |
 | `proxy.cluster_setup_delay_ms` | `500` | Delay between cluster setup commands |
+| `proxy.reload_debounce_ms` | `500` | Debounce window, in ms, applied to reload signals. A reload runs only after this many ms of silence, coalescing bursts of container start/stop events into one reload |
+| `proxy.metrics_poll_timeout_ms` | `200` | Per-worker deadline, in ms, for a metrics poll round-trip. Keep it short: the poll shares the loop that accepts traffic and applies certificates, so a slow or silent worker must not be allowed to block proxying |
 
 ## Middleware
 
@@ -142,6 +144,7 @@ Every field above can be overridden through an environment variable. The env var
 | `proxy.startup_delay_ms` | `SOZUNE_PROXY_STARTUP_DELAY_MS` |
 | `proxy.cluster_setup_delay_ms` | `SOZUNE_PROXY_CLUSTER_SETUP_DELAY_MS` |
 | `proxy.reload_debounce_ms` | `SOZUNE_PROXY_RELOAD_DEBOUNCE_MS` |
+| `proxy.metrics_poll_timeout_ms` | `SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS` |
 | `api.enabled` | `SOZUNE_API_ENABLED` |
 | `api.listen_address` | `SOZUNE_API_LISTEN_ADDRESS` |
 | `dashboard.enabled` | `SOZUNE_DASHBOARD_ENABLED` |

--- a/src/config.rs
+++ b/src/config.rs
@@ -472,6 +472,19 @@ pub struct ProxyConfig {
         deserialize_with = "deserialize_reload_debounce_ms_with_env"
     )]
     pub reload_debounce_ms: u64,
+    /// Per-worker deadline, in milliseconds, for a metrics poll round-trip. The
+    /// poll runs inside the same loop that accepts traffic and applies
+    /// certificates, and reads the worker reply with a *blocking* wait — so this
+    /// deadline is the longest that one worker's metrics query can monopolize
+    /// that loop. A silent or overwhelmed worker (e.g. a metrics reply that
+    /// overflows the command channel's back buffer) would otherwise block here;
+    /// keep this short so a metrics hiccup can never freeze proxying. Defaults
+    /// to 200 ms (a healthy worker answers in single-digit ms).
+    #[serde(
+        default = "default_metrics_poll_timeout_ms",
+        deserialize_with = "deserialize_metrics_poll_timeout_ms_with_env"
+    )]
+    pub metrics_poll_timeout_ms: u64,
     /// CIDRs of reverse-proxies that sit in front of Sōzune and are trusted
     /// to set `X-Forwarded-For`. **Empty by default** — when no entry is
     /// configured, Sōzune ignores `X-Forwarded-For` entirely and treats the
@@ -765,6 +778,7 @@ impl Default for ProxyConfig {
             startup_delay_ms: default_startup_delay_ms(),
             cluster_setup_delay_ms: default_cluster_setup_delay_ms(),
             reload_debounce_ms: default_reload_debounce_ms(),
+            metrics_poll_timeout_ms: default_metrics_poll_timeout_ms(),
             trusted_proxies: Vec::new(),
         }
     }
@@ -788,6 +802,10 @@ fn default_cluster_setup_delay_ms() -> u64 {
 
 fn default_reload_debounce_ms() -> u64 {
     500
+}
+
+pub(crate) fn default_metrics_poll_timeout_ms() -> u64 {
+    200
 }
 
 fn default_api_listen_address() -> String {
@@ -1133,6 +1151,12 @@ deserialize_with_env!(
     "SOZUNE_PROXY_RELOAD_DEBOUNCE_MS",
     u64,
     default_reload_debounce_ms
+);
+deserialize_with_env!(
+    deserialize_metrics_poll_timeout_ms_with_env,
+    "SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS",
+    u64,
+    default_metrics_poll_timeout_ms
 );
 
 deserialize_bool_with_env!(
@@ -1537,6 +1561,9 @@ impl ProxyConfig {
         if let Some(v) = env_parse::<u64>("SOZUNE_PROXY_RELOAD_DEBOUNCE_MS") {
             self.reload_debounce_ms = v;
         }
+        if let Some(v) = env_parse::<u64>("SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS") {
+            self.metrics_poll_timeout_ms = v;
+        }
     }
 }
 
@@ -1800,6 +1827,7 @@ acme:
         assert_eq!(default_startup_delay_ms(), 1000);
         assert_eq!(default_cluster_setup_delay_ms(), 500);
         assert_eq!(default_reload_debounce_ms(), 500);
+        assert_eq!(default_metrics_poll_timeout_ms(), 200);
     }
 
     #[test]
@@ -1842,6 +1870,7 @@ acme:
                 "SOZUNE_PROXY_STARTUP_DELAY_MS",
                 "SOZUNE_PROXY_CLUSTER_SETUP_DELAY_MS",
                 "SOZUNE_PROXY_RELOAD_DEBOUNCE_MS",
+                "SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS",
             ] {
                 std::env::remove_var(k);
             }
@@ -1857,6 +1886,7 @@ buffer_size: 32768
 startup_delay_ms: 2000
 cluster_setup_delay_ms: 1000
 reload_debounce_ms: 750
+metrics_poll_timeout_ms: 250
 "#;
         let config: ProxyConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.http.listen_address, 9080);
@@ -1866,6 +1896,7 @@ reload_debounce_ms: 750
         assert_eq!(config.startup_delay_ms, 2000);
         assert_eq!(config.cluster_setup_delay_ms, 1000);
         assert_eq!(config.reload_debounce_ms, 750);
+        assert_eq!(config.metrics_poll_timeout_ms, 250);
     }
 
     #[test]
@@ -2066,6 +2097,7 @@ https:
         assert_eq!(config.startup_delay_ms, 1000);
         assert_eq!(config.cluster_setup_delay_ms, 500);
         assert_eq!(config.reload_debounce_ms, 500);
+        assert_eq!(config.metrics_poll_timeout_ms, 200);
     }
 
     #[test]

--- a/src/proxy/sozu/channel.rs
+++ b/src/proxy/sozu/channel.rs
@@ -94,3 +94,106 @@ pub(super) fn send_to_worker(
         }
     }
 }
+
+#[cfg(test)]
+mod repro_tests {
+    //! Reproduction harness for the production incident where Sōzune froze all
+    //! traffic. These tests drive the *real* `Channel::generate(1000, 10000)`
+    //! pair (same buffer sizes as production) to observe, not assume, what the
+    //! command channel does when (a) a worker reply exceeds the 10000-byte back
+    //! buffer and (b) a worker stays silent. The goal is to confirm the root
+    //! cause before any fix is written.
+
+    use super::*;
+    use crate::config::default_metrics_poll_timeout_ms;
+    use std::time::Instant;
+
+    /// (a) A reply larger than `max_buffer_size` (10000 bytes, the prod value)
+    /// surfaces the exact "too large for back buffer capacity" error we saw in
+    /// production — observed to be raised on the WORKER's WRITE, not on
+    /// Sōzune's read. The oversized frame never leaves the worker, so from
+    /// Sōzune's side the worker simply goes silent (see test b for the freeze
+    /// this silence then causes).
+    #[test]
+    fn oversized_worker_reply_fails_on_worker_write_with_back_buffer_error() {
+        let (_command, mut proxy) = Channel::<WorkerRequest, WorkerResponse>::generate(1000, 10000)
+            .expect("generate channel pair");
+        // The proxy-side channel is the worker's view; blocking so the write
+        // path mirrors a real worker emitting its reply.
+        proxy.blocking().expect("set proxy side blocking");
+
+        // A reply whose serialized size exceeds 10000 bytes by stuffing the
+        // `message` field — mirrors a fat WorkerMetrics payload growing past the
+        // ceiling as entrypoints accumulate. 12_000 bytes -> message_len 12033.
+        let huge = WorkerResponse {
+            id: "HTTP-metrics-repro".to_string(),
+            status: ResponseStatus::Ok as i32,
+            message: "x".repeat(12_000),
+            content: None,
+        };
+
+        let err = proxy
+            .write_message(&huge)
+            .expect_err("oversized reply must be rejected by the channel");
+        let msg = err.to_string();
+        println!("[repro a] worker write error = {msg}");
+
+        // Confirm it is the exact production error.
+        assert!(
+            msg.contains("too large for back buffer capacity"),
+            "expected back-buffer-capacity error, got: {msg}"
+        );
+    }
+
+    /// (b) A silent worker makes the blocking read consume its entire deadline.
+    /// poll_worker_metrics calls this for BOTH workers, so a 2000ms deadline
+    /// means up to ~4s of frozen select! loop per poll cycle.
+    #[test]
+    fn silent_worker_burns_the_full_blocking_deadline() {
+        let (mut command, _proxy) = Channel::<WorkerRequest, WorkerResponse>::generate(1000, 10000)
+            .expect("generate channel pair");
+        // _proxy stays alive but never replies.
+
+        let started = Instant::now();
+        let result = command.read_message_blocking_timeout(Some(Duration::from_millis(2000)));
+        let elapsed = started.elapsed();
+        println!("[repro b] elapsed={elapsed:?} result={result:?}");
+
+        assert!(result.is_err(), "silent worker must time out");
+        assert!(
+            elapsed >= Duration::from_millis(1900),
+            "expected ~2s blocking wait, got {elapsed:?}"
+        );
+    }
+
+    /// Regression guard for the freeze fix: with the *default* metrics poll
+    /// timeout, a silent worker must release the loop quickly (well under the
+    /// old 2s), so a metrics hiccup can never monopolize the proxying loop.
+    /// Mirrors the read poll_worker_metrics performs, bounded by the config
+    /// default. Fails fast if anyone restores a multi-second deadline.
+    #[test]
+    fn default_poll_timeout_bounds_a_silent_worker_to_well_under_two_seconds() {
+        let default_ms = default_metrics_poll_timeout_ms();
+        assert!(
+            default_ms <= 500,
+            "default metrics poll timeout regressed to {default_ms}ms; \
+             a long blocking deadline re-introduces the freeze"
+        );
+
+        let (mut command, _proxy) = Channel::<WorkerRequest, WorkerResponse>::generate(1000, 10000)
+            .expect("generate channel pair");
+
+        let started = Instant::now();
+        let result = command.read_message_blocking_timeout(Some(Duration::from_millis(default_ms)));
+        let elapsed = started.elapsed();
+        println!("[regression] default={default_ms}ms elapsed={elapsed:?} result={result:?}");
+
+        assert!(result.is_err(), "silent worker must still time out");
+        // The blocking read has a 100ms internal poll granularity, so allow a
+        // little slack above the deadline, but it must stay far below the old 2s.
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "poll did not release the loop fast enough: {elapsed:?}"
+        );
+    }
+}

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -491,6 +491,7 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
     let https_port = config.https.listen_address;
     let cluster_setup_delay_ms = config.cluster_setup_delay_ms;
     let reload_debounce = Duration::from_millis(config.reload_debounce_ms);
+    let metrics_poll_timeout = Duration::from_millis(config.metrics_poll_timeout_ms);
 
     // Now that every worker is up and the static ACME cluster has been
     // registered, fold the three command channels into a single `Channels`
@@ -570,8 +571,22 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
 
                             let mut merged = std::collections::BTreeMap::new();
                             for (proxy_metrics, name) in [
-                                (poll_worker_metrics(&mut channels.http, "HTTP"), "HTTP"),
-                                (poll_worker_metrics(&mut channels.https, "HTTPS"), "HTTPS"),
+                                (
+                                    poll_worker_metrics(
+                                        &mut channels.http,
+                                        "HTTP",
+                                        metrics_poll_timeout,
+                                    ),
+                                    "HTTP",
+                                ),
+                                (
+                                    poll_worker_metrics(
+                                        &mut channels.https,
+                                        "HTTPS",
+                                        metrics_poll_timeout,
+                                    ),
+                                    "HTTPS",
+                                ),
                             ] {
                                 debug!("metrics: {} worker returned {} keys", name, proxy_metrics.len());
                                 for (k, v) in proxy_metrics {
@@ -1432,6 +1447,7 @@ fn remove_udp_entrypoint(udp_channels: &mut L4Channels, cluster_id: &str, entryp
 fn poll_worker_metrics(
     channel: &mut Channel<WorkerRequest, WorkerResponse>,
     name: &str,
+    timeout: Duration,
 ) -> std::collections::BTreeMap<String, sozu_command_lib::proto::command::FilteredMetrics> {
     let id = format!("{}-metrics-{}", name, metrics_snapshot::now_unix());
     let request = WorkerRequest {
@@ -1456,7 +1472,7 @@ fn poll_worker_metrics(
         return Default::default();
     }
 
-    let deadline = std::time::Instant::now() + Duration::from_millis(2000);
+    let deadline = std::time::Instant::now() + timeout;
     loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {


### PR DESCRIPTION
## Incident

In production, Sōzune froze **all** traffic (HTTP + HTTPS, every domain) until a restart. The logs were flooded with `Could not write message HTTPS-metrics-… too large for back buffer capacity (1000 bytes, max 10000 bytes)`.

## Root cause

`poll_worker_metrics` reads the worker reply with a **blocking** wait of up to **2s**, *inside the same `select!` loop* that accepts traffic and applies certificates. When a worker goes silent — e.g. its metrics reply outgrows the command channel's 10000-byte back buffer and the worker can't write it — each poll cycle monopolizes that loop for up to ~4s (2s × 2 workers, every 5s), so no connection is accepted. The `back buffer capacity` spam was the symptom; the blocking poll was what actually froze proxying.

Separate command channels per concern are not possible: Sōzu exposes a single channel per worker (`Server::new`), and `Channel` is neither `Send` nor `Clone`.

## Fix

Make the per-worker metrics poll deadline **short and configurable** instead of a hardcoded 2s:

- new `proxy.metrics_poll_timeout_ms` (default **200ms**) + `SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS` override, following the `reload_debounce_ms` pattern
- worst-case loop stall drops from ~4s to ~0.4s; metrics are kept

## Reproduction & tests

Added a reproduction harness driving the real `Channel::generate(1000, 10000)` pair:

- oversized reply surfaces the exact production error (`max 10000 bytes`) on the worker's write
- a silent worker burns the full 2s blocking deadline (the freeze)
- regression guard: with the default timeout the loop is released in ~200ms

Validation: 598 tests pass, `cargo fmt` clean, `clippy` clean. Also confirmed end-to-end with a scaled Docker metrics lab (32 backends), where the metrics payload measured 4370 bytes — well under the 10000-byte ceiling, consistent with the production overflow building up over 64 entrypoints and hours of uptime.

## Follow-ups (not in this PR)

- `send_to_worker` (config/frontends) shares the same 2s blocking pattern — lower exposure, same class of risk
- raising the channel back buffer ceiling would push the overflow further out at the source