### PR TITLE
Lifetime-ratio certificate renewal and GET /certificates endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "cheti"
 version = "0.1.0"
-source = "git+https://github.com/kemeter/cheti?rev=39987633dd4f53d1399231ec3d83225df97683c5#39987633dd4f53d1399231ec3d83225df97683c5"
+source = "git+https://github.com/kemeter/cheti?rev=dd798b850186c485d6da6a7e7a00b9e274219cb3#dd798b850186c485d6da6a7e7a00b9e274219cb3"
 dependencies = [
  "async-trait",
  "hex",
@@ -1156,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2046,7 +2046,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2603,7 +2603,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3472,7 +3472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3553,7 +3553,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3944,7 +3944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4048,6 +4048,8 @@ dependencies = [
  "sozu-command-lib",
  "sozu-lib",
  "subtle",
+ "tempfile",
+ "time",
  "tokio",
  "tower",
  "tower-http",
@@ -4151,7 +4153,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5258,7 +5260,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
 futures-util = "0.3"
 notify = "8.2.0"
 instant-acme = "0.8"
-cheti = { git = "https://github.com/kemeter/cheti", rev = "39987633dd4f53d1399231ec3d83225df97683c5" }
+cheti = { git = "https://github.com/kemeter/cheti", rev = "dd798b850186c485d6da6a7e7a00b9e274219cb3" }
 http-wasm-host = { git = "https://github.com/kemeter/http-wasm", rev = "3f82f100b1e139890657ea6c333a0092dedc9871" }
 rcgen = { version = "0.14", features = ["pem"] }
 hyper = { version = "1", features = ["client", "server", "http1"] }
@@ -53,6 +53,10 @@ mime_guess = "2"
 kube = { version = "0.99", default-features = false, features = ["client", "runtime", "rustls-tls"] }
 k8s-openapi = { version = "0.24", features = ["latest"] }
 gateway-api = "0.15"
+
+[dev-dependencies]
+tempfile = "3"
+time = "0.3"
 
 [profile.release]
 strip = true

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -172,6 +172,34 @@ export interface ProvidersResponse {
   providers: Provider[];
 }
 
+/** Lifecycle bucket for a certificate. Mirrors `CertStatus` server-side, which
+ *  derives it from the same lifetime ratio the ACME renewal uses — so the
+ *  badge here and the renewal trigger never disagree. */
+export type CertStatus = 'valid' | 'expiring' | 'expired';
+
+export interface Certificate {
+  /** Hostname recovered from the cert store directory (wildcards restored). */
+  hostname: string;
+  /** Subject Common Name, if the certificate carries one. */
+  subject_cn: string | null;
+  /** DNS names from the Subject Alternative Name extension. */
+  sans: string[];
+  /** `notBefore` as Unix epoch seconds. */
+  not_before: number;
+  /** `notAfter` as Unix epoch seconds. */
+  not_after: number;
+  /** Full lifetime in whole days. */
+  total_days: number;
+  /** Whole days until expiry; negative once expired. */
+  remaining_days: number;
+  /** Lifecycle bucket derived from the lifetime ratio. */
+  status: CertStatus;
+}
+
+export interface CertificatesResponse {
+  certificates: Certificate[];
+}
+
 export function listEntrypoints(): Promise<Entrypoint[]> {
   return request<Entrypoint[]>('/entrypoints');
 }
@@ -182,6 +210,10 @@ export function listDiagnostics(): Promise<DiagnosticsResponse> {
 
 export function listProviders(): Promise<ProvidersResponse> {
   return request<ProvidersResponse>('/providers');
+}
+
+export function listCertificates(): Promise<CertificatesResponse> {
+  return request<CertificatesResponse>('/certificates');
 }
 
 export function getEntrypoint(id: string): Promise<Entrypoint> {

--- a/dashboard/src/routes/certificates/+page.svelte
+++ b/dashboard/src/routes/certificates/+page.svelte
@@ -1,142 +1,25 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
-  import { listEntrypoints, type Entrypoint } from '$lib/api';
+  import { listCertificates, type Certificate, type CertStatus } from '$lib/api';
   import { isAuthenticated } from '$lib/auth';
 
-  let entrypoints = $state<Entrypoint[]>([]);
+  let certs = $state<Certificate[]>([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
   let poll: ReturnType<typeof setInterval> | null = null;
 
-  type CertStatus = 'valid' | 'expiring' | 'expired';
-
-  interface Cert {
-    /** Common name (primary host). */
-    cn: string;
-    /** Other hostnames on the same cert (SAN — minus the CN). */
-    san: string[];
-    issuer: string;
-    issuedAt: Date;
-    expiresAt: Date;
-    serial: string;
-    keyType: string;
-    /** Where the cert came from: ACME (auto-renewed) or a static file path. */
-    source: 'acme' | 'file';
-    sourceLabel: string;
-    /** Which entrypoint(s) serve this cert. Empty if cert exists but no
-     *  route references it (orphan). */
-    entrypoints: string[];
-  }
-
-  /** Mock certificate inventory until `GET /certificates` lands. Mixes valid,
-   *  expiring soon, and expired so the UI can demo every state. Dates are
-   *  computed from `now` so the demo always looks live. */
-  const certs = $derived.by<Cert[]>(() => {
-    const now = new Date();
-    const days = (n: number) => {
-      const d = new Date(now);
-      d.setDate(d.getDate() + n);
-      return d;
-    };
-    return [
-      {
-        cn: 'shop.demo.localhost',
-        san: [],
-        issuer: "Let's Encrypt R3",
-        issuedAt: days(-23),
-        expiresAt: days(67),
-        serial: '04:8d:e9:14:0e:1c:c7:b1:c9:5b',
-        keyType: 'ECDSA P-256',
-        source: 'acme',
-        sourceLabel: 'acme · letsencrypt',
-        entrypoints: ['Shop Frontend']
-      },
-      {
-        cn: 'api.demo.localhost',
-        san: ['api-v2.demo.localhost'],
-        issuer: "Let's Encrypt R3",
-        issuedAt: days(-67),
-        expiresAt: days(23),
-        serial: '03:b9:2e:81:7c:42:8e:0a:1f:64',
-        keyType: 'ECDSA P-256',
-        source: 'acme',
-        sourceLabel: 'acme · letsencrypt',
-        entrypoints: ['Public API']
-      },
-      {
-        cn: 'blog.demo.localhost',
-        san: [],
-        issuer: "Let's Encrypt R3",
-        issuedAt: days(-88),
-        expiresAt: days(2),
-        serial: '04:b1:5e:0c:71:35:a4:f2:c8:de',
-        keyType: 'RSA 2048',
-        source: 'acme',
-        sourceLabel: 'acme · letsencrypt',
-        entrypoints: ['Blog']
-      },
-      {
-        cn: 'admin.demo.localhost',
-        san: [],
-        issuer: 'Internal CA — kemeter',
-        issuedAt: days(-180),
-        expiresAt: days(185),
-        serial: '7f:ab:09:1c:55:9a:e4:12:00:88',
-        keyType: 'RSA 4096',
-        source: 'file',
-        sourceLabel: 'file · /etc/sozune/certs/admin.pem',
-        entrypoints: ['Admin Portal']
-      },
-      {
-        cn: 'legacy.demo.localhost',
-        san: [],
-        issuer: 'DigiCert TLS RSA SHA256 2020 CA1',
-        issuedAt: days(-410),
-        expiresAt: days(-45),
-        serial: '0a:1b:2c:3d:4e:5f:60:71:82:93',
-        keyType: 'RSA 2048',
-        source: 'file',
-        sourceLabel: 'file · /etc/sozune/certs/legacy.pem',
-        entrypoints: []
-      },
-      {
-        cn: '*.lab.demo.localhost',
-        san: [],
-        issuer: "Let's Encrypt R3",
-        issuedAt: days(-12),
-        expiresAt: days(78),
-        serial: '04:c3:7d:e9:14:0e:8b:af:5c:21',
-        keyType: 'ECDSA P-256',
-        source: 'acme',
-        sourceLabel: 'acme · letsencrypt (DNS-01)',
-        entrypoints: ['lab', 'sandbox']
-      }
-    ];
-  });
-
-  function daysLeft(c: Cert): number {
-    const ms = c.expiresAt.getTime() - Date.now();
-    return Math.ceil(ms / (1000 * 60 * 60 * 24));
-  }
-
-  function statusOf(c: Cert): CertStatus {
-    const d = daysLeft(c);
-    if (d < 0) return 'expired';
-    if (d <= 30) return 'expiring';
-    return 'valid';
-  }
-
-  function fmtDate(d: Date): string {
-    return d.toLocaleDateString(undefined, {
+  function fmtDate(epochSeconds: number): string {
+    return new Date(epochSeconds * 1000).toLocaleDateString(undefined, {
       year: 'numeric',
       month: 'short',
       day: 'numeric'
     });
   }
 
-  function fmtRelative(c: Cert): string {
-    const d = daysLeft(c);
+  /** Human-friendly remaining lifetime, from the server-computed day count. */
+  function fmtRelative(c: Certificate): string {
+    const d = c.remaining_days;
     if (d < 0) return `expired ${-d} d ago`;
     if (d === 0) return 'expires today';
     if (d === 1) return 'expires in 1 day';
@@ -149,18 +32,24 @@
     return `${y} years left`;
   }
 
+  /** SANs other than the one already shown as the primary name, so the row
+   *  doesn't repeat the hostname. */
+  function extraSans(c: Certificate): string[] {
+    const primary = c.subject_cn ?? c.hostname;
+    return c.sans.filter((s) => s !== primary);
+  }
+
   const stats = $derived({
     total: certs.length,
-    valid: certs.filter((c) => statusOf(c) === 'valid').length,
-    expiring: certs.filter((c) => statusOf(c) === 'expiring').length,
-    expired: certs.filter((c) => statusOf(c) === 'expired').length,
-    acme: certs.filter((c) => c.source === 'acme').length
+    valid: certs.filter((c) => c.status === 'valid').length,
+    expiring: certs.filter((c) => c.status === 'expiring').length,
+    expired: certs.filter((c) => c.status === 'expired').length
   });
 
   async function load(silent = false) {
     if (!silent) loading = true;
     try {
-      entrypoints = await listEntrypoints();
+      certs = (await listCertificates()).certificates;
       error = null;
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
@@ -225,58 +114,41 @@
       <tr>
         <th>Status</th>
         <th>Common name</th>
-        <th>Issuer</th>
         <th>Expires</th>
-        <th>Source</th>
-        <th>Entrypoints</th>
+        <th>Lifetime</th>
       </tr>
     </thead>
     <tbody>
-      {#each certs as cert (cert.serial)}
-        {@const status = statusOf(cert)}
-        <tr class="row-{status}">
+      {#if !loading && certs.length === 0}
+        <tr>
+          <td colspan="4" class="empty">No certificates on disk.</td>
+        </tr>
+      {/if}
+      {#each certs as cert (cert.hostname)}
+        {@const sans = extraSans(cert)}
+        <tr class="row-{cert.status}">
           <td>
-            <span class="badge badge-{status}">
-              <span class="dot dot-{status}"></span>
-              {status}
+            <span class="badge badge-{cert.status}">
+              <span class="dot dot-{cert.status}"></span>
+              {cert.status}
             </span>
           </td>
           <td>
-            <div class="cn mono">{cert.cn}</div>
-            {#if cert.san.length > 0}
+            <div class="cn mono">{cert.subject_cn ?? cert.hostname}</div>
+            {#if sans.length > 0}
               <div class="san">
-                + {cert.san.length} SAN{cert.san.length > 1 ? 's' : ''} ·
-                <span class="mono">{cert.san.join(', ')}</span>
+                + {sans.length} SAN{sans.length > 1 ? 's' : ''} ·
+                <span class="mono">{sans.join(', ')}</span>
               </div>
             {/if}
-            <div class="meta">
-              <span class="key-type">{cert.keyType}</span>
-              <span class="dot-sep">·</span>
-              <span class="serial mono" title="Serial number">SN {cert.serial.slice(0, 11)}…</span>
-            </div>
           </td>
           <td>
-            <div>{cert.issuer}</div>
-            <div class="meta">issued {fmtDate(cert.issuedAt)}</div>
+            <div class="mono">{fmtDate(cert.not_after)}</div>
+            <div class="meta meta-{cert.status}">{fmtRelative(cert)}</div>
           </td>
           <td>
-            <div class="mono">{fmtDate(cert.expiresAt)}</div>
-            <div class="meta meta-{status}">{fmtRelative(cert)}</div>
-          </td>
-          <td>
-            <span class="badge badge-source badge-source-{cert.source}">{cert.source}</span>
-            <div class="meta source-detail mono">{cert.sourceLabel.replace(/^acme · |^file · /, '')}</div>
-          </td>
-          <td>
-            {#if cert.entrypoints.length === 0}
-              <span class="muted">— no route</span>
-            {:else}
-              <div class="chips">
-                {#each cert.entrypoints as ep}
-                  <span class="chip">{ep}</span>
-                {/each}
-              </div>
-            {/if}
+            <div>{cert.total_days} days</div>
+            <div class="meta">issued {fmtDate(cert.not_before)}</div>
           </td>
         </tr>
       {/each}
@@ -394,20 +266,6 @@
     padding: 2rem !important;
   }
 
-  .chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-  .chip {
-    background: var(--bg-3);
-    color: var(--fg-1);
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 0.72rem;
-    font-family: var(--font-mono);
-  }
-
   .badge {
     display: inline-flex;
     align-items: center;
@@ -447,15 +305,6 @@
     50% { opacity: 0.4; }
   }
 
-  .badge-source {
-    background: var(--bg-3);
-    color: var(--fg-1);
-  }
-  .badge-source-acme {
-    color: var(--accent);
-    background: var(--accent-bg);
-  }
-
   .row-expired td {
     background: rgba(248, 81, 73, 0.04);
   }
@@ -485,23 +334,5 @@
   .meta-expired {
     color: var(--danger);
     font-weight: 500;
-  }
-  .dot-sep {
-    margin: 0 4px;
-    opacity: 0.5;
-  }
-  .key-type {
-    color: var(--fg-2);
-  }
-  .source-detail {
-    font-size: 0.68rem;
-    color: var(--fg-3);
-    margin-top: 4px;
-    word-break: break-all;
-  }
-
-  .muted {
-    color: var(--fg-3);
-    font-size: 0.78rem;
   }
 </style>

--- a/documentation/configuration/api.md
+++ b/documentation/configuration/api.md
@@ -234,6 +234,41 @@ curl -u admin:your-password http://localhost:3035/providers
 
 The list always contains every known provider, even when not configured, so the dashboard can render "configure me" rows next to inactive providers.
 
+### `GET /certificates`
+
+Lists the TLS certificates sōzune has on disk under `acme.certs_dir`, with the identity and expiry of each. Returns an empty list when ACME isn't configured (there is no cert store to scan). **Admin only.**
+
+```bash
+curl -u admin:your-password http://localhost:3035/certificates
+```
+
+```json
+{
+  "certificates": [
+    {
+      "hostname": "shop.example.com",
+      "subject_cn": "shop.example.com",
+      "sans": ["shop.example.com", "www.example.com"],
+      "not_before": 1750000000,
+      "not_after": 1757776000,
+      "total_days": 90,
+      "remaining_days": 47,
+      "status": "valid"
+    }
+  ]
+}
+```
+
+- `hostname`: the host the certificate is stored under (wildcards are restored from the on-disk directory name, e.g. `*.example.com`)
+- `subject_cn`: the certificate's subject Common Name, or `null` if it has none
+- `sans`: the `dNSName` entries from the Subject Alternative Name extension
+- `not_before` / `not_after`: validity window as Unix epoch seconds
+- `total_days`: the certificate's full lifetime in whole days
+- `remaining_days`: whole days until expiry; negative once expired
+- `status`: lifecycle bucket — `valid`, `expiring`, or `expired`
+
+The `status` is derived from the same lifetime-ratio rule that drives ACME renewal: a certificate is `expiring` once its remaining lifetime drops below one third of its total lifetime (capped at 30 days), so short-lived certificates (7-day, 45-day profiles) aren't flagged the moment they're issued, and the dashboard badge never disagrees with when sōzune actually renews.
+
 ### `GET /config`
 
 Read-only snapshot of the running configuration: listener ports, ACME settings, providers, the dashboard listener, and the API listener (without the user list). **Admin only.**

--- a/src/acme/inventory.rs
+++ b/src/acme/inventory.rs
@@ -1,0 +1,312 @@
+//! Read-only inventory of the certificates Sōzune has on disk.
+//!
+//! Walks `certs_dir` (the same layout [`super::AcmeManager`] writes: one
+//! `{path_safe(hostname)}/cert.pem` per host) and reports identity and expiry
+//! metadata for each certificate, so the API can list them without the proxy
+//! having to track certs in memory.
+
+use std::path::Path;
+
+use serde::Serialize;
+use tracing::warn;
+
+use super::{RENEWAL_FLOOR_DAYS, hostname_from_path};
+
+/// Lifecycle bucket for a certificate, mirroring the renewal decision so the
+/// dashboard's "expiring soon" badge and the ACME renewal trigger never
+/// disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CertStatus {
+    /// Comfortably within its lifetime.
+    Valid,
+    /// Past the lifetime-ratio renewal point but not yet expired.
+    Expiring,
+    /// `not_after` is in the past.
+    Expired,
+}
+
+/// One certificate on disk, with the metadata the API surfaces.
+///
+/// `subject_cn` and `sans` come straight from the leaf certificate, so they
+/// reflect what the cert actually covers rather than the directory name.
+/// Timestamps are Unix seconds; `total_days` / `remaining_days` are whole days.
+#[derive(Debug, Clone, Serialize)]
+pub struct CertificateInfo {
+    /// Hostname recovered from the storage directory (wildcards restored).
+    pub hostname: String,
+    /// Subject Common Name, if the certificate carries one.
+    pub subject_cn: Option<String>,
+    /// DNS names from the Subject Alternative Name extension.
+    pub sans: Vec<String>,
+    /// `notBefore` as Unix seconds.
+    pub not_before: i64,
+    /// `notAfter` as Unix seconds.
+    pub not_after: i64,
+    /// Full lifetime in whole days.
+    pub total_days: i64,
+    /// Whole days until expiry; negative once expired.
+    pub remaining_days: i64,
+    /// Lifecycle bucket derived from the lifetime ratio.
+    pub status: CertStatus,
+}
+
+/// Scan `certs_dir` and return one [`CertificateInfo`] per readable
+/// certificate, sorted by hostname for stable output.
+///
+/// Unreadable or unparseable certificates are logged and skipped rather than
+/// failing the whole listing — one bad cert on disk shouldn't blank the API.
+/// Returns an empty vec if the directory doesn't exist.
+pub async fn scan_certificates(certs_dir: &Path) -> Vec<CertificateInfo> {
+    let mut certs = Vec::new();
+
+    if !certs_dir.exists() {
+        return certs;
+    }
+
+    let mut entries = match tokio::fs::read_dir(certs_dir).await {
+        Ok(entries) => entries,
+        Err(e) => {
+            warn!("Failed to read certs directory: {}", e);
+            return certs;
+        }
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let dir_name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => name.to_string(),
+            None => continue,
+        };
+
+        let cert_path = path.join("cert.pem");
+        if !cert_path.exists() {
+            continue;
+        }
+
+        let pem = match tokio::fs::read_to_string(&cert_path).await {
+            Ok(data) => data,
+            Err(e) => {
+                warn!("Failed to read cert at {}: {}", cert_path.display(), e);
+                continue;
+            }
+        };
+
+        if let Some(info) = certificate_info(&dir_name, &pem) {
+            certs.push(info);
+        }
+    }
+
+    certs.sort_by(|a, b| a.hostname.cmp(&b.hostname));
+    certs
+}
+
+/// Build a [`CertificateInfo`] from a storage directory name and its leaf PEM.
+/// Returns `None` (with a warning) if the PEM can't be parsed.
+fn certificate_info(dir_name: &str, pem: &str) -> Option<CertificateInfo> {
+    let life = match cheti::cert_lifetime(pem) {
+        Ok(life) => life,
+        Err(e) => {
+            warn!("Skipping unparseable certificate for {}: {}", dir_name, e);
+            return None;
+        }
+    };
+
+    let status = if life.remaining_days < 0 {
+        CertStatus::Expired
+    } else if cheti::needs_renewal_ratio(pem, RENEWAL_FLOOR_DAYS) {
+        CertStatus::Expiring
+    } else {
+        CertStatus::Valid
+    };
+
+    Some(CertificateInfo {
+        hostname: hostname_from_path(dir_name),
+        subject_cn: life.subject_cn,
+        sans: life.sans,
+        not_before: life.not_before,
+        not_after: life.not_after,
+        total_days: life.total_days,
+        remaining_days: life.remaining_days,
+        status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{CertificateParams, DnType, KeyPair, SanType};
+    use std::path::PathBuf;
+    use time::{Duration, OffsetDateTime};
+
+    /// Write `{dir}/{cert_subdir}/cert.pem` for a self-signed cert that is
+    /// `lifetime_days` long and expires `expires_in_days` from now (negative ⇒
+    /// already expired). Returns nothing; the caller scans the parent dir.
+    fn write_cert(
+        dir: &std::path::Path,
+        cert_subdir: &str,
+        cn: &str,
+        sans: &[&str],
+        lifetime_days: i64,
+        expires_in_days: i64,
+    ) {
+        let not_after = OffsetDateTime::now_utc() + Duration::days(expires_in_days);
+        let not_before = not_after - Duration::days(lifetime_days);
+
+        let mut params =
+            CertificateParams::new(sans.iter().map(|s| s.to_string()).collect::<Vec<_>>()).unwrap();
+        params.not_before = not_before;
+        params.not_after = not_after;
+        params.distinguished_name.push(DnType::CommonName, cn);
+        params.subject_alt_names = sans
+            .iter()
+            .map(|s| SanType::DnsName(s.to_string().try_into().unwrap()))
+            .collect();
+
+        let key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+
+        let host_dir: PathBuf = dir.join(cert_subdir);
+        std::fs::create_dir_all(&host_dir).unwrap();
+        std::fs::write(host_dir.join("cert.pem"), cert.pem()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn scan_returns_empty_for_missing_dir() {
+        let missing = std::env::temp_dir().join("sozune-no-such-certs-dir-xyz");
+        assert!(scan_certificates(&missing).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_reports_identity_and_sorts_by_hostname() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Classic 90-day cert with 60 days left → valid.
+        write_cert(
+            tmp.path(),
+            "shop.example.com",
+            "shop.example.com",
+            &["shop.example.com", "www.example.com"],
+            90,
+            60,
+        );
+        write_cert(
+            tmp.path(),
+            "api.example.com",
+            "api.example.com",
+            &["api.example.com"],
+            90,
+            60,
+        );
+
+        let certs = scan_certificates(tmp.path()).await;
+        assert_eq!(certs.len(), 2);
+        // Sorted by hostname: api before shop.
+        assert_eq!(certs[0].hostname, "api.example.com");
+        assert_eq!(certs[1].hostname, "shop.example.com");
+
+        let shop = &certs[1];
+        assert_eq!(shop.subject_cn.as_deref(), Some("shop.example.com"));
+        assert_eq!(shop.sans, vec!["shop.example.com", "www.example.com"]);
+        assert_eq!(shop.total_days, 90);
+        assert_eq!(shop.status, CertStatus::Valid);
+    }
+
+    #[tokio::test]
+    async fn status_valid_expiring_expired_track_the_ratio() {
+        let tmp = tempfile::tempdir().unwrap();
+        // 90-day cert, 60 days left → above the 30-day floor → valid.
+        write_cert(
+            tmp.path(),
+            "valid.example",
+            "valid.example",
+            &["valid.example"],
+            90,
+            60,
+        );
+        // 90-day cert, 20 days left → below 30-day floor → expiring.
+        write_cert(
+            tmp.path(),
+            "soon.example",
+            "soon.example",
+            &["soon.example"],
+            90,
+            20,
+        );
+        // 7-day cert freshly issued (6 days left) → ratio trigger ~2.3d → still valid,
+        // which is the whole point of the ratio fix (fixed-30 would say expiring).
+        write_cert(
+            tmp.path(),
+            "short.example",
+            "short.example",
+            &["short.example"],
+            7,
+            6,
+        );
+        // Expired cert (1 day past not_after).
+        write_cert(
+            tmp.path(),
+            "dead.example",
+            "dead.example",
+            &["dead.example"],
+            90,
+            -1,
+        );
+
+        let certs = scan_certificates(tmp.path()).await;
+        let by_host = |h: &str| {
+            certs
+                .iter()
+                .find(|c| c.hostname == h)
+                .unwrap_or_else(|| panic!("missing {h}"))
+                .status
+        };
+
+        assert_eq!(by_host("valid.example"), CertStatus::Valid);
+        assert_eq!(by_host("soon.example"), CertStatus::Expiring);
+        assert_eq!(by_host("short.example"), CertStatus::Valid);
+        assert_eq!(by_host("dead.example"), CertStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn wildcard_hostname_is_restored_from_dir_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cert(
+            tmp.path(),
+            "_wildcard_.example.com",
+            "*.example.com",
+            &["*.example.com"],
+            90,
+            60,
+        );
+
+        let certs = scan_certificates(tmp.path()).await;
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].hostname, "*.example.com");
+    }
+
+    #[tokio::test]
+    async fn unparseable_cert_is_skipped_not_fatal() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_cert(
+            tmp.path(),
+            "good.example",
+            "good.example",
+            &["good.example"],
+            90,
+            60,
+        );
+        // A directory with garbage instead of a real PEM.
+        let bad = tmp.path().join("bad.example");
+        std::fs::create_dir_all(&bad).unwrap();
+        std::fs::write(bad.join("cert.pem"), "not a certificate").unwrap();
+
+        let certs = scan_certificates(tmp.path()).await;
+        // The bad one is dropped; the good one still lists.
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].hostname, "good.example");
+    }
+}

--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -1,4 +1,5 @@
 pub mod challenge_server;
+pub mod inventory;
 pub mod resolver;
 
 use std::collections::BTreeMap;
@@ -17,6 +18,13 @@ use crate::model::Entrypoint;
 
 use self::challenge_server::ChallengeState;
 use self::resolver::{Resolver, build_resolver};
+
+/// Upper bound, in days, on how early a certificate may be renewed before
+/// expiry. The renewal trigger is `min(total_lifetime / 3, RENEWAL_FLOOR_DAYS)`:
+/// the ratio adapts to short-lived certs, and this floor stops a long-lived cert
+/// from being reissued months ahead of time. Set to 30 so the common 90-day
+/// Let's Encrypt profile keeps renewing at the 30-days-left mark.
+const RENEWAL_FLOOR_DAYS: u32 = 30;
 
 /// Command sent from ACME manager to the proxy reload handler
 pub struct CertCommand {
@@ -169,7 +177,15 @@ impl AcmeManager {
         Ok(())
     }
 
-    /// Check if a hostname needs a new certificate (missing or expiring within 30 days)
+    /// Check if a hostname needs a new certificate (missing, or past the
+    /// lifetime-ratio renewal point).
+    ///
+    /// Renewal triggers once the remaining lifetime drops below one third of the
+    /// certificate's total lifetime, capped at [`RENEWAL_FLOOR_DAYS`] so a
+    /// long-lived cert isn't reissued months early. For Let's Encrypt's classic
+    /// 90-day profile this is the 30-days-left mark — identical to the previous
+    /// fixed threshold — while short-lived profiles (7-day, 45-day) no longer
+    /// renew on every poll the moment they're issued.
     async fn needs_certificate(&self, hostname: &str) -> bool {
         if Self::validate_hostname(hostname).is_err() {
             warn!("Skipping invalid hostname: {}", hostname);
@@ -182,13 +198,14 @@ impl AcmeManager {
 
         // Read and parse existing cert to check expiration
         match tokio::fs::read_to_string(&cert_path).await {
-            Ok(pem_data) => cheti::needs_renewal_checked(&pem_data, 30).unwrap_or_else(|e| {
-                warn!(
-                    "Could not parse certificate expiry, assuming renewal needed: {}",
-                    e
-                );
-                true
-            }),
+            Ok(pem_data) => cheti::needs_renewal_ratio_checked(&pem_data, RENEWAL_FLOOR_DAYS)
+                .unwrap_or_else(|e| {
+                    warn!(
+                        "Could not parse certificate expiry, assuming renewal needed: {}",
+                        e
+                    );
+                    true
+                }),
             Err(_) => true,
         }
     }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -235,6 +235,7 @@ pub async fn serve(config: ApiConfig, state: AppState) -> anyhow::Result<()> {
         )
         .route("/diagnostics", get(list_diagnostics))
         .route("/providers", get(list_providers))
+        .route("/certificates", get(list_certificates))
         .route("/config", get(crate::api::config_view::config))
         .route_layer(axum_middleware::from_fn(require_admin));
 
@@ -534,6 +535,23 @@ async fn list_providers(State(state): State<AppState>) -> (StatusCode, Json<serd
         Json(serde_json::json!({
             "providers": items,
         })),
+    )
+}
+
+/// List the certificates Sōzune has on disk, with their identity (CN/SAN),
+/// validity window, and lifecycle status. Reads `acme.certs_dir`; returns an
+/// empty list when ACME isn't configured (no cert store to scan).
+async fn list_certificates(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
+    let certs = match state.config.acme.as_ref() {
+        Some(acme) => {
+            crate::acme::inventory::scan_certificates(std::path::Path::new(&acme.certs_dir)).await
+        }
+        None => Vec::new(),
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "certificates": certs })),
     )
 }
 

--- a/tests/e2e/03-api.sh
+++ b/tests/e2e/03-api.sh
@@ -99,3 +99,31 @@ if [[ -n "$ep_id" ]]; then
 else
     fail "API create did not return an ID, skipping GET/PUT/DELETE tests"
 fi
+
+# --- GET /certificates ---------------------------------------------------
+# Auth is required, and the response is a JSON object with a `certificates`
+# array. With no ACME cert store on disk the array is empty — the shape is
+# what we lock down here; per-cert metadata is covered by Rust unit tests.
+certs_noauth_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+    "$API_URL/certificates" 2>/dev/null || echo "000")
+if [[ "$certs_noauth_status" == "401" ]]; then
+    pass "API /certificates returns 401 without auth token"
+else
+    fail "API /certificates returned $certs_noauth_status instead of 401 without auth"
+fi
+
+certs_response=$(curl -s --max-time 2 \
+    -H "$AUTH_HEADER" "$API_URL/certificates" 2>/dev/null || echo "")
+certs_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+    -H "$AUTH_HEADER" "$API_URL/certificates" 2>/dev/null || echo "000")
+if [[ "$certs_status" == "200" ]]; then
+    pass "API /certificates returns 200 with auth"
+else
+    fail "API /certificates returned $certs_status instead of 200"
+fi
+
+if echo "$certs_response" | grep -q '"certificates"'; then
+    pass "API /certificates payload exposes a certificates array"
+else
+    fail "API /certificates payload is missing the certificates key (got: $certs_response)"
+fi


### PR DESCRIPTION
## What

- **Lifetime-ratio renewal** — ACME renewal now triggers once a certificate's remaining lifetime drops below one third of its total lifetime, capped at 30 days (`src/acme/mod.rs`). Replaces the fixed 30-day threshold.
- **`GET /certificates`** — new admin-only endpoint that scans `acme.certs_dir` and reports each cert's identity (CN, SANs), validity window, lifetime, remaining days, and lifecycle status (`src/acme/inventory.rs`, `src/api/server.rs`).
- **Dashboard** — the certificates page now reads the real endpoint instead of mock data; its "expiring" badge is driven by the same ratio status the server computes.

## Why

The fixed 30-day threshold misfires on short-lived certificates. With it, a 7-day Let's Encrypt cert is "within 30 days of expiry" the moment it is issued, so it would renew on every poll; a 45-day profile renews after ~15 days of life. Scaling the trigger to each cert's own lifetime fixes that:

| lifetime | trigger |
|----------|---------|
| 7 days   | ~2 days left |
| 45 days  | 15 days left |
| 90 days  | 30 days left (unchanged) |
| 1 year   | 30 days left (floor caps it) |

The 90-day / 30-day-floor case is identical to the previous behaviour, so the common Let's Encrypt profile is unaffected. The dashboard badge and the renewal trigger share the same rule, so they never disagree.

This mirrors traefik/traefik#13352 (which moved its dashboard cert status off a static 30-day threshold to a lifetime ratio), adapted to Sōzune's ACME + dashboard split.

## Dependency

The renewal ratio, lifetime, and CN/SAN extraction live in the shared `cheti` crate (kemeter/cheti#6, #7, both merged). `Cargo.toml` is pinned to the merged `main`.

## Tests & docs

- 5 unit tests for the inventory scan (status buckets, CN/SAN, wildcard restore, unparseable-cert skip); full suite 631 passing.
- e2e: `GET /certificates` auth + response-shape assertions in `tests/e2e/03-api.sh` (suite 120 passed, 0 failed).
- `cargo fmt --check`, clippy, and dashboard `check`/`build`/`lint` all clean.
- Documented under `documentation/configuration/api.md`.

## Notes

- The dashboard drops the Issuer / Source / Entrypoints columns the mock showed: the endpoint doesn't expose that metadata yet. They can return once the backend surfaces issuer and source.
- Pre-existing doc inaccuracy (not touched here): `api.md` describes some GET endpoints as available to read-only users, but `require_admin` covers the whole protected router — those reads are admin-only. Worth a follow-up.