### PR TITLE
ci: save rust-cache only from main to protect the cache quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,11 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      # save-if: only main writes the cache; PRs restore it. Keeps PR branches
+      # from filling the 10 GB per-repo cache quota (and evicting each other).
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Rust format
         run: cargo fmt -- --check
@@ -62,6 +66,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cargo test
         run: cargo test --bin sozune
@@ -83,6 +89,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cargo build (release)
         run: cargo build --release --locked


### PR DESCRIPTION
## Why

The CI already uses `Swatinem/rust-cache@v2`, but every job saved the cache on every run — including PR branches. With GitHub's 10 GB per-repo cache limit and LRU eviction, PR branches compete for the quota and evict each other's (and main's) caches.

## Change

Add `save-if: ${{ github.ref == 'refs/heads/main' }}` to the three cached jobs (lint, test, build). PRs now **restore** the cache but only **main** writes it — the pattern documented by rust-cache and used by axum.

## Source

- README Swatinem/rust-cache — `save-if` guidance for additive/PR jobs
- GitHub Actions cache docs — 10 GB/repo limit, LRU eviction
- axum CI uses `save-if: ${{ github.ref == 'refs/heads/main' }}`