### PR TITLE
fix(proxy): make the command channel back buffer ceiling configurable

### DIFF
--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -120,6 +120,7 @@ providers:
 | `proxy.cluster_setup_delay_ms` | `500` | Delay between cluster setup commands |
 | `proxy.reload_debounce_ms` | `500` | Debounce window, in ms, applied to reload signals. A reload runs only after this many ms of silence, coalescing bursts of container start/stop events into one reload |
 | `proxy.metrics_poll_timeout_ms` | `200` | Per-worker deadline, in ms, for a metrics poll round-trip. Keep it short: the poll shares the loop that accepts traffic and applies certificates, so a slow or silent worker must not be allowed to block proxying |
+| `proxy.command_buffer_max_bytes` | `65536` | Maximum size, in bytes, the Sōzu command channel back buffer may grow to. A single command or worker reply larger than this is rejected; raise it if you have a very large number of entrypoints |
 
 ## Middleware
 
@@ -145,6 +146,7 @@ Every field above can be overridden through an environment variable. The env var
 | `proxy.cluster_setup_delay_ms` | `SOZUNE_PROXY_CLUSTER_SETUP_DELAY_MS` |
 | `proxy.reload_debounce_ms` | `SOZUNE_PROXY_RELOAD_DEBOUNCE_MS` |
 | `proxy.metrics_poll_timeout_ms` | `SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS` |
+| `proxy.command_buffer_max_bytes` | `SOZUNE_PROXY_COMMAND_BUFFER_MAX_BYTES` |
 | `api.enabled` | `SOZUNE_API_ENABLED` |
 | `api.listen_address` | `SOZUNE_API_LISTEN_ADDRESS` |
 | `dashboard.enabled` | `SOZUNE_DASHBOARD_ENABLED` |

--- a/src/config.rs
+++ b/src/config.rs
@@ -485,6 +485,18 @@ pub struct ProxyConfig {
         deserialize_with = "deserialize_metrics_poll_timeout_ms_with_env"
     )]
     pub metrics_poll_timeout_ms: u64,
+    /// Maximum size, in bytes, the Sōzu command channel back buffer may grow to.
+    /// The channel carries config commands and worker replies (including the
+    /// metrics reply); a single frame larger than this ceiling is rejected with
+    /// a "too large for back buffer capacity" error and never reaches the peer.
+    /// The production incident hit the old 10000-byte ceiling once the metrics
+    /// reply grew past it. Defaults to 65536, well above any realistic command
+    /// or metrics frame, while still bounding memory per channel.
+    #[serde(
+        default = "default_command_buffer_max_bytes",
+        deserialize_with = "deserialize_command_buffer_max_bytes_with_env"
+    )]
+    pub command_buffer_max_bytes: u64,
     /// CIDRs of reverse-proxies that sit in front of Sōzune and are trusted
     /// to set `X-Forwarded-For`. **Empty by default** — when no entry is
     /// configured, Sōzune ignores `X-Forwarded-For` entirely and treats the
@@ -779,6 +791,7 @@ impl Default for ProxyConfig {
             cluster_setup_delay_ms: default_cluster_setup_delay_ms(),
             reload_debounce_ms: default_reload_debounce_ms(),
             metrics_poll_timeout_ms: default_metrics_poll_timeout_ms(),
+            command_buffer_max_bytes: default_command_buffer_max_bytes(),
             trusted_proxies: Vec::new(),
         }
     }
@@ -806,6 +819,10 @@ fn default_reload_debounce_ms() -> u64 {
 
 pub(crate) fn default_metrics_poll_timeout_ms() -> u64 {
     200
+}
+
+pub(crate) fn default_command_buffer_max_bytes() -> u64 {
+    65536
 }
 
 fn default_api_listen_address() -> String {
@@ -1157,6 +1174,12 @@ deserialize_with_env!(
     "SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS",
     u64,
     default_metrics_poll_timeout_ms
+);
+deserialize_with_env!(
+    deserialize_command_buffer_max_bytes_with_env,
+    "SOZUNE_PROXY_COMMAND_BUFFER_MAX_BYTES",
+    u64,
+    default_command_buffer_max_bytes
 );
 
 deserialize_bool_with_env!(
@@ -1564,6 +1587,9 @@ impl ProxyConfig {
         if let Some(v) = env_parse::<u64>("SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS") {
             self.metrics_poll_timeout_ms = v;
         }
+        if let Some(v) = env_parse::<u64>("SOZUNE_PROXY_COMMAND_BUFFER_MAX_BYTES") {
+            self.command_buffer_max_bytes = v;
+        }
     }
 }
 
@@ -1828,6 +1854,7 @@ acme:
         assert_eq!(default_cluster_setup_delay_ms(), 500);
         assert_eq!(default_reload_debounce_ms(), 500);
         assert_eq!(default_metrics_poll_timeout_ms(), 200);
+        assert_eq!(default_command_buffer_max_bytes(), 65536);
     }
 
     #[test]
@@ -1871,6 +1898,7 @@ acme:
                 "SOZUNE_PROXY_CLUSTER_SETUP_DELAY_MS",
                 "SOZUNE_PROXY_RELOAD_DEBOUNCE_MS",
                 "SOZUNE_PROXY_METRICS_POLL_TIMEOUT_MS",
+                "SOZUNE_PROXY_COMMAND_BUFFER_MAX_BYTES",
             ] {
                 std::env::remove_var(k);
             }
@@ -1887,6 +1915,7 @@ startup_delay_ms: 2000
 cluster_setup_delay_ms: 1000
 reload_debounce_ms: 750
 metrics_poll_timeout_ms: 250
+command_buffer_max_bytes: 131072
 "#;
         let config: ProxyConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.http.listen_address, 9080);
@@ -1897,6 +1926,7 @@ metrics_poll_timeout_ms: 250
         assert_eq!(config.cluster_setup_delay_ms, 1000);
         assert_eq!(config.reload_debounce_ms, 750);
         assert_eq!(config.metrics_poll_timeout_ms, 250);
+        assert_eq!(config.command_buffer_max_bytes, 131072);
     }
 
     #[test]
@@ -2098,6 +2128,7 @@ https:
         assert_eq!(config.cluster_setup_delay_ms, 500);
         assert_eq!(config.reload_debounce_ms, 500);
         assert_eq!(config.metrics_poll_timeout_ms, 200);
+        assert_eq!(config.command_buffer_max_bytes, 65536);
     }
 
     #[test]

--- a/src/proxy/sozu/channel.rs
+++ b/src/proxy/sozu/channel.rs
@@ -105,7 +105,7 @@ mod repro_tests {
     //! cause before any fix is written.
 
     use super::*;
-    use crate::config::default_metrics_poll_timeout_ms;
+    use crate::config::{default_command_buffer_max_bytes, default_metrics_poll_timeout_ms};
     use std::time::Instant;
 
     /// (a) A reply larger than `max_buffer_size` (10000 bytes, the prod value)
@@ -195,5 +195,39 @@ mod repro_tests {
             elapsed < Duration::from_millis(800),
             "poll did not release the loop fast enough: {elapsed:?}"
         );
+    }
+
+    /// With the raised default ceiling, a reply that overflowed the old
+    /// 10000-byte buffer (the prod incident) now fits and round-trips cleanly.
+    /// Pairs with repro (a): same 12_000-byte payload, but written and read back
+    /// successfully instead of being rejected.
+    #[test]
+    fn raised_ceiling_lets_a_formerly_oversized_reply_round_trip() {
+        let max = default_command_buffer_max_bytes();
+        assert!(
+            max > 10_000,
+            "ceiling must exceed the old 10000-byte limit, got {max}"
+        );
+
+        let (mut command, mut proxy) =
+            Channel::<WorkerRequest, WorkerResponse>::generate(1000, max)
+                .expect("generate channel pair");
+        proxy.blocking().expect("set proxy side blocking");
+
+        let reply = WorkerResponse {
+            id: "HTTP-metrics-repro".to_string(),
+            status: ResponseStatus::Ok as i32,
+            message: "x".repeat(12_000),
+            content: None,
+        };
+        proxy
+            .write_message(&reply)
+            .expect("reply now fits under the raised ceiling");
+
+        let got = command
+            .read_message_blocking_timeout(Some(Duration::from_millis(500)))
+            .expect("reply round-trips under the raised ceiling");
+        assert_eq!(got.id, "HTTP-metrics-repro");
+        assert_eq!(got.message.len(), 12_000);
     }
 }

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -244,9 +244,10 @@ fn spawn_tcp_workers(
                     )
                 })?;
 
-        let (mut command, proxy_chan) = Channel::generate(1000, 10000).map_err(|e| {
-            anyhow::anyhow!("Could not create TCP channel for `{}`: {}", tcp_cfg.name, e)
-        })?;
+        let (mut command, proxy_chan) = Channel::generate(1000, config.command_buffer_max_bytes)
+            .map_err(|e| {
+                anyhow::anyhow!("Could not create TCP channel for `{}`: {}", tcp_cfg.name, e)
+            })?;
 
         let listener_name = tcp_cfg.name.clone();
         let handle = thread::spawn(move || {
@@ -314,9 +315,10 @@ fn spawn_udp_workers(
                     )
                 })?;
 
-        let (mut command, proxy_chan) = Channel::generate(1000, 10000).map_err(|e| {
-            anyhow::anyhow!("Could not create UDP channel for `{}`: {}", udp_cfg.name, e)
-        })?;
+        let (mut command, proxy_chan) = Channel::generate(1000, config.command_buffer_max_bytes)
+            .map_err(|e| {
+                anyhow::anyhow!("Could not create UDP channel for `{}`: {}", udp_cfg.name, e)
+            })?;
 
         let listener_name = udp_cfg.name.clone();
         let listener_port = udp_cfg.listen;
@@ -424,10 +426,12 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
         .map_err(|e| anyhow::anyhow!("Could not create HTTPS listener: {}", e))?;
 
     // Create communication channels
-    let (mut command_channel, proxy_channel) = Channel::generate(1000, 10000)
+    let command_buffer_max_bytes = config.command_buffer_max_bytes;
+    let (mut command_channel, proxy_channel) = Channel::generate(1000, command_buffer_max_bytes)
         .map_err(|e| anyhow::anyhow!("Could not create HTTP channel: {}", e))?;
-    let (mut command_channel_https, proxy_channel_https) = Channel::generate(1000, 10000)
-        .map_err(|e| anyhow::anyhow!("Could not create HTTPS channel: {}", e))?;
+    let (mut command_channel_https, proxy_channel_https) =
+        Channel::generate(1000, command_buffer_max_bytes)
+            .map_err(|e| anyhow::anyhow!("Could not create HTTPS channel: {}", e))?;
 
     let worker_http_handle = thread::spawn(move || {
         if let Err(e) =


### PR DESCRIPTION
## Context

Follow-up to #101. That PR stopped an oversized metrics reply from **freezing** proxying. This PR addresses the same incident's root trigger: the overflow itself.

## Problem

The Sōzu command channel is created with a hardcoded 10000-byte back buffer ceiling (`Channel::generate(1000, 10000)`) at all four worker sites (TCP/UDP/HTTP/HTTPS). When a frame — notably the worker metrics reply — grows past 10000 bytes, it is rejected with `too large for back buffer capacity` and never reaches the peer. In production this happened once the metrics reply outgrew the ceiling over many entrypoints and hours of uptime.

## Fix

Make the ceiling configurable with a generous default:

- new `proxy.command_buffer_max_bytes` (default **65536**) + `SOZUNE_PROXY_COMMAND_BUFFER_MAX_BYTES` override, following the same pattern as `metrics_poll_timeout_ms`
- applied to all four `Channel::generate` sites
- the initial buffer stays at 1000 bytes and grows on demand up to the ceiling, so memory is unchanged in the common case

This is complementary to #101: #101 ensures an overflow can't freeze the proxy; this PR pushes the overflow point far past any realistic frame so it stops happening in the first place.

## Tests

- new repro test: a 12_000-byte reply that is rejected at the old 10000 ceiling now round-trips cleanly under the raised default
- existing repro tests keep `10000` on purpose (they reproduce the historical prod ceiling)
- config defaults/override/YAML coverage extended for the new field

Validation: 599 tests pass, `cargo fmt` clean, `clippy` clean.