### PR TITLE
Add hermetic ACME e2e harness with Pebble, fixing two provisioning bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ ROADMAP.md
 .prd/
 .gstack/
 .issues/
+
+# ACME e2e: the Pebble test CA is fetched at runtime, never committed
+tests/e2e/acme/pebble-ca.pem

--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -68,6 +68,30 @@ impl Backoff {
         }
     }
 
+    /// Drop backoff state for any hostname not in `live`. Called each cycle so
+    /// an entry whose hostname left the config cannot keep the renewal loop
+    /// waking on an overdue, unactionable deadline.
+    fn retain_hostnames(&self, live: &std::collections::HashSet<&str>) {
+        if let Ok(mut failures) = self.failures.write() {
+            failures.retain(|hostname, _| live.contains(hostname.as_str()));
+        }
+    }
+
+    /// Shortest remaining backoff across all failing hostnames, or `None` when
+    /// none is waiting. The renewal loop uses this to wake up exactly when the
+    /// soonest retry is due instead of sleeping the full 12h cycle — without
+    /// it, a transient first-attempt failure (e.g. the challenge route not yet
+    /// in place at cold start) would strand a hostname for 12h even though its
+    /// backoff said 60s.
+    fn soonest_retry(&self) -> Option<Duration> {
+        let failures = self.failures.read().ok()?;
+        let now = Instant::now();
+        failures
+            .values()
+            .map(|state| state.next_attempt_at.saturating_duration_since(now))
+            .min()
+    }
+
     /// Record a failed attempt and schedule the next one. When a `retry after`
     /// instant is present (Let's Encrypt rate limiting), honor it: the next
     /// attempt is deferred until at least that time, even if the backoff
@@ -145,9 +169,17 @@ impl AcmeManager {
             error!("Initial ACME provisioning failed: {}", e);
         }
 
-        // Renewal loop: check every 12 hours OR when notified of new entrypoints
+        // Renewal loop: check every 12 hours, when notified of new entrypoints,
+        // or as soon as a failing hostname's backoff is due — otherwise a
+        // transient failure would wait out the full 12h before its 60s retry.
         let mut interval = tokio::time::interval(Duration::from_secs(12 * 3600));
         loop {
+            // A far-future default so the branch is inert when nothing is
+            // backing off; `sleep` needs a concrete duration to await.
+            let until_retry = self
+                .backoff
+                .soonest_retry()
+                .unwrap_or(Duration::from_secs(12 * 3600));
             tokio::select! {
                 _ = interval.tick() => {
                     info!("Running ACME renewal check");
@@ -156,6 +188,9 @@ impl AcmeManager {
                     // Small delay to let storage settle
                     tokio::time::sleep(Duration::from_secs(2)).await;
                     info!("Running ACME check after storage update");
+                }
+                _ = tokio::time::sleep(until_retry) => {
+                    info!("Retrying ACME provisioning after backoff");
                 }
             }
             if let Err(e) = self.provision_all().await {
@@ -204,10 +239,20 @@ impl AcmeManager {
                     }
                 }
                 false => {
+                    // No longer needs a cert (already valid, or one appeared on
+                    // disk since the last failure). Clear any stale backoff, or
+                    // the renewal loop would wake on its overdue deadline every
+                    // pass with nothing to do — a busy spin.
+                    self.backoff.record_success(hostname);
                     debug!("Certificate for {} is still valid, skipping", hostname);
                 }
             }
         }
+
+        // Drop backoff entries for hostnames no longer in the config at all, so
+        // a removed-then-failed hostname can't hold the loop awake forever.
+        let live: std::collections::HashSet<&str> = certs.iter().map(|(h, _)| h.as_str()).collect();
+        self.backoff.retain_hostnames(&live);
 
         Ok(())
     }
@@ -439,15 +484,16 @@ impl AcmeManager {
         let store = FileAccountStore::new(self.certs_dir.join(account_file_for(server_url)));
 
         match store.load() {
-            Ok(Some(credentials)) => {
-                match Account::builder()?.from_credentials(credentials).await {
-                    Ok(account) => {
-                        info!("Loaded existing ACME account");
-                        return Ok(account);
-                    }
-                    Err(e) => warn!("Failed to restore ACME account, creating new one: {}", e),
+            Ok(Some(credentials)) => match account_builder(server_url)?
+                .from_credentials(credentials)
+                .await
+            {
+                Ok(account) => {
+                    info!("Loaded existing ACME account");
+                    return Ok(account);
                 }
-            }
+                Err(e) => warn!("Failed to restore ACME account, creating new one: {}", e),
+            },
             Ok(None) => {}
             Err(e) => warn!(
                 "Failed to load account credentials, creating new one: {}",
@@ -461,7 +507,7 @@ impl AcmeManager {
             vec![format!("mailto:{}", self.config.email)]
         };
 
-        let (account, credentials) = Account::builder()?
+        let (account, credentials) = account_builder(server_url)?
             .create(
                 &NewAccount {
                     contact: &contact.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
@@ -711,6 +757,42 @@ fn split_pem_chain(pem_chain: &str) -> (String, Vec<String>) {
         .collect();
 
     (leaf, chain)
+}
+
+/// Build an ACME account builder for `server_url`, trusting a test CA when
+/// `SOZUNE_ACME_TEST_CA` points to a PEM root.
+///
+/// Public ACME directories (Let's Encrypt) are reached through the default
+/// client, which trusts the system roots. A test CA (Pebble) serves its
+/// directory over HTTPS with a self-signed root the system does not know, so
+/// e2e runs set `SOZUNE_ACME_TEST_CA` to that root's PEM and every ACME call
+/// goes through `builder_with_root`. Unset — which is always the case in
+/// production — nothing changes.
+///
+/// `builder_with_root` *replaces* the whole trust store with the given root, so
+/// the variable is refused against a public Let's Encrypt directory: an env var
+/// leaked from a test environment must never be able to weaken trust for a real
+/// CA. It only takes effect for a non-Let's-Encrypt (test) directory.
+fn account_builder(server_url: &str) -> anyhow::Result<instant_acme::AccountBuilder> {
+    match std::env::var("SOZUNE_ACME_TEST_CA") {
+        Ok(path) if !path.is_empty() => {
+            if server_url.contains("acme-v02.api.letsencrypt.org")
+                || server_url.contains("acme-staging-v02.api.letsencrypt.org")
+            {
+                anyhow::bail!(
+                    "SOZUNE_ACME_TEST_CA is set but the directory is a public Let's Encrypt \
+                     endpoint ({server_url}) — refusing to replace the trust store for a real CA. \
+                     Unset the variable, or point the resolver at a test directory."
+                );
+            }
+            let builder = Account::builder_with_root(&path).map_err(|e| {
+                anyhow::anyhow!("SOZUNE_ACME_TEST_CA `{path}` is not a usable PEM root: {e}")
+            })?;
+            warn!("ACME: trusting test CA from SOZUNE_ACME_TEST_CA=`{path}` — not for production");
+            Ok(builder)
+        }
+        _ => Ok(Account::builder()?),
+    }
 }
 
 /// Credentials filename for an ACME account, derived from the directory URL so
@@ -968,6 +1050,55 @@ mod tests {
             backoff.remaining("healthy.example.com"),
             None,
             "an unrelated hostname must not inherit a sibling's backoff"
+        );
+    }
+
+    #[test]
+    fn soonest_retry_reports_the_nearest_pending_backoff() {
+        let backoff = Backoff::default();
+        // Nothing failing → nothing to wake up for.
+        assert_eq!(backoff.soonest_retry(), None);
+
+        // One failure: the soonest retry is that hostname's first backoff step.
+        backoff.record_failure("a.example.com", None);
+        let one = backoff.soonest_retry().expect("a retry should be pending");
+        assert!(
+            one <= BACKOFF_SCHEDULE[0],
+            "first retry is bounded by the 60s step"
+        );
+
+        // A second hostname fails twice, so it backs off further; the soonest
+        // retry across both must still be the nearer (first) one.
+        backoff.record_failure("b.example.com", None);
+        backoff.record_failure("b.example.com", None);
+        let soonest = backoff.soonest_retry().expect("a retry should be pending");
+        assert!(
+            soonest <= BACKOFF_SCHEDULE[0],
+            "the loop must wake for the nearest retry, not the furthest"
+        );
+
+        // Clearing every failing hostname leaves nothing to wake for.
+        backoff.record_success("a.example.com");
+        backoff.record_success("b.example.com");
+        assert_eq!(backoff.soonest_retry(), None);
+    }
+
+    #[test]
+    fn retain_hostnames_drops_entries_no_longer_in_config() {
+        // A hostname that failed, then left the config, must not keep an
+        // overdue backoff entry alive — that would spin the renewal loop.
+        let backoff = Backoff::default();
+        backoff.record_failure("gone.example.com", None);
+        backoff.record_failure("still.example.com", None);
+
+        let live: std::collections::HashSet<&str> = ["still.example.com"].into_iter().collect();
+        backoff.retain_hostnames(&live);
+
+        assert!(backoff.remaining("still.example.com").is_some());
+        assert_eq!(
+            backoff.remaining("gone.example.com"),
+            None,
+            "a hostname dropped from config must lose its backoff entry"
         );
     }
 

--- a/tests/e2e/acme/compose.acme.yaml
+++ b/tests/e2e/acme/compose.acme.yaml
@@ -1,0 +1,65 @@
+# ACME e2e harness. Pebble (Let's Encrypt's test CA) issues a real certificate
+# to Sōzune over a real challenge, hermetically — no public ACME, no port 80 on
+# the host. Everything shares one Docker network so Pebble can resolve the test
+# domain to the Sōzune container by network alias and reach it for validation.
+services:
+  # The test CA. Serves its ACME directory on :14000 over HTTPS with a
+  # self-signed root; Sōzune trusts that root via SOZUNE_ACME_TEST_CA.
+  # httpPort/tlsPort are 80/443 (see pebble-config.json) so validation targets
+  # the same ports Sōzune actually listens on.
+  pebble:
+    image: ghcr.io/letsencrypt/pebble:latest
+    command: ["-config", "/test/config/pebble-config.json"]
+    volumes:
+      - "./pebble-config.json:/test/config/pebble-config.json:ro"
+    environment:
+      # Validate immediately instead of sleeping a random 0-15s per attempt.
+      PEBBLE_VA_NOSLEEP: "1"
+    networks:
+      default:
+    ports:
+      - "14000:14000" # ACME directory, for pulling the CA from the host
+
+  # A plain backend behind the routed hostname, so the entrypoint Sōzune
+  # provisions a cert for actually has something to serve.
+  backend:
+    image: traefik/whoami
+    networks:
+      default:
+        # Fixed IP: Sōzune's config_file backends must be IP literals (Sōzu
+        # rejects DNS-style addresses), so the entrypoint points here directly.
+        ipv4_address: 10.44.7.10
+
+  # Sōzune under test, built from the repo. Runs in the network so Pebble can
+  # reach it as `acme.test` (the alias below) on port 80 for the HTTP-01
+  # challenge.
+  sozune:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    depends_on:
+      - pebble
+      - backend
+    environment:
+      CONFIG_PATH: /config/config.yaml
+      SOZUNE_ACME_TEST_CA: /config/pebble-ca.pem
+      RUST_LOG: sozune=debug
+    volumes:
+      - "./config.acme.yaml:/config/config.yaml:ro"
+      - "./entrypoints.acme.yaml:/config/entrypoints.acme.yaml:ro"
+      - "./pebble-ca.pem:/config/pebble-ca.pem:ro"
+    networks:
+      default:
+        aliases:
+          # Pebble resolves the challenged hostname to this container.
+          - acme.test
+    ports:
+      - "18080:80"
+      - "18443:443"
+      - "18081:8081" # API, to assert the issued cert landed
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 10.44.7.0/24

--- a/tests/e2e/acme/config.acme.yaml
+++ b/tests/e2e/acme/config.acme.yaml
@@ -1,0 +1,33 @@
+# Sōzune config for the ACME e2e harness. One HTTPS entrypoint for `acme.test`,
+# backed by the whoami container, provisioned through Pebble via HTTP-01.
+providers:
+  config_file:
+    enabled: true
+    path: /config/entrypoints.acme.yaml
+  docker:
+    enabled: false
+
+api:
+  enabled: true
+  listen_address: "0.0.0.0:8081"
+  users:
+    - name: admin
+      # sha256 of "admin"
+      hash: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+      role: admin
+
+proxy:
+  http:
+    listen_address: 80
+  https:
+    listen_address: 443
+
+acme:
+  enabled: true
+  email: "e2e@acme.test"
+  certs_dir: /tmp/acme-certs
+  resolvers:
+    pebble:
+      challenge: http-01
+      # Pebble's ACME directory. Trusted via SOZUNE_ACME_TEST_CA.
+      ca_server: "https://pebble:14000/dir"

--- a/tests/e2e/acme/entrypoints.acme.yaml
+++ b/tests/e2e/acme/entrypoints.acme.yaml
@@ -1,0 +1,21 @@
+entrypoints:
+  - id: acme-site
+    name: ACME Site
+    protocol: Http
+    backends:
+      - address: "10.44.7.10"
+        port: 80
+    config:
+      hostnames:
+        - "acme.test"
+      path:
+        rule_type: Prefix
+        value: "/"
+      # tls:true routes this hostname onto the HTTPS worker and marks it for
+      # ACME; `acme.resolver` picks which resolver provisions the cert.
+      tls: true
+      acme:
+        resolver: pebble
+      strip_prefix: false
+      priority: 10
+      headers: []

--- a/tests/e2e/acme/pebble-config.json
+++ b/tests/e2e/acme/pebble-config.json
@@ -1,0 +1,12 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "test/certs/localhost/cert.pem",
+    "privateKey": "test/certs/localhost/key.pem",
+    "httpPort": 80,
+    "tlsPort": 443,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false
+  }
+}

--- a/tests/e2e/acme/run-acme.sh
+++ b/tests/e2e/acme/run-acme.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# ACME e2e harness. Boots Pebble (Let's Encrypt's test CA), a backend, and
+# Sōzune in one Docker network, then asserts Sōzune completes a real HTTP-01
+# challenge and serves the Pebble-issued certificate.
+#
+# Hermetic: no public ACME, no host port 80. Not run by run-all.sh (needs
+# Docker + a network pull); invoke directly.
+#
+# Requirements: docker (compose v2), openssl, curl
+
+set -euo pipefail
+
+ACME_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE="docker compose -p sozune-acme -f $ACME_DIR/compose.acme.yaml"
+
+PASSED=0
+FAILED=0
+pass() { echo -e "\033[0;32m[PASS]\033[0m $*"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "\033[0;31m[FAIL]\033[0m $*"; FAILED=$((FAILED + 1)); }
+log()  { echo -e "\033[1;33m[ACME]\033[0m $*"; }
+
+cleanup() {
+    log "Cleaning up..."
+    $COMPOSE down --remove-orphans --volumes >/dev/null 2>&1 || true
+    rm -f "$ACME_DIR/pebble-ca.pem"
+}
+trap cleanup EXIT
+
+# The CA file is a bind mount. If it doesn't exist when any `up` runs, Docker
+# creates a *directory* in its place, which then breaks every later run. Touch
+# it up front so the mount is always a file, and start from a clean slate.
+$COMPOSE down --remove-orphans --volumes >/dev/null 2>&1 || true
+rm -rf "$ACME_DIR/pebble-ca.pem"
+: > "$ACME_DIR/pebble-ca.pem"
+
+# --- Pebble's test CA -----------------------------------------------------
+# Sōzune must trust the root that signs Pebble's *ACME directory* endpoint,
+# which is minica (`CN=localhost` issued by `minica root ca`) — NOT the ACME
+# issuance root served at /roots/0, a different chain entirely. minica mints a
+# fresh root per image build, so extract it from the image rather than
+# committing a stale copy.
+log "Extracting Pebble's minica root..."
+cid=$(docker create ghcr.io/letsencrypt/pebble:latest 2>/dev/null)
+if ! docker cp "$cid:/test/certs/pebble.minica.pem" "$ACME_DIR/pebble-ca.pem" 2>/dev/null; then
+    docker rm "$cid" >/dev/null 2>&1 || true
+    fail "could not extract minica root from the Pebble image"
+    exit 1
+fi
+docker rm "$cid" >/dev/null 2>&1 || true
+pass "minica root extracted"
+
+# --- Pebble, then gate Sōzune on it ---------------------------------------
+# Sōzune runs its ACME check seconds after boot and only retries every 12h, so
+# it must not start before Pebble's directory answers.
+log "Starting Pebble + backend..."
+$COMPOSE up -d pebble backend >/dev/null 2>&1
+
+# The directory itself must answer before Sōzune's ACME manager fires.
+for _ in $(seq 1 30); do
+    if docker run --rm --network sozune-acme_default curlimages/curl:latest \
+        -sk --max-time 3 https://pebble:14000/dir 2>/dev/null | grep -q newOrder; then
+        break
+    fi
+    sleep 1
+done
+
+# --- Now Sōzune, with the CA in place -------------------------------------
+log "Building and starting Sōzune..."
+$COMPOSE up -d --build sozune >/dev/null 2>&1
+
+# --- Wait for the certificate ---------------------------------------------
+# Provisioning races container startup; poll the API until the cert for
+# acme.test appears, or give up.
+log "Waiting for Sōzune to provision the certificate via Pebble..."
+issued=0
+for _ in $(seq 1 60); do
+    certs=$(curl -s -u admin:admin --max-time 3 \
+        http://127.0.0.1:18081/certificates 2>/dev/null || true)
+    if [[ "$certs" == *"acme.test"* ]]; then
+        issued=1
+        break
+    fi
+    sleep 2
+done
+
+if [[ $issued -eq 1 ]]; then
+    pass "certificate for acme.test provisioned through HTTP-01"
+else
+    fail "no certificate for acme.test after 120s"
+    echo "--- last API response ---"; echo "$certs"
+    echo "--- sozune logs (tail) ---"
+    $COMPOSE logs --tail=40 sozune 2>/dev/null || true
+fi
+
+# --- The cert is actually served on 443, and it's Pebble's ----------------
+if [[ $issued -eq 1 ]]; then
+    log "Checking the served certificate..."
+    served=$(timeout 5 openssl s_client -connect 127.0.0.1:18443 \
+        -servername acme.test </dev/null 2>/dev/null |
+        openssl x509 -noout -issuer 2>/dev/null || true)
+    if [[ "$served" == *"Pebble"* || "$served" == *"minica"* ]]; then
+        pass "acme.test serves the Pebble-issued certificate on 443"
+    else
+        fail "unexpected issuer on the served cert (got: '$served')"
+    fi
+fi
+
+echo ""
+echo "=============================="
+echo -e "  \033[0;32mPassed: $PASSED\033[0m  \033[0;31mFailed: $FAILED\033[0m"
+echo "=============================="
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
Adds the first end-to-end ACME test to Sōzune: Pebble (Let's Encrypt's test CA) issues a real certificate over a real HTTP-01 challenge, hermetically — everything in Docker, no public ACME, no host port 80. Building it surfaced a provisioning bug, and reviewing the fix surfaced a second; both are fixed here.

## Why this exists

HTTP-01 and DNS-01 have run in production with no e2e coverage since they shipped. This lays down a Pebble-based harness that exercises a full issuance cycle, and is structured to extend to DNS-01 and (later) TLS-ALPN-01.

## The harness

`tests/e2e/acme/` — a self-contained Docker compose (Pebble + a backend + Sōzune on one network) and `run-acme.sh`. Not wired into `run-all.sh`: it pulls an image and builds Sōzune, so it's run on demand. It asserts Sōzune provisions a cert for the routed host and serves the Pebble-issued cert on 443.

A few integration details worth calling out:
- Sōzune trusts Pebble's directory root via a new `SOZUNE_ACME_TEST_CA` env var (see below). The root that matters is Pebble's **minica** (which signs its HTTPS directory endpoint), *not* the ACME issuance root at `/roots/0` — a distinction that cost a while to pin down.
- Pebble validates on ports 80/443 (config), and resolves the challenged host to the Sōzune container by Docker network alias, so no external DNS is involved.

## The test hook

`SOZUNE_ACME_TEST_CA`, read only in `account_builder()`. When set, ACME calls go through instant-acme's `builder_with_root` so a test PKI is trusted; unset (production) the path is byte-for-byte the old `Account::builder()`. Because `builder_with_root` *replaces* the whole trust store, the variable is refused against a public Let's Encrypt directory — a leaked test env var must never weaken trust for a real CA.

## Bug 1 — a transient failure stranded a cert for 12h

Found by the harness. The per-hostname backoff was computed (60s, 5min, 15min, …) but never consulted between cycles: the renewal loop only woke every 12h or on a new entrypoint. So a first-attempt failure — e.g. the challenge route not yet in place at cold start — waited out the full 12h before its 60s retry ever fired. Fixed by waking the loop at the soonest pending backoff.

## Bug 2 — the fix for bug 1 could spin at 100% CPU

Found in review. Waking on the soonest backoff means a due entry returns `sleep(0)`. If that entry's hostname no longer needs a cert, no success/failure is recorded, the entry lives on, and the loop busy-spins. The nastiest trigger: `save_certificate` succeeds but `cert_tx.send` fails — the attempt records a failure, yet the cert is now on disk so `needs_certificate` turns false forever. Fixed by clearing backoff when a hostname no longer needs a cert, and dropping entries for hostnames removed from config.

Both behaviours are covered by unit tests (`soonest_retry_reports_the_nearest_pending_backoff`, `retain_hostnames_drops_entries_no_longer_in_config`).

## Not committed

`tests/e2e/acme/pebble-ca.pem` is fetched at runtime (minica mints a fresh root per image build) and gitignored.
