### PR TITLE
Bump http-wasm-host to fix http_send plugins and surface rejected analytics beacons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "http-wasm-host"
 version = "0.1.0"
-source = "git+https://github.com/kemeter/http-wasm?rev=3f82f100b1e139890657ea6c333a0092dedc9871#3f82f100b1e139890657ea6c333a0092dedc9871"
+source = "git+https://github.com/kemeter/http-wasm?rev=f70a710d686e9029eac1fe75df625057f30303ed#f70a710d686e9029eac1fe75df625057f30303ed"
 dependencies = [
  "log",
  "wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = "0.3"
 notify = "8.2.0"
 instant-acme = "0.8"
 cheti = { git = "https://github.com/kemeter/cheti", rev = "dd798b850186c485d6da6a7e7a00b9e274219cb3" }
-http-wasm-host = { git = "https://github.com/kemeter/http-wasm", rev = "3f82f100b1e139890657ea6c333a0092dedc9871" }
+http-wasm-host = { git = "https://github.com/kemeter/http-wasm", rev = "f70a710d686e9029eac1fe75df625057f30303ed" }
 rcgen = { version = "0.14", features = ["pem"] }
 hyper = { version = "1", features = ["client", "server", "http1"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "tokio", "http1"] }

--- a/src/middleware/wasm.rs
+++ b/src/middleware/wasm.rs
@@ -458,9 +458,22 @@ impl EventSink {
                 if !req.body.is_empty() {
                     builder = builder.body(req.body);
                 }
-                // Fire-and-forget: we don't surface the result, only log failures.
-                if let Err(e) = builder.send().await {
-                    warn!("wasm plugin event send failed: {e}");
+                // Fire-and-forget: we don't wait on the body, but we do surface
+                // failures. A transport error is an outright send failure; a
+                // non-2xx response means the sink reached the collector but it
+                // rejected the event (e.g. a bad website id, or an analytics
+                // backend that silently drops bot-looking traffic), which is
+                // otherwise invisible and looks like "nothing is being tracked".
+                let target = req.url.clone();
+                match builder.send().await {
+                    Ok(resp) if !resp.status().is_success() => {
+                        warn!(
+                            "wasm plugin event to {target} rejected with status {}",
+                            resp.status()
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => warn!("wasm plugin event send to {target} failed: {e}"),
                 }
             }
         });


### PR DESCRIPTION
## Changes

1. **Bump `http-wasm-host`** to the revision that always links the `http_send`/`http_fetch` imports ([http-wasm#1](https://github.com/kemeter/http-wasm/pull/1)). Without it, a plugin importing `http_send` without a configured sink (the Umami plugin's case) trapped on every request and the listener returned `502 "wasm plugin error"` for all routed traffic.

2. **Surface rejected analytics beacons.** The event sink was fire-and-forget and only logged transport errors. A non-2xx response from the collector (bad website id, an analytics backend dropping the event) was invisible and looked like "nothing is being tracked". Now a non-success status is logged at `warn`.

## Notes

Depends on http-wasm#1 being merged; the pinned rev currently points at that PR's branch. Bump to the merged main SHA once it lands.