### PR TITLE
Skip backend creation for pure-redirect entrypoints

### DIFF
--- a/src/labels/parser.rs
+++ b/src/labels/parser.rs
@@ -8,7 +8,7 @@ use crate::labels::fields::{
     path, plugin_config, plugins, ratelimit, redirect, request_match,
 };
 use crate::labels::network;
-use crate::model::{Backend, Entrypoint, EntrypointConfig, Protocol};
+use crate::model::{Backend, Entrypoint, EntrypointConfig, Protocol, RedirectPolicy};
 
 const SUPPORTED_PROTOCOLS: &[&str] = &["http", "tcp", "udp"];
 
@@ -219,14 +219,29 @@ fn build_entrypoint(
         _ => return None,
     };
 
-    let backend = match weight {
-        Some(weight) => Backend::new(backend_ip, port).with_weight(weight),
-        None => Backend::new(backend_ip, port),
+    // A permanent/unauthorized redirect answers at the frontend and never reaches
+    // a backend (see proxy::sozu — "a permanent redirect never [reaches the]
+    // backend"). Attaching one anyway registers a phantom backend that the health
+    // checker probes forever (e.g. an alias host with no `.port` falls back to
+    // `:80`, which nothing listens on) and pollutes the cluster's backend set.
+    // Forwarding redirects still proxy, so they keep their backend.
+    let is_pure_redirect = matches!(
+        redirect,
+        Some(RedirectPolicy::Permanent | RedirectPolicy::Unauthorized)
+    );
+    let backends = if is_pure_redirect {
+        Vec::new()
+    } else {
+        let backend = match weight {
+            Some(weight) => Backend::new(backend_ip, port).with_weight(weight),
+            None => Backend::new(backend_ip, port),
+        };
+        vec![backend]
     };
 
     Some(Entrypoint {
         id: format!("{protocol}_{service_name}"),
-        backends: vec![backend],
+        backends,
         name: service_name.to_string(),
         protocol: protocol_enum,
         config: EntrypointConfig {


### PR DESCRIPTION
An entrypoint whose redirect policy is `permanent` or `unauthorized` answers at the frontend and never forwards to a backend. Today the parser still attaches a `Backend` to it, which registers a phantom backend the health checker then probes forever — and if the entrypoint declares no `.port`, that backend falls back to `:80` where nothing listens, so it's reported unhealthy indefinitely and pollutes the cluster's backend set.

This skips backend creation when the redirect policy is `Permanent` or `Unauthorized`. Forwarding redirects still proxy, so they keep their backend.

Covered by the existing parser tests (25 passing); `cargo fmt` and `clippy` clean.