### PR TITLE
Add dedicated metrics listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this project will be documented in this file.
 
 - Optional auth header on outgoing fetches — `providers.http.auth.header` and `auth.value` send an arbitrary header (typically `Authorization: Bearer <token>`) with every poll. Useful when the upstream config service sits behind its own auth layer.
 
+### Observability
+
+- Dedicated `/metrics` listener — scrape Prometheus metrics without enabling (or exposing) the admin API. Enable with `metrics.enabled: true` (or `SOZUNE_METRICS_ENABLED=true`); binds `127.0.0.1:3039` by default (`metrics.listen_address` / `SOZUNE_METRICS_LISTEN_ADDRESS`). Off by default. When the API is also enabled, `/metrics` keeps being served there too, unchanged. See [Observability docs](documentation/advanced/observability.md#the-metrics-endpoint).
+
 ### Providers
 
 - Ring provider — discover entrypoints from a [Ring](https://github.com/kemeter/ring) cluster (a lightweight container / microVM orchestrator). Enable with `providers.ring` (`endpoint`, optional `token`, `poll_interval`, `expose_by_default`); Sōzune polls Ring's `GET /deployments` HTTP API, turns each deployment's `sozune.*` labels into routes, and fans a multi-replica deployment out to one backend per running instance. Discovery is interval-based and only triggers a reload when the Ring-sourced view changes. See [Ring provider docs](documentation/providers/ring.md).

--- a/documentation/advanced/observability.md
+++ b/documentation/advanced/observability.md
@@ -4,10 +4,34 @@ Sōzune exposes a Prometheus-compatible `/metrics` endpoint so any Prometheus sc
 
 ## The `/metrics` endpoint
 
-- Path: `/metrics` on the API listener (default `:3035`)
-- Method: `GET`
+- Path: `/metrics`, method `GET`
 - Auth: **none** (Prometheus scrapers don't authenticate by default; protect the listener with TLS / network ACLs at the perimeter)
 - Re-computed on every scrape from authoritative state — no background aggregator, no stale cache
+
+`/metrics` is reachable on **two** listeners; enable whichever fits your setup:
+
+| Listener | Default address | Enable with | Use when |
+|---|---|---|---|
+| **Dedicated metrics listener** | `127.0.0.1:3039` | `metrics.enabled: true` (or `SOZUNE_METRICS_ENABLED=true`) | You want metrics **without** exposing the admin API. Independent port and flag. |
+| **API listener** | `127.0.0.1:3035` | `api.enabled: true` | The admin API is already running — `/metrics` is served there too, unchanged. |
+
+The two are independent: the dedicated listener lets you scrape Prometheus while
+keeping `api.enabled: false`. When both are on, `/metrics` is served on both
+(same handler, same values) — existing scrapers pointed at the API port keep
+working.
+
+### Configuring the dedicated metrics listener
+
+```yaml
+metrics:
+  enabled: true
+  listen_address: "127.0.0.1:3039"   # default; bind 0.0.0.0 only behind an ACL
+```
+
+Environment overrides (win over YAML): `SOZUNE_METRICS_ENABLED`,
+`SOZUNE_METRICS_LISTEN_ADDRESS`. Disabled by default. The address stays on
+loopback by default — like the API and dashboard — so nothing is exposed until
+you opt in.
 
 ### Output formats
 
@@ -151,7 +175,7 @@ docker compose -f compose.metrics.yaml up -d
 
 Then open:
 
-- Sōzune (assuming it's running on the host): `http://127.0.0.1:3035/metrics`
+- Sōzune (assuming it's running on the host): `http://127.0.0.1:3039/metrics` with the dedicated metrics listener (`metrics.enabled: true`), or `http://127.0.0.1:3035/metrics` when scraping through the API
 - Prometheus: `http://127.0.0.1:9090`
 - Grafana: `http://127.0.0.1:3000` — login `admin` / `admin`, dashboard "Sozune Overview" auto-loaded
 

--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -54,6 +54,7 @@ middleware:
 | `acme` | Let's Encrypt provisioning. |
 | `proxy` | Sōzu listeners and runtime tuning. |
 | `middleware` | Internal middleware proxy port. |
+| `metrics` | Dedicated Prometheus `/metrics` listener, independent of the API. Off by default. See [Observability](../advanced/observability.md#the-metrics-endpoint). |
 | `log` | Log output format (`text` or `json`). |
 | `tracing` | OpenTelemetry distributed tracing (OTLP export). Off by default. See [Observability](../advanced/observability.md#distributed-tracing-opentelemetry). |
 
@@ -106,6 +107,17 @@ providers:
 | `api.listen_address` | `127.0.0.1:3035` | Bind address |
 | `api.users` | `[]` | List of API users. Each entry has `name`, `hash` (hex sha256 of the password) and `role` (`admin` or `read-only`). The API refuses to start if this list is empty when `api.enabled: true`. |
 | `api.cors_origins` | `[]` | Allowed origins for CORS |
+
+## Metrics
+
+Dedicated Prometheus `/metrics` listener, independent of the API — lets you
+scrape metrics without enabling the admin API. When the API is also enabled,
+`/metrics` is served on both listeners.
+
+| Field | Default | Description |
+|---|---|---|
+| `metrics.enabled` | `false` | Enables the dedicated `/metrics` listener (`SOZUNE_METRICS_ENABLED`) |
+| `metrics.listen_address` | `127.0.0.1:3039` | Bind address (`SOZUNE_METRICS_LISTEN_ADDRESS`); keep on loopback or restrict with an ACL |
 
 ## Proxy
 

--- a/src/api/metrics_server.rs
+++ b/src/api/metrics_server.rs
@@ -1,0 +1,36 @@
+//! Dedicated `/metrics` listener.
+//!
+//! Serves only the Prometheus `/metrics` endpoint on its own port, reusing the
+//! same handler and shared [`AppState`] as the API. This lets an operator
+//! scrape metrics without enabling (or exposing) the admin API: the two are
+//! gated by independent `enabled` flags. When the API *is* enabled it keeps
+//! serving `/metrics` too, so existing scrapers are unaffected.
+
+use crate::api::server::AppState;
+use crate::config::MetricsConfig;
+use axum::Router;
+use axum::routing::get;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use tracing::info;
+
+pub async fn serve(config: MetricsConfig, state: AppState) -> anyhow::Result<()> {
+    let app = Router::new()
+        .route("/metrics", get(crate::api::metrics::metrics))
+        .with_state(state);
+
+    let addr = SocketAddr::from_str(&config.listen_address).map_err(|e| {
+        anyhow::anyhow!(
+            "Invalid metrics listen address '{}': {}",
+            config.listen_address,
+            e
+        )
+    })?;
+
+    info!("Metrics listening on http://{}/metrics", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod auth;
 pub(crate) mod config_view;
 pub(crate) mod metrics;
+pub(crate) mod metrics_server;
 pub(crate) mod server;

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,9 @@ pub struct AppConfig {
     pub middleware: MiddlewareConfig,
     #[serde(default)]
     pub dashboard: DashboardConfig,
+    /// Dedicated `/metrics` listener, independent of the API. Disabled by default.
+    #[serde(default)]
+    pub metrics: MetricsConfig,
     /// Logging output configuration (text vs JSON).
     #[serde(default)]
     pub log: LogConfig,
@@ -593,6 +596,37 @@ impl Default for DashboardConfig {
 
 fn default_dashboard_listen_address() -> String {
     "127.0.0.1:3038".to_string()
+}
+
+/// Dedicated `/metrics` listener, independent of the API.
+///
+/// `/metrics` is also served by the API listener when the API is enabled, but
+/// that couples scraping to running (and exposing) the admin API. This lets an
+/// operator expose only Prometheus metrics — its own port, its own `enabled`
+/// flag — without turning on the rest of the API.
+#[derive(Deserialize, Debug, Clone)]
+pub struct MetricsConfig {
+    #[serde(default, deserialize_with = "deserialize_metrics_enabled_with_env")]
+    pub enabled: bool,
+    #[serde(
+        default = "default_metrics_listen_address",
+        deserialize_with = "deserialize_metrics_listen_address_with_env"
+    )]
+    pub listen_address: String,
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_address: default_metrics_listen_address(),
+        }
+    }
+}
+
+fn default_metrics_listen_address() -> String {
+    // 3035 API, 3036 ACME challenge, 3037 middleware, 3038 dashboard → 3039.
+    "127.0.0.1:3039".to_string()
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -1209,6 +1243,16 @@ deserialize_string_with_env!(
     "SOZUNE_DASHBOARD_LISTEN_ADDRESS",
     default_dashboard_listen_address
 );
+deserialize_bool_with_env!(
+    deserialize_metrics_enabled_with_env,
+    "SOZUNE_METRICS_ENABLED",
+    false
+);
+deserialize_string_with_env!(
+    deserialize_metrics_listen_address_with_env,
+    "SOZUNE_METRICS_LISTEN_ADDRESS",
+    default_metrics_listen_address
+);
 
 fn env_bool(var: &str) -> Option<bool> {
     std::env::var(var)
@@ -1239,6 +1283,7 @@ impl AppConfig {
         self.proxy.apply_env_overrides();
         self.middleware.apply_env_overrides();
         self.dashboard.apply_env_overrides();
+        self.metrics.apply_env_overrides();
         self.log.apply_env_overrides();
         self.tracing.apply_env_overrides();
 
@@ -1593,6 +1638,17 @@ impl DashboardConfig {
     }
 }
 
+impl MetricsConfig {
+    fn apply_env_overrides(&mut self) {
+        if let Some(v) = env_bool("SOZUNE_METRICS_ENABLED") {
+            self.enabled = v;
+        }
+        if let Some(v) = env_string("SOZUNE_METRICS_LISTEN_ADDRESS") {
+            self.listen_address = v;
+        }
+    }
+}
+
 impl AcmeConfig {
     fn apply_env_overrides(&mut self) {
         if let Some(v) = env_bool("SOZUNE_ACME_ENABLED") {
@@ -1789,6 +1845,24 @@ acme:
         let acme = config.acme.expect("acme present in YAML");
         assert_eq!(acme.email, "override@example.com");
         assert!(acme.enabled, "yaml-only fields untouched");
+    }
+
+    #[test]
+    fn apply_env_overrides_enables_metrics_listener_without_yaml() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::new(&[
+            ("SOZUNE_METRICS_ENABLED", "true"),
+            ("SOZUNE_METRICS_LISTEN_ADDRESS", "0.0.0.0:9100"),
+        ]);
+
+        // Env-only deployment: no config file, so `apply_env_overrides` is the
+        // only path that can turn the metrics listener on.
+        let mut config = AppConfig::default();
+        assert!(!config.metrics.enabled, "disabled by default");
+        config.apply_env_overrides();
+
+        assert!(config.metrics.enabled, "env enables the metrics listener");
+        assert_eq!(config.metrics.listen_address, "0.0.0.0:9100");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,20 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
         request_metrics: Arc::clone(&request_metrics_store),
         config: Arc::new(config.clone()),
     };
+    // Dedicated `/metrics` listener — independent of the API, so metrics can be
+    // scraped without enabling/exposing the admin API. Reuses the same state and
+    // handler; clone the state before `api_task` moves the original.
+    let metrics_config = config.metrics.clone();
+    let metrics_state = api_state.clone();
+    let metrics_task = tokio::spawn(async move {
+        if metrics_config.enabled {
+            info!("Starting Metrics server");
+            api::metrics_server::serve(metrics_config, metrics_state).await?;
+        }
+
+        Ok::<(), anyhow::Error>(())
+    });
+
     let api_task = tokio::spawn(async move {
         if api_config.enabled {
             info!("Starting API server");
@@ -382,6 +396,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let secondary_tasks_future = async {
         tokio::try_join!(
             api_task,
+            metrics_task,
             dashboard_task,
             provider_task,
             acme_task,
@@ -403,11 +418,16 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
         },
         result = secondary_tasks_future => {
             signal_handle.close();
-            let (api_result, dashboard_result, provider_result, acme_result, middleware_result, health_result) = result?;
+            let (api_result, metrics_result, dashboard_result, provider_result, acme_result, middleware_result, health_result) = result?;
 
             match api_result {
                 Ok(_) => debug!("API task completed successfully"),
                 Err(e) => error!("API task failed: {}", e),
+            }
+
+            match metrics_result {
+                Ok(_) => debug!("Metrics task completed successfully"),
+                Err(e) => error!("Metrics task failed: {}", e),
             }
 
             match dashboard_result {


### PR DESCRIPTION
Adds a dedicated `/metrics` listener so Prometheus can be scraped without enabling (or exposing) the admin API. Independent port and `enabled` flag; off by default, binds `127.0.0.1:3039`. When the API is also enabled, `/metrics` keeps being served there too.

Configurable via `metrics.enabled` / `metrics.listen_address` or `SOZUNE_METRICS_ENABLED` / `SOZUNE_METRICS_LISTEN_ADDRESS`.