### PR TITLE
chore(build): frozen lockfile in make build-dashboard + align biome schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: build-dashboard
 	cargo build --release
 
 build-dashboard:
-	cd dashboard && bun install && bun run build
+	cd dashboard && bun install --frozen-lockfile && bun run build
 
 docker-build:
 	docker build -t $(IMAGE):$(TAG) -t $(IMAGE):$(VERSION) .

--- a/dashboard/biome.json
+++ b/dashboard/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Why

Two related build-determinism fixes spotted while building the image.

### 1. `make build-dashboard` could silently bump dependencies

The Makefile ran `bun install` (non-frozen), while both CI (`bun install --frozen-lockfile`) and the Dockerfile (`bun install --frozen-lockfile`) pin the lockfile. So a local `make build-dashboard` / `make docker-build` could resolve newer versions allowed by `^` ranges and rewrite `bun.lock` — a build silently mutating dependencies. Aligned the Makefile to `--frozen-lockfile` so no build path touches the lock; only a deliberate `bun install` does.

### 2. `biome.json` schema lagged the locked Biome version

`bun.lock` resolves `@biomejs/biome` to `2.4.16`, but `biome.json` still referenced the `2.4.13` schema, so `bun run lint` emitted a version-mismatch info. Bumped the schema URL to `2.4.16` to match what is actually installed. `bun run lint` is now clean.

## Validation

- `bun run lint` → clean, no info
- `bun install --frozen-lockfile` → no changes to `bun.lock`