### PR TITLE
Add ACME TLS-ALPN-01 challenge with an ALPN gate on 443

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4001,6 +4001,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -511,13 +511,14 @@ dependencies = [
 [[package]]
 name = "cheti"
 version = "0.1.0"
-source = "git+https://github.com/kemeter/cheti?rev=dd798b850186c485d6da6a7e7a00b9e274219cb3#dd798b850186c485d6da6a7e7a00b9e274219cb3"
+source = "git+https://github.com/kemeter/cheti?rev=dca6075d67a8830e6796b47d9f217394b1580880#dca6075d67a8830e6796b47d9f217394b1580880"
 dependencies = [
  "async-trait",
  "hex",
  "hickory-resolver",
  "instant-acme",
  "percent-encoding",
+ "rcgen 0.13.2",
  "reqwest",
  "secrecy",
  "serde",
@@ -1148,7 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1996,7 +1997,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "rcgen",
+ "rcgen 0.14.8",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2035,7 +2036,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2600,7 +2601,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3127,7 +3128,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3228,6 +3229,19 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
@@ -3238,7 +3252,7 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
- "yasna",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -3443,7 +3457,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3502,7 +3516,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3880,7 +3894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3971,7 +3985,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rcgen",
+ "rcgen 0.14.8",
  "reqwest",
  "rust-embed",
  "rustls",
@@ -4097,10 +4111,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5163,7 +5177,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5458,6 +5472,15 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
 futures-util = "0.3"
 notify = "8.2.0"
 instant-acme = "0.8"
-cheti = { git = "https://github.com/kemeter/cheti", rev = "dd798b850186c485d6da6a7e7a00b9e274219cb3" }
+cheti = { git = "https://github.com/kemeter/cheti", rev = "dca6075d67a8830e6796b47d9f217394b1580880" }
 http-wasm-host = { git = "https://github.com/kemeter/http-wasm", rev = "18e7f22d6441639210680db161776da1446a1db5" }
 rcgen = { version = "0.14", features = ["pem"] }
 hyper = { version = "1", features = ["client", "server", "http1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ hyper-util = { version = "0.1", features = ["client-legacy", "tokio", "http1"] }
 http-body-util = "0.1"
 base64 = "0.22"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
+# Terminates the TLS-ALPN-01 challenge handshake on the loopback responder.
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 flate2 = "1"

--- a/documentation/tls/acme.md
+++ b/documentation/tls/acme.md
@@ -19,6 +19,8 @@ acme:
       provider:
         type: cloudflare
         api_token_env: CF_API_TOKEN
+    edge:
+      challenge: tls-alpn-01
 ```
 
 | Field | Default | Description |
@@ -28,7 +30,8 @@ acme:
 | `certs_dir` | `/etc/sozune/certs` | Where certificates and the ACME account credentials are stored. |
 | `staging` | `true` | Use Let's Encrypt's staging environment (no rate limit, untrusted certs). **Switch to `false` for production.** |
 | `challenge_port` | `3036` | Port where Sōzune answers HTTP-01 challenges (loopback only). |
-| `resolvers` | `{}` | Named challenge resolvers (HTTP-01 or DNS-01 with a provider). Entrypoints reference one by name. |
+| `tls_alpn_port` | `3040` | Loopback port the TLS-ALPN-01 responder binds. Only used when a `tls-alpn-01` resolver is configured; never exposed directly. |
+| `resolvers` | `{}` | Named challenge resolvers (`http-01`, `dns-01` with a provider, or `tls-alpn-01`). Entrypoints reference one by name. |
 
 Top-level fields are overridable through `SOZUNE_ACME_*` environment variables. Provider credentials are always read from environment variables — never inlined in YAML.
 
@@ -118,6 +121,41 @@ acme:
 ```
 
 Each distinct `ca_server` keeps its own ACME account on disk (the account file is derived from the directory URL), so switching or mixing CAs never reuses an account that belongs to a different server. `ca_server` also accepts a non-Let's-Encrypt ACME directory (e.g. an internal CA).
+
+## TLS-ALPN-01 (no port 80, no DNS API)
+
+TLS-ALPN-01 ([RFC 8737](https://www.rfc-editor.org/rfc/rfc8737.html)) proves control of a hostname over the TLS handshake on port 443 itself — the CA connects with the ALPN protocol `acme-tls/1` and Sōzune answers with a challenge certificate. It needs **neither port 80** (unlike HTTP-01) **nor DNS API credentials** (unlike DNS-01), so it fits when 80 is closed and DNS-01 is not an option.
+
+```yaml
+acme:
+  enabled: true
+  email: ops@example.com
+  resolvers:
+    edge:
+      challenge: tls-alpn-01
+```
+
+```yaml
+# entrypoints, or Docker labels
+- "sozune.http.app.host=app.example.com"
+- "sozune.http.app.tls=true"
+- "sozune.http.app.acme.resolver=edge"
+```
+
+### How the listener changes
+
+Answering the challenge means intercepting the handshake on 443, which the HTTPS worker cannot do on its own. So **when — and only when — a `tls-alpn-01` resolver is configured**, Sōzune puts an ALPN-aware gate in front of 443:
+
+- the gate binds the public 443 and prereads each connection's ClientHello;
+- a handshake offering `acme-tls/1` is routed to the internal responder, which presents the challenge certificate;
+- every other connection is spliced, untouched, to the HTTPS worker (now on a loopback port).
+
+The preread neither decrypts nor consumes the connection: normal HTTPS reaches the worker exactly as before. **Without a `tls-alpn-01` resolver, none of this happens** — 443 stays a direct HTTPS listener.
+
+### Limitations
+
+- **Wildcards are not supported** (a TLS-ALPN-01 validator connects to a concrete name). Use DNS-01 for `*.example.com`.
+- All HTTPS traffic passes through the gate's preread hop while a `tls-alpn-01` resolver is active. It is a bounded, non-decrypting splice — the same mechanism as SNI-based TCP routing — but it is a hop the default HTTPS path does not have. The real client IP is preserved: the gate prepends a PROXY-v2 header the HTTPS worker consumes, so client-IP allow-lists, access logs and metrics stay accurate.
 
 ## How it works
 

--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -1,13 +1,14 @@
 pub mod challenge_server;
 pub mod inventory;
 pub mod resolver;
+pub mod tls_alpn_responder;
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use cheti::{AccountStore, Dns01Solver, FileAccountStore};
+use cheti::{AccountStore, Dns01Solver, FileAccountStore, TlsAlpn01Solver};
 use instant_acme::{Account, ChallengeType, Identifier, NewAccount, NewOrder, Order, OrderStatus};
 use rcgen::{CertificateParams, KeyPair};
 use tokio::sync::{Notify, mpsc};
@@ -18,6 +19,7 @@ use crate::model::Entrypoint;
 
 use self::challenge_server::ChallengeState;
 use self::resolver::{Resolver, build_resolver};
+use self::tls_alpn_responder::TlsAlpnResponder;
 
 /// Upper bound, in days, on how early a certificate may be renewed before
 /// expiry. The renewal trigger is `min(total_lifetime / 3, RENEWAL_FLOOR_DAYS)`:
@@ -131,6 +133,10 @@ pub struct CertCommand {
 pub struct AcmeManager {
     config: AcmeConfig,
     challenges: ChallengeState,
+    /// Shared store the TLS-ALPN-01 challenge certificates are presented
+    /// through, read by the loopback responder. Cloned from what the responder
+    /// task serves, so `present`/`cleanup` here reach that listener.
+    tls_alpn: TlsAlpnResponder,
     storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
     cert_tx: mpsc::Sender<CertCommand>,
     certs_dir: PathBuf,
@@ -143,6 +149,7 @@ impl AcmeManager {
     pub fn new(
         config: AcmeConfig,
         challenges: ChallengeState,
+        tls_alpn: TlsAlpnResponder,
         storage: Arc<RwLock<BTreeMap<String, Entrypoint>>>,
         cert_tx: mpsc::Sender<CertCommand>,
         notify: Arc<Notify>,
@@ -151,6 +158,7 @@ impl AcmeManager {
         Self {
             config,
             challenges,
+            tls_alpn,
             storage,
             cert_tx,
             certs_dir,
@@ -390,6 +398,7 @@ impl AcmeManager {
 
         let (cert_chain_pem, key_pem) = match resolver {
             Some(Resolver::Dns01(provider)) => self.solve_dns01(order, provider).await?,
+            Some(Resolver::TlsAlpn01) => self.solve_tls_alpn01(order).await?,
             Some(Resolver::Http01) | None => self.solve_http01(order, hostname).await?,
         };
 
@@ -471,6 +480,18 @@ impl AcmeManager {
             .solve_and_finalize(order)
             .await
             .map_err(|e| anyhow::anyhow!("DNS-01 challenge failed: {e}"))
+    }
+
+    /// TLS-ALPN-01 challenge flow: hand the order off to cheti, which builds
+    /// the challenge certificate and presents it through the shared responder;
+    /// the loopback responder task serves it on `acme-tls/1`. The responder is
+    /// cloned (a shared handle), so the certificate cheti presents here is the
+    /// one that listener answers with.
+    async fn solve_tls_alpn01(&self, order: Order) -> anyhow::Result<(String, String)> {
+        TlsAlpn01Solver::new(self.tls_alpn.clone())
+            .solve_and_finalize(order)
+            .await
+            .map_err(|e| anyhow::anyhow!("TLS-ALPN-01 challenge failed: {e}"))
     }
 
     /// Get or create an ACME account, persisted via cheti's FileAccountStore.

--- a/src/acme/resolver.rs
+++ b/src/acme/resolver.rs
@@ -11,6 +11,10 @@ use crate::config::{AcmeConfig, ProviderConfig, ResolverConfig};
 pub enum Resolver {
     Http01,
     Dns01(Box<dyn DnsProvider>),
+    /// TLS-ALPN-01 (RFC 8737): answered over the TLS handshake on 443. The
+    /// challenge certificate is served by the shared responder the ACME
+    /// manager holds, so this variant carries no state of its own.
+    TlsAlpn01,
 }
 
 /// Resolve a resolver name from `AcmeConfig.resolvers` and build it.
@@ -30,6 +34,7 @@ pub fn build_resolver(name: Option<&str>, acme: &AcmeConfig) -> anyhow::Result<O
         ResolverConfig::Dns01 { provider, .. } => {
             Ok(Some(Resolver::Dns01(build_provider(provider)?)))
         }
+        ResolverConfig::TlsAlpn01 { .. } => Ok(Some(Resolver::TlsAlpn01)),
     }
 }
 
@@ -123,6 +128,7 @@ mod tests {
             certs_dir: String::from("/tmp"),
             staging: true,
             challenge_port: 80,
+            tls_alpn_port: 3038,
             resolvers: HashMap::new(),
         }
     }

--- a/src/acme/tls_alpn_responder.rs
+++ b/src/acme/tls_alpn_responder.rs
@@ -1,0 +1,191 @@
+//! Serves TLS-ALPN-01 challenge certificates on a loopback listener.
+//!
+//! When an ACME CA validates a TLS-ALPN-01 challenge it opens a TLS connection
+//! offering only the `acme-tls/1` ALPN protocol and an SNI of the domain, and
+//! expects the special challenge certificate cheti built. This responder
+//! terminates that handshake: it accepts only `acme-tls/1`, looks up the
+//! challenge certificate for the requested SNI, and presents it.
+//!
+//! It listens on loopback. Routing the CA's `acme-tls/1` connection on the
+//! public 443 to this loopback port is the proxy's job (the SNI+ALPN preread on
+//! the TCP listener) and lives elsewhere; here we only terminate and answer.
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use cheti::{ACME_TLS_ALPN_NAME, ChallengeResponder, DnsError};
+use rustls::ServerConfig;
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+use tracing::{debug, error, info};
+
+/// Challenge certificates currently presented, keyed by lowercased SNI.
+type ChallengeCerts = Arc<RwLock<HashMap<String, Arc<CertifiedKey>>>>;
+
+/// Shared handle to the presented challenge certificates. The ACME manager
+/// writes to it through [`ChallengeResponder`]; the loopback listener reads it
+/// to answer handshakes. Cheap to clone.
+#[derive(Clone, Default)]
+pub struct TlsAlpnResponder {
+    certs: ChallengeCerts,
+}
+
+impl TlsAlpnResponder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build the `CertifiedKey` from the DER cheti produced. Kept separate so
+    /// the error path is testable without ACME.
+    fn build_certified_key(cert_der: Vec<u8>, key_der: Vec<u8>) -> Result<CertifiedKey, DnsError> {
+        let cert = rustls::pki_types::CertificateDer::from(cert_der);
+        let key = rustls::pki_types::PrivateKeyDer::Pkcs8(
+            rustls::pki_types::PrivatePkcs8KeyDer::from(key_der),
+        );
+        let signing_key = rustls::crypto::aws_lc_rs::sign::any_supported_type(&key)
+            .map_err(|e| DnsError::Other(format!("challenge key is not usable: {e}")))?;
+        Ok(CertifiedKey::new(vec![cert], signing_key))
+    }
+}
+
+#[async_trait]
+impl ChallengeResponder for TlsAlpnResponder {
+    async fn present(
+        &self,
+        domain: &str,
+        cert_der: Vec<u8>,
+        key_der: Vec<u8>,
+    ) -> Result<(), DnsError> {
+        let certified = Self::build_certified_key(cert_der, key_der)?;
+        let mut certs = self
+            .certs
+            .write()
+            .map_err(|e| DnsError::Other(format!("challenge cert store poisoned: {e}")))?;
+        certs.insert(domain.to_ascii_lowercase(), Arc::new(certified));
+        debug!("TLS-ALPN-01 challenge certificate presented for {domain}");
+        Ok(())
+    }
+
+    async fn cleanup(&self, domain: &str) -> Result<(), DnsError> {
+        if let Ok(mut certs) = self.certs.write() {
+            certs.remove(&domain.to_ascii_lowercase());
+            debug!("TLS-ALPN-01 challenge certificate removed for {domain}");
+        }
+        Ok(())
+    }
+}
+
+/// A rustls certificate resolver that only ever answers `acme-tls/1`
+/// handshakes, and only for a domain that currently has a challenge
+/// certificate presented. Every other handshake gets no certificate, so the
+/// TLS layer aborts it — this listener is not meant to serve real traffic.
+#[derive(Debug)]
+struct ChallengeCertResolver {
+    certs: ChallengeCerts,
+}
+
+impl ResolvesServerCert for ChallengeCertResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        // The responder is single-purpose: it must only ever answer the ACME
+        // challenge protocol. rustls only offers a protocol it was configured
+        // with, but guard anyway so a stray connection can't be served.
+        let is_acme = client_hello
+            .alpn()
+            .map(|mut it| it.any(|p| p == ACME_TLS_ALPN_NAME))
+            .unwrap_or(false);
+        if !is_acme {
+            return None;
+        }
+        let sni = client_hello.server_name()?.to_ascii_lowercase();
+        self.certs.read().ok()?.get(&sni).cloned()
+    }
+}
+
+/// Bind the loopback responder on `port` and serve `acme-tls/1` challenge
+/// handshakes from `responder`'s store until the process exits.
+pub async fn serve(port: u16, responder: TlsAlpnResponder) -> anyhow::Result<()> {
+    let resolver = Arc::new(ChallengeCertResolver {
+        certs: responder.certs.clone(),
+    });
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_cert_resolver(resolver);
+    // Advertise only `acme-tls/1`: the CA offers exactly that, and a normal
+    // client offering h2/http1.1 finds no overlap and is turned away.
+    config.alpn_protocols = vec![ACME_TLS_ALPN_NAME.to_vec()];
+
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port)).await?;
+    info!("TLS-ALPN-01 responder listening on 127.0.0.1:{port}");
+
+    loop {
+        let (stream, _peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!("TLS-ALPN-01 responder accept error: {e}");
+                continue;
+            }
+        };
+        let acceptor = acceptor.clone();
+        tokio::spawn(async move {
+            // The handshake is the whole exchange: the CA inspects the
+            // presented certificate and closes. No application data flows, so
+            // completing (or failing) the accept is all there is to do.
+            if let Err(e) = acceptor.accept(stream).await {
+                debug!("TLS-ALPN-01 handshake did not complete: {e}");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cheti::build_challenge_certificate;
+
+    /// A real RFC 8737 challenge cert/key pair from cheti, for exercising the
+    /// responder's DER handling.
+    fn challenge_der(domain: &str) -> (Vec<u8>, Vec<u8>) {
+        let cert = build_challenge_certificate(domain, &[0x11; 32]).unwrap();
+        (cert.cert_der, cert.key_der)
+    }
+
+    #[test]
+    fn build_certified_key_accepts_a_real_challenge_pair() {
+        let (cert_der, key_der) = challenge_der("example.com");
+        assert!(TlsAlpnResponder::build_certified_key(cert_der, key_der).is_ok());
+    }
+
+    #[test]
+    fn build_certified_key_rejects_a_bogus_key() {
+        let (cert_der, _) = challenge_der("example.com");
+        let err = TlsAlpnResponder::build_certified_key(cert_der, vec![0, 1, 2, 3]).unwrap_err();
+        assert!(err.to_string().contains("not usable"));
+    }
+
+    #[tokio::test]
+    async fn present_then_cleanup_round_trips_through_the_store() {
+        let responder = TlsAlpnResponder::new();
+        let (cert_der, key_der) = challenge_der("app.example.com");
+
+        responder
+            .present("App.Example.COM", cert_der, key_der)
+            .await
+            .unwrap();
+        // Stored lowercased, the form the resolver looks up by.
+        assert!(
+            responder
+                .certs
+                .read()
+                .unwrap()
+                .contains_key("app.example.com")
+        );
+
+        responder.cleanup("app.example.com").await.unwrap();
+        assert!(responder.certs.read().unwrap().is_empty());
+    }
+}

--- a/src/acme/tls_alpn_responder.rs
+++ b/src/acme/tls_alpn_responder.rs
@@ -111,7 +111,14 @@ pub async fn serve(port: u16, responder: TlsAlpnResponder) -> anyhow::Result<()>
     let resolver = Arc::new(ChallengeCertResolver {
         certs: responder.certs.clone(),
     });
-    let mut config = ServerConfig::builder()
+    // Name the crypto provider explicitly: `ServerConfig::builder()` panics
+    // when it can't infer one, and the dependency tree carries both aws-lc-rs
+    // (ours) and ring (via cheti), so inference fails. This also frees the
+    // responder from having to start after the global default is installed.
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let mut config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| anyhow::anyhow!("TLS-ALPN-01 responder crypto setup: {e}"))?
         .with_no_client_auth()
         .with_cert_resolver(resolver);
     // Advertise only `acme-tls/1`: the CA offers exactly that, and a normal

--- a/src/api/config_view.rs
+++ b/src/api/config_view.rs
@@ -67,6 +67,9 @@ pub enum ResolverView {
         domains: Vec<String>,
         ca_server: Option<String>,
     },
+    TlsAlpn01 {
+        ca_server: Option<String>,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -196,6 +199,9 @@ fn resolver_view(r: &ResolverConfig) -> ResolverView {
                 ca_server: ca_server.clone(),
             }
         }
+        ResolverConfig::TlsAlpn01 { ca_server } => ResolverView::TlsAlpn01 {
+            ca_server: ca_server.clone(),
+        },
     }
 }
 
@@ -284,6 +290,7 @@ mod tests {
             certs_dir: "/var/lib/sozune/certs".into(),
             staging: true,
             challenge_port: 8080,
+            tls_alpn_port: 8443,
             resolvers: HashMap::new(),
         });
         cfg.dashboard.enabled = true;

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,11 @@ pub struct AcmeConfig {
         deserialize_with = "deserialize_acme_challenge_port_with_env"
     )]
     pub challenge_port: u16,
+    /// Loopback port the TLS-ALPN-01 responder binds. The public 443 routes
+    /// `acme-tls/1` handshakes here when a tls-alpn-01 resolver is configured;
+    /// it is never exposed directly.
+    #[serde(default = "default_acme_tls_alpn_port")]
+    pub tls_alpn_port: u16,
     #[serde(default)]
     pub resolvers: HashMap<String, ResolverConfig>,
 }
@@ -203,6 +208,21 @@ pub enum ResolverConfig {
         #[serde(default)]
         ca_server: Option<String>,
     },
+    /// TLS passthrough challenge (RFC 8737): the CA validates over a TLS
+    /// handshake on 443 with ALPN `acme-tls/1`, so it needs neither port 80
+    /// (unlike `http-01`) nor DNS API credentials (unlike `dns-01`).
+    ///
+    /// Declaring a `tls-alpn-01` resolver switches the HTTPS listener to an
+    /// ALPN-aware mode so the challenge can be answered without disturbing
+    /// normal traffic — see the TLS docs. No listener change happens unless a
+    /// resolver of this kind exists.
+    #[serde(rename = "tls-alpn-01")]
+    TlsAlpn01 {
+        /// ACME directory URL for this resolver (Traefik's `caServer`). See
+        /// the `http-01` variant for semantics.
+        #[serde(default)]
+        ca_server: Option<String>,
+    },
 }
 
 impl ResolverConfig {
@@ -211,7 +231,7 @@ impl ResolverConfig {
     pub fn managed_domains(&self) -> &[String] {
         match self {
             ResolverConfig::Dns01 { domains, .. } => domains,
-            ResolverConfig::Http01 { .. } => &[],
+            ResolverConfig::Http01 { .. } | ResolverConfig::TlsAlpn01 { .. } => &[],
         }
     }
 
@@ -219,9 +239,9 @@ impl ResolverConfig {
     /// fall back to the global staging/prod URL.
     pub fn ca_server(&self) -> Option<&str> {
         match self {
-            ResolverConfig::Http01 { ca_server } | ResolverConfig::Dns01 { ca_server, .. } => {
-                ca_server.as_deref()
-            }
+            ResolverConfig::Http01 { ca_server }
+            | ResolverConfig::Dns01 { ca_server, .. }
+            | ResolverConfig::TlsAlpn01 { ca_server } => ca_server.as_deref(),
         }
     }
 }
@@ -965,6 +985,12 @@ fn default_acme_challenge_port() -> u16 {
     3036
 }
 
+fn default_acme_tls_alpn_port() -> u16 {
+    // 3035 API, 3036 ACME challenge, 3037 middleware, 3038 dashboard, 3039 …,
+    // 3040 TLS-ALPN-01 responder.
+    3040
+}
+
 fn default_middleware_port() -> u16 {
     3037
 }
@@ -1436,6 +1462,7 @@ impl AppConfig {
                 certs_dir: default_acme_certs_dir(),
                 staging: default_acme_staging(),
                 challenge_port: default_acme_challenge_port(),
+                tls_alpn_port: default_acme_tls_alpn_port(),
                 resolvers: HashMap::new(),
             });
             acme.apply_env_overrides();

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,16 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
     let active_acme = config.acme.as_ref().filter(|a| a.enabled);
     let acme_enabled = active_acme.is_some();
     let acme_challenge_port = active_acme.map(|a| a.challenge_port);
+    // The HTTPS listener only switches to the ALPN-aware gate when a
+    // tls-alpn-01 resolver is actually configured — otherwise 443 stays a
+    // direct Sōzu HTTPS listener, byte-for-byte the old path.
+    let tls_alpn_responder_port = active_acme
+        .filter(|a| {
+            a.resolvers
+                .values()
+                .any(|r| matches!(r, config::ResolverConfig::TlsAlpn01 { .. }))
+        })
+        .map(|a| a.tls_alpn_port);
 
     // Create middleware state shared between middleware server and proxy reload
     let middleware_state: middleware::MiddlewareState =
@@ -212,6 +222,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                 metrics_poll_rx,
                 metrics_store: metrics_store_proxy,
                 acme_challenge_port,
+                tls_alpn_responder_port,
                 middleware_state: middleware_state_proxy,
                 middleware_port,
                 plugins,
@@ -427,8 +438,18 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
             signal_handle.close();
             match result {
                 Ok(Ok(_)) => debug!("Proxy task completed successfully"),
-                Ok(Err(e)) => error!("Proxy task failed: {}", e),
-                Err(e) => error!("Proxy task panicked: {:?}", e),
+                // A proxy startup failure (e.g. the TLS-ALPN-01 gate can't bind
+                // 443) must fail the process, not just log: the HTTPS worker has
+                // already moved to loopback, so continuing would leave 443
+                // unserved while the process reports success.
+                Ok(Err(e)) => {
+                    error!("Proxy task failed: {}", e);
+                    return Err(e);
+                }
+                Err(e) => {
+                    error!("Proxy task panicked: {:?}", e);
+                    return Err(anyhow::anyhow!("proxy task panicked: {e}"));
+                }
             }
         },
         result = secondary_tasks_future => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,7 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
 
                 let challenges = Arc::new(RwLock::new(HashMap::new()));
 
-                // Start the challenge server
+                // Start the HTTP-01 challenge server
                 let challenge_port = acme_config.challenge_port;
                 let challenges_server = Arc::clone(&challenges);
                 tokio::spawn(async move {
@@ -351,10 +351,26 @@ async fn serve(config_path: &str) -> anyhow::Result<()> {
                     }
                 });
 
+                // Start the TLS-ALPN-01 responder on a loopback port. It always
+                // runs when ACME is enabled; nothing routes `acme-tls/1` to it
+                // until a tls-alpn-01 resolver flips the HTTPS listener into
+                // preread mode (that wiring lives in the proxy layer).
+                let tls_alpn = acme::tls_alpn_responder::TlsAlpnResponder::new();
+                let tls_alpn_port = acme_config.tls_alpn_port;
+                let tls_alpn_server = tls_alpn.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        acme::tls_alpn_responder::serve(tls_alpn_port, tls_alpn_server).await
+                    {
+                        error!("TLS-ALPN-01 responder failed: {}", e);
+                    }
+                });
+
                 // Run the ACME manager
                 let manager = acme::AcmeManager::new(
                     acme_config,
                     challenges,
+                    tls_alpn,
                     storage_acme,
                     cert_tx,
                     Arc::clone(&acme_notify),

--- a/src/proxy/backend.rs
+++ b/src/proxy/backend.rs
@@ -20,6 +20,12 @@ pub struct ProxyInputs {
     pub metrics_poll_rx: mpsc::Receiver<()>,
     pub metrics_store: MetricsSnapshotStore,
     pub acme_challenge_port: Option<u16>,
+    /// When a `tls-alpn-01` resolver is configured, the loopback port of the
+    /// TLS-ALPN-01 responder. `Some(port)` flips the HTTPS listener into the
+    /// ALPN-aware gate on 443, routing `acme-tls/1` handshakes to that port and
+    /// everything else to the (now loopback-bound) HTTPS worker. `None` keeps
+    /// the default path: the HTTPS worker binds 443 directly.
+    pub tls_alpn_responder_port: Option<u16>,
     pub middleware_state: MiddlewareState,
     pub middleware_port: u16,
     /// Compiled WASM plugins, keyed by declared name. Built once at startup.

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -3,3 +3,4 @@ pub mod health;
 pub mod metrics_snapshot;
 pub mod request_metrics;
 pub mod sozu;
+pub mod tls_alpn_gate;

--- a/src/proxy/sozu/acme.rs
+++ b/src/proxy/sozu/acme.rs
@@ -62,14 +62,14 @@ pub(super) fn register_acme_challenge_cluster(
 /// Send an AddCertificate command to the HTTPS worker.
 pub(super) fn add_certificate(
     command_channel_https: &mut Channel<WorkerRequest, WorkerResponse>,
-    https_port: u16,
+    https_addr: SocketAddress,
     cert_pem: &str,
     chain: &[String],
     key_pem: &str,
     names: &[String],
 ) -> anyhow::Result<()> {
     let cert = AddCertificate {
-        address: SocketAddress::new_v4(0, 0, 0, 0, https_port),
+        address: https_addr,
         certificate: CertificateAndKey {
             certificate: cert_pem.to_string(),
             certificate_chain: chain.to_vec(),

--- a/src/proxy/sozu/mod.rs
+++ b/src/proxy/sozu/mod.rs
@@ -11,6 +11,7 @@ use crate::middleware::{self, MiddlewareState};
 use crate::model::{Backend, Entrypoint, LoadBalancer, Protocol};
 use crate::proxy::backend::ProxyInputs;
 use crate::proxy::metrics_snapshot;
+use crate::proxy::tls_alpn_gate;
 use acme::{add_certificate, register_acme_challenge_cluster};
 use addr::{l4_backend_id, parse_backend_address};
 use builders::{
@@ -88,9 +89,24 @@ struct Channels {
     udp: L4Channels,
     http_port: u16,
     https_port: u16,
+    /// Octets of the IP the HTTPS worker listens on. `0.0.0.0` normally, but
+    /// `127.0.0.1` when the ALPN gate fronts 443 and the worker moved to
+    /// loopback. HTTPS frontends and certificates must attach to this exact
+    /// address, or Sōzu rejects them ("found no listener with address …").
+    https_ip: [u8; 4],
     /// Loopback port serving the ACME HTTP-01 challenge responder, when
     /// ACME is enabled. `None` disables every ACME-specific code path.
     acme_challenge_port: Option<u16>,
+}
+
+impl Channels {
+    /// The address the HTTPS worker's listener is bound to. HTTPS frontends and
+    /// certificates must attach here — using `0.0.0.0` when the worker is on
+    /// loopback (behind the ALPN gate) makes Sōzu reject them.
+    fn https_addr(&self) -> SocketAddress {
+        let [a, b, c, d] = self.https_ip;
+        SocketAddress::new_v4(a, b, c, d, self.https_port)
+    }
 }
 
 fn snapshot_from_storage(storage: &BTreeMap<String, Entrypoint>) -> RoutingSnapshot {
@@ -387,6 +403,7 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
         mut metrics_poll_rx,
         metrics_store,
         acme_challenge_port,
+        tls_alpn_responder_port,
         middleware_state,
         middleware_port,
         plugins,
@@ -417,15 +434,31 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
         .to_http(None)
         .map_err(|e| anyhow::anyhow!("Could not create HTTP listener: {}", e))?;
 
+    // With the ALPN gate active, the HTTPS worker steps off the public 443 onto
+    // loopback and the gate owns 443, prereading each connection's ALPN. Bound
+    // to 127.0.0.1 so nothing but the gate can reach it. Without the gate, the
+    // worker binds the public 443 directly — the unchanged default.
+    let (https_bind_ip, https_bind_port) = match tls_alpn_responder_port {
+        Some(_) => (Ipv4Addr::LOCALHOST, pick_loopback_port()?),
+        None => (Ipv4Addr::UNSPECIFIED, config.https.listen_address),
+    };
+    let https_bind = https_bind_ip.octets();
     let mut https_builder = ListenerBuilder::new_https(SocketAddress::new_v4(
-        0,
-        0,
-        0,
-        0,
-        config.https.listen_address,
+        https_bind[0],
+        https_bind[1],
+        https_bind[2],
+        https_bind[3],
+        https_bind_port,
     ));
     apply_listener_error_pages(&mut https_builder, &config.https.error_pages, "HTTPS");
     apply_listener_http2(&mut https_builder, &config.https.http2);
+    // Behind the gate the worker only ever sees loopback connections, losing the
+    // real client IP. So the gate prepends a PROXY-v2 header carrying the true
+    // peer, and the worker is told to expect it — otherwise client-IP matching,
+    // allow-lists and access logs would all read 127.0.0.1.
+    if tls_alpn_responder_port.is_some() {
+        https_builder.with_expect_proxy(true);
+    }
     let https_listener = https_builder
         .to_tls(None)
         .map_err(|e| anyhow::anyhow!("Could not create HTTPS listener: {}", e))?;
@@ -481,10 +514,29 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
         "Sōzu HTTP worker running on 0.0.0.0:{}",
         config.http.listen_address
     );
-    info!(
-        "Sōzu HTTPS worker running on 0.0.0.0:{}",
-        config.https.listen_address
-    );
+    match tls_alpn_responder_port {
+        Some(_) => info!(
+            "Sōzu HTTPS worker running on 127.0.0.1:{https_bind_port} (behind the TLS-ALPN-01 gate on :{})",
+            config.https.listen_address
+        ),
+        None => info!(
+            "Sōzu HTTPS worker running on 0.0.0.0:{}",
+            config.https.listen_address
+        ),
+    }
+
+    // Front 443 with the ALPN-aware gate when a tls-alpn-01 resolver exists:
+    // `acme-tls/1` handshakes go to the responder, everything else to the HTTPS
+    // worker now on `https_bind_port`. Bind synchronously so a taken 443 fails
+    // startup here — the worker has already moved to loopback, so a silent gate
+    // failure would leave 443 unserved.
+    if let Some(responder_port) = tls_alpn_responder_port {
+        let public_port = config.https.listen_address;
+        let listener = handle.block_on(tls_alpn_gate::bind(public_port))?;
+        handle.spawn(async move {
+            tls_alpn_gate::run(listener, public_port, https_bind_port, responder_port).await;
+        });
+    }
 
     // Register ACME challenge cluster if enabled (routes added per-hostname during reload)
     if let Some(challenge_port) = acme_challenge_port
@@ -497,7 +549,11 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
     let storage_reload = Arc::clone(&storage);
     let trusted_proxies_reload = Arc::clone(&trusted_proxies);
     let http_port = config.http.listen_address;
-    let https_port = config.https.listen_address;
+    // The port the HTTPS worker actually listens on: the loopback port behind
+    // the gate, or the public 443. Certificates and HTTPS frontends attach to
+    // this listener, so they must use the worker's real port, not the public
+    // one the gate fronts.
+    let https_port = https_bind_port;
     let cluster_setup_delay_ms = config.cluster_setup_delay_ms;
     let reload_debounce = Duration::from_millis(config.reload_debounce_ms);
     let metrics_poll_timeout = Duration::from_millis(config.metrics_poll_timeout_ms);
@@ -513,6 +569,7 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
         udp: udp_channels,
         http_port,
         https_port,
+        https_ip: https_bind_ip.octets(),
         acme_challenge_port,
     };
 
@@ -551,9 +608,10 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
                     cert_cmd = cert_rx.recv(), if cert_rx_open => match cert_cmd {
                         Some(cmd) => {
                             info!("Adding certificate for {}", cmd.hostname);
+                            let https_addr = channels.https_addr();
                             if let Err(e) = add_certificate(
                                 &mut channels.https,
-                                https_port,
+                                https_addr,
                                 &cmd.cert_pem,
                                 &cmd.chain,
                                 &cmd.key_pem,
@@ -651,9 +709,10 @@ pub fn start_sozu_proxy(inputs: ProxyInputs, config: &ProxyConfig) -> anyhow::Re
                             cert_cmd = cert_rx.recv(), if cert_rx_open => match cert_cmd {
                                 Some(cmd) => {
                                     info!("Adding certificate for {}", cmd.hostname);
+                                    let https_addr = channels.https_addr();
                                     if let Err(e) = add_certificate(
                                         &mut channels.https,
-                                        https_port,
+                                        https_addr,
                                         &cmd.cert_pem,
                                         &cmd.chain,
                                         &cmd.key_pem,
@@ -994,13 +1053,15 @@ fn configure_sozu_routing(
                     }
                 }
 
+                let https_addr = channels.https_addr();
+                let http_port = channels.http_port;
                 configure_http_entrypoint(
                     &mut channels.http,
                     &mut channels.https,
                     cluster_id,
                     entrypoint,
-                    channels.http_port,
-                    channels.https_port,
+                    http_port,
+                    https_addr,
                     middleware_port,
                 )?;
             }
@@ -1025,7 +1086,7 @@ fn configure_http_entrypoint(
     cluster_id: &str,
     entrypoint: &Entrypoint,
     http_port: u16,
-    https_port: u16,
+    https_addr: SocketAddress,
     middleware_port: u16,
 ) -> anyhow::Result<()> {
     // Add cluster for both HTTP and HTTPS
@@ -1149,7 +1210,7 @@ fn configure_http_entrypoint(
             if entrypoint.config.tls {
                 let https_front = RequestHttpFrontend {
                     cluster_id: Some(cluster_id.to_string()),
-                    address: SocketAddress::new_v4(0, 0, 0, 0, https_port),
+                    address: https_addr,
                     hostname: hostname.clone(),
                     path: path_rule.clone(),
                     method: method.clone(),
@@ -1653,7 +1714,7 @@ fn remove_http_frontends(
     cluster_id: &str,
     entrypoint: &Entrypoint,
     http_port: u16,
-    https_port: u16,
+    https_addr: SocketAddress,
 ) {
     let (path_rule, _) = build_path_and_rewrite(
         entrypoint.config.path.as_ref(),
@@ -1694,7 +1755,7 @@ fn remove_http_frontends(
             if entrypoint.config.tls {
                 let https_front = RequestHttpFrontend {
                     cluster_id: Some(cluster_id.to_string()),
-                    address: SocketAddress::new_v4(0, 0, 0, 0, https_port),
+                    address: https_addr,
                     hostname: hostname.clone(),
                     path: path_rule.clone(),
                     method: method.clone(),
@@ -2116,13 +2177,15 @@ fn apply_routing_diff(
             info!("Removing stale cluster: {}", cluster_id);
             match old.protocol {
                 Protocol::Http => {
+                    let https_addr = channels.https_addr();
+                    let http_port = channels.http_port;
                     remove_http_frontends(
                         &mut channels.http,
                         &mut channels.https,
                         cluster_id,
                         old,
-                        channels.http_port,
-                        channels.https_port,
+                        http_port,
+                        https_addr,
                     );
                     remove_backends(&mut channels.http, &mut channels.https, cluster_id, old);
                     remove_cluster(&mut channels.http, &mut channels.https, cluster_id);
@@ -2166,13 +2229,15 @@ fn apply_routing_diff(
             info!("Updating changed cluster: {}", cluster_id);
             match old.protocol {
                 Protocol::Http => {
+                    let https_addr = channels.https_addr();
+                    let http_port = channels.http_port;
                     remove_http_frontends(
                         &mut channels.http,
                         &mut channels.https,
                         cluster_id,
                         old,
-                        channels.http_port,
-                        channels.https_port,
+                        http_port,
+                        https_addr,
                     );
                     remove_backends(&mut channels.http, &mut channels.https, cluster_id, old);
 

--- a/src/proxy/tls_alpn_gate.rs
+++ b/src/proxy/tls_alpn_gate.rs
@@ -1,0 +1,525 @@
+//! Front door for port 443 when TLS-ALPN-01 is enabled.
+//!
+//! Normally Sōzu's HTTPS worker binds 443 directly. But answering a
+//! TLS-ALPN-01 challenge means intercepting the handshake on 443 to present a
+//! special certificate for the `acme-tls/1` protocol — something the HTTPS
+//! worker won't do. So when a `tls-alpn-01` resolver is configured, this gate
+//! binds 443 instead, prereads each connection's `ClientHello` for its ALPN
+//! offer, and splices it to one of two loopback backends:
+//!
+//!   - offers `acme-tls/1`  → the local TLS-ALPN-01 responder
+//!   - anything else        → the HTTPS worker (moved to a loopback port)
+//!
+//! The preread neither decrypts nor consumes: the buffered `ClientHello` bytes
+//! are replayed to the chosen backend, so the handshake completes there exactly
+//! as if the client had connected to it directly. This is the same
+//! `copy_bidirectional` splice the TCP forwarder already uses, with an ALPN
+//! decision in front.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, error, info};
+
+/// `acme-tls/1`, the ALPN protocol a TLS-ALPN-01 validator offers.
+const ACME_TLS_ALPN: &[u8] = b"acme-tls/1";
+
+/// How long to wait for a `ClientHello` before giving up on a connection, and
+/// how many wire bytes (record headers included) to buffer looking for it.
+///
+/// The cap bounds what a hostile peer can make the gate buffer per connection.
+/// A hello whose ALPN only appears past the cap is treated as non-ACME and
+/// spliced to the HTTPS worker unread — safe for normal traffic, which the
+/// worker parses itself. The only casualty would be a *challenge* hello larger
+/// than 64 KiB, which cannot happen: a TLS-ALPN-01 validator sends a minimal
+/// hello (SNI + `acme-tls/1`), a few hundred bytes. So 64 KiB never misroutes a
+/// real challenge while still being a firm ceiling.
+const PREREAD_TIMEOUT: Duration = Duration::from_secs(5);
+const PREREAD_MAX_BYTES: usize = 64 * 1024;
+
+/// Where a prereaded connection should go.
+struct GateSpec {
+    /// Public port to bind (443).
+    public_port: u16,
+    /// Loopback port the HTTPS worker moved to — the default backend.
+    https_loopback_port: u16,
+    /// Loopback port the TLS-ALPN-01 responder listens on.
+    responder_port: u16,
+}
+
+/// Bind the public port for the gate, failing loudly if it's taken.
+///
+/// Bound synchronously at startup — separate from [`run`] — so a bind failure
+/// (e.g. 443 already in use) aborts startup instead of leaving the process up
+/// with no public HTTPS listener at all: the HTTPS worker has already stepped
+/// onto loopback by this point, so a silent gate failure would black-hole 443.
+pub async fn bind(public_port: u16) -> anyhow::Result<TcpListener> {
+    TcpListener::bind((Ipv4Addr::UNSPECIFIED, public_port))
+        .await
+        .map_err(|e| anyhow::anyhow!("TLS-ALPN-01 gate could not bind 0.0.0.0:{public_port}: {e}"))
+}
+
+/// Route each connection on an already-bound `listener` by its ClientHello ALPN
+/// offer, until the process exits.
+pub async fn run(
+    listener: TcpListener,
+    public_port: u16,
+    https_loopback_port: u16,
+    responder_port: u16,
+) {
+    let spec = GateSpec {
+        public_port,
+        https_loopback_port,
+        responder_port,
+    };
+    info!(
+        "TLS-ALPN-01 gate on 0.0.0.0:{} → acme-tls/1 to 127.0.0.1:{}, else 127.0.0.1:{}",
+        spec.public_port, spec.responder_port, spec.https_loopback_port
+    );
+
+    loop {
+        let (inbound, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!("TLS-ALPN-01 gate accept error: {e}");
+                continue;
+            }
+        };
+        let responder_port = spec.responder_port;
+        let https_port = spec.https_loopback_port;
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(inbound, peer, responder_port, https_port).await {
+                debug!("TLS-ALPN-01 gate connection closed: {e}");
+            }
+        });
+    }
+}
+
+/// Preread the ClientHello, pick a backend by ALPN, replay the buffered bytes,
+/// and splice the rest.
+///
+/// `peer` is the real client address. The HTTPS worker (behind the gate on
+/// loopback) would otherwise see every connection as `127.0.0.1`, so its
+/// traffic is prefixed with a PROXY-v2 header carrying the true source and the
+/// public destination the client actually reached. The responder gets no such
+/// header — it doesn't expect one and doesn't care who is connecting.
+async fn handle_connection(
+    mut inbound: TcpStream,
+    peer: std::net::SocketAddr,
+    responder_port: u16,
+    https_loopback_port: u16,
+) -> std::io::Result<()> {
+    // The public address the client connected to, before the gate spliced it
+    // onto loopback — this is what belongs in the PROXY header's destination.
+    let public_dest = inbound.local_addr()?;
+
+    let (buffered, wants_acme) = preread_alpn(&mut inbound).await?;
+    let backend_port = if wants_acme {
+        responder_port
+    } else {
+        https_loopback_port
+    };
+
+    let mut outbound = TcpStream::connect((Ipv4Addr::LOCALHOST, backend_port)).await?;
+    if !wants_acme {
+        // Preserve the client IP for the HTTPS worker, which is configured to
+        // expect this header (`with_expect_proxy`).
+        outbound
+            .write_all(&proxy_v2_header(peer, public_dest))
+            .await?;
+    }
+    // Replay the bytes consumed during preread, so the backend sees the whole
+    // ClientHello from its first byte.
+    if !buffered.is_empty() {
+        outbound.write_all(&buffered).await?;
+    }
+    copy_bidirectional(&mut inbound, &mut outbound).await?;
+    Ok(())
+}
+
+/// Build a PROXY protocol v2 header for a `source` → `destination` TCP
+/// connection (RFC by HAProxy). Only the two address families Sōzune binds are
+/// emitted; a mixed-family pair can't occur here (both ends are the same
+/// socket's view), so it isn't handled.
+fn proxy_v2_header(source: std::net::SocketAddr, dest: std::net::SocketAddr) -> Vec<u8> {
+    use std::net::SocketAddr;
+
+    // 12-byte signature, then version+command (0x21 = v2, PROXY), then the
+    // transport+family byte, then a u16 address-block length.
+    let mut h: Vec<u8> = vec![
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
+    ];
+    h.push(0x21);
+    match (source, dest) {
+        (SocketAddr::V4(s), SocketAddr::V4(d)) => {
+            h.push(0x11); // AF_INET + STREAM
+            h.extend_from_slice(&12u16.to_be_bytes());
+            h.extend_from_slice(&s.ip().octets());
+            h.extend_from_slice(&d.ip().octets());
+            h.extend_from_slice(&s.port().to_be_bytes());
+            h.extend_from_slice(&d.port().to_be_bytes());
+        }
+        (SocketAddr::V6(s), SocketAddr::V6(d)) => {
+            h.push(0x21); // AF_INET6 + STREAM
+            h.extend_from_slice(&36u16.to_be_bytes());
+            h.extend_from_slice(&s.ip().octets());
+            h.extend_from_slice(&d.ip().octets());
+            h.extend_from_slice(&s.port().to_be_bytes());
+            h.extend_from_slice(&d.port().to_be_bytes());
+        }
+        _ => {
+            // Mixed families: emit LOCAL (0x20) with no addresses so the worker
+            // still parses a valid header rather than the raw bytes.
+            h[12] = 0x20;
+            h.push(0x00);
+            h.extend_from_slice(&0u16.to_be_bytes());
+        }
+    }
+    h
+}
+
+/// Read from `inbound` until the ClientHello's ALPN can be decided, or the
+/// preread deadline / byte cap is hit. Returns the raw bytes consumed (to be
+/// replayed to the backend) and whether `acme-tls/1` was offered. On any parse
+/// failure, timeout, or truncation the connection is treated as non-ACME: it
+/// flows to the HTTPS worker, which makes its own call.
+///
+/// The deadline is a single absolute bound on the whole preread, not a
+/// per-read one — otherwise a peer dripping a byte just under the timeout could
+/// hold the task open indefinitely (a slowloris).
+async fn preread_alpn(inbound: &mut TcpStream) -> std::io::Result<(Vec<u8>, bool)> {
+    let mut buf = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 4096];
+    let deadline = tokio::time::Instant::now() + PREREAD_TIMEOUT;
+
+    loop {
+        match parse_client_hello_alpn(&buf) {
+            AlpnParse::Decided(found) => return Ok((buf, found)),
+            AlpnParse::NeedMore => {}
+            AlpnParse::NotTls => return Ok((buf, false)),
+        }
+        if buf.len() >= PREREAD_MAX_BYTES {
+            return Ok((buf, false));
+        }
+
+        let n = match tokio::time::timeout_at(deadline, inbound.read(&mut chunk)).await {
+            Ok(Ok(0)) => return Ok((buf, false)), // peer closed
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Ok((buf, false)), // deadline: let HTTPS decide
+        };
+        // Never buffer past the cap, even if a single read overshoots it.
+        let room = PREREAD_MAX_BYTES - buf.len();
+        buf.extend_from_slice(&chunk[..n.min(room)]);
+    }
+}
+
+enum AlpnParse {
+    /// ALPN resolved: `true` if `acme-tls/1` was among the offered protocols.
+    Decided(bool),
+    /// Not enough bytes yet to reach (or finish) the ALPN extension.
+    NeedMore,
+    /// The stream isn't a TLS ClientHello at all.
+    NotTls,
+}
+
+/// Extract whether the ClientHello in `buf` offers `acme-tls/1`.
+///
+/// A ClientHello can be split across several TLS handshake records, so the
+/// handshake body is first reassembled from every leading `0x16` record, then
+/// walked once. The walk is bounded by the handshake's own declared length, not
+/// the record boundary, so trailing bytes after the ClientHello can't be read
+/// as extensions. Anything malformed or truncated returns `NeedMore`/`NotTls`
+/// rather than erroring; the caller degrades to the HTTPS path.
+fn parse_client_hello_alpn(buf: &[u8]) -> AlpnParse {
+    // Reassemble the handshake stream from consecutive handshake records.
+    let mut hs_stream: Vec<u8> = Vec::new();
+    let mut r = 0usize;
+    loop {
+        if buf.len() < r + 5 {
+            // Header incomplete: need more, unless we've already got a
+            // complete ClientHello reassembled below.
+            break;
+        }
+        if buf[r] != 0x16 {
+            // A non-handshake record interrupting the ClientHello: this isn't
+            // the plain TLS-ALPN validator flow.
+            if r == 0 {
+                return AlpnParse::NotTls;
+            }
+            break;
+        }
+        let rec_len = u16::from_be_bytes([buf[r + 3], buf[r + 4]]) as usize;
+        let rec_end = r + 5 + rec_len;
+        if buf.len() < rec_end {
+            hs_stream.extend_from_slice(&buf[r + 5..]); // partial tail
+            break;
+        }
+        hs_stream.extend_from_slice(&buf[r + 5..rec_end]);
+        r = rec_end;
+    }
+
+    if hs_stream.len() < 4 {
+        return AlpnParse::NeedMore;
+    }
+    // Handshake header: msg_type(1) length(3). Type 1 = ClientHello.
+    if hs_stream[0] != 0x01 {
+        return AlpnParse::NotTls;
+    }
+    let declared = u32::from_be_bytes([0, hs_stream[1], hs_stream[2], hs_stream[3]]) as usize;
+    let body_end = 4 + declared;
+    if hs_stream.len() < body_end {
+        return AlpnParse::NeedMore;
+    }
+    // Bound the walk by the ClientHello's declared length: trailing handshake
+    // messages (or crafted bytes) after it must not be parsed as extensions.
+    let hs = &hs_stream[..body_end];
+    let mut p = 4usize;
+    // client_version(2) random(32)
+    p += 34;
+    // session_id
+    let Some(&sid_len) = hs.get(p) else {
+        return AlpnParse::NeedMore;
+    };
+    p += 1 + sid_len as usize;
+    // cipher_suites (u16 length-prefixed)
+    let Some(cs_len) = read_u16(hs, p) else {
+        return AlpnParse::NeedMore;
+    };
+    p += 2 + cs_len as usize;
+    // compression_methods (u8 length-prefixed)
+    let Some(&comp_len) = hs.get(p) else {
+        return AlpnParse::NeedMore;
+    };
+    p += 1 + comp_len as usize;
+    // extensions (u16 length-prefixed)
+    let Some(ext_total) = read_u16(hs, p) else {
+        return AlpnParse::NeedMore;
+    };
+    p += 2;
+    let ext_end = p + ext_total as usize;
+    if hs.len() < ext_end {
+        return AlpnParse::NeedMore;
+    }
+
+    while p + 4 <= ext_end {
+        let ext_type = u16::from_be_bytes([hs[p], hs[p + 1]]);
+        let ext_len = u16::from_be_bytes([hs[p + 2], hs[p + 3]]) as usize;
+        p += 4;
+        if p + ext_len > ext_end {
+            return AlpnParse::NotTls;
+        }
+        if ext_type == 0x0010 {
+            // ALPN: protocol_name_list is a u16-length-prefixed list of
+            // u8-length-prefixed names.
+            return AlpnParse::Decided(alpn_offers_acme(&hs[p..p + ext_len]));
+        }
+        p += ext_len;
+    }
+    // Fully parsed, no ALPN extension present.
+    AlpnParse::Decided(false)
+}
+
+/// True if the ALPN extension body offers `acme-tls/1`.
+fn alpn_offers_acme(ext: &[u8]) -> bool {
+    // list_len(2), then repeated: name_len(1) name.
+    if ext.len() < 2 {
+        return false;
+    }
+    let list_len = u16::from_be_bytes([ext[0], ext[1]]) as usize;
+    let mut p = 2;
+    let end = (2 + list_len).min(ext.len());
+    while p < end {
+        let name_len = ext[p] as usize;
+        p += 1;
+        if p + name_len > end {
+            break;
+        }
+        if &ext[p..p + name_len] == ACME_TLS_ALPN {
+            return true;
+        }
+        p += name_len;
+    }
+    false
+}
+
+fn read_u16(buf: &[u8], at: usize) -> Option<u16> {
+    Some(u16::from_be_bytes([*buf.get(at)?, *buf.get(at + 1)?]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal ClientHello record carrying the given ALPN protocols.
+    fn client_hello_with_alpn(protocols: &[&[u8]]) -> Vec<u8> {
+        // Extensions: one ALPN extension.
+        let mut names = Vec::new();
+        for proto in protocols {
+            names.push(proto.len() as u8);
+            names.extend_from_slice(proto);
+        }
+        let mut alpn_body = Vec::new();
+        alpn_body.extend_from_slice(&(names.len() as u16).to_be_bytes());
+        alpn_body.extend_from_slice(&names);
+
+        let mut ext = Vec::new();
+        ext.extend_from_slice(&0x0010u16.to_be_bytes());
+        ext.extend_from_slice(&(alpn_body.len() as u16).to_be_bytes());
+        ext.extend_from_slice(&alpn_body);
+
+        // Handshake body: version(2) random(32) sid(1=0) ciphers(2len+2) comp(1len+1) ext(2len+..)
+        let mut hs = Vec::new();
+        hs.extend_from_slice(&[0x03, 0x03]); // version
+        hs.extend_from_slice(&[0u8; 32]); // random
+        hs.push(0); // session_id len
+        hs.extend_from_slice(&2u16.to_be_bytes()); // cipher len
+        hs.extend_from_slice(&[0x13, 0x01]); // one cipher
+        hs.push(1); // compression len
+        hs.push(0); // null compression
+        hs.extend_from_slice(&(ext.len() as u16).to_be_bytes());
+        hs.extend_from_slice(&ext);
+
+        // Handshake header: type(1)=ClientHello, length(3)
+        let mut handshake = Vec::new();
+        handshake.push(0x01);
+        let hl = hs.len();
+        handshake.push((hl >> 16) as u8);
+        handshake.push((hl >> 8) as u8);
+        handshake.push(hl as u8);
+        handshake.extend_from_slice(&hs);
+
+        // Record header: type(1)=handshake, version(2), length(2)
+        let mut record = Vec::new();
+        record.push(0x16);
+        record.extend_from_slice(&[0x03, 0x01]);
+        record.extend_from_slice(&(handshake.len() as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+        record
+    }
+
+    fn decide(buf: &[u8]) -> AlpnParse {
+        parse_client_hello_alpn(buf)
+    }
+
+    #[test]
+    fn detects_acme_tls_alpn() {
+        let hello = client_hello_with_alpn(&[b"acme-tls/1"]);
+        assert!(matches!(decide(&hello), AlpnParse::Decided(true)));
+    }
+
+    #[test]
+    fn normal_alpn_is_not_acme() {
+        let hello = client_hello_with_alpn(&[b"h2", b"http/1.1"]);
+        assert!(matches!(decide(&hello), AlpnParse::Decided(false)));
+    }
+
+    #[test]
+    fn acme_among_others_is_detected() {
+        // A conformant validator offers only acme-tls/1, but be liberal.
+        let hello = client_hello_with_alpn(&[b"h2", b"acme-tls/1"]);
+        assert!(matches!(decide(&hello), AlpnParse::Decided(true)));
+    }
+
+    #[test]
+    fn no_alpn_extension_decides_non_acme() {
+        // Truncate the ALPN extension off by rebuilding without it: a hello
+        // with no extensions at all still parses to a non-ACME decision.
+        let hello = client_hello_with_alpn(&[]);
+        // Empty protocol list → no acme match.
+        assert!(matches!(decide(&hello), AlpnParse::Decided(false)));
+    }
+
+    #[test]
+    fn non_tls_first_byte_is_rejected() {
+        assert!(matches!(decide(b"GET / HTTP/1.1\r\n"), AlpnParse::NotTls));
+    }
+
+    #[test]
+    fn a_truncated_record_asks_for_more() {
+        let hello = client_hello_with_alpn(&[b"acme-tls/1"]);
+        // Cut mid-record: header says more is coming.
+        assert!(matches!(decide(&hello[..8]), AlpnParse::NeedMore));
+    }
+
+    /// Re-frame a single-record ClientHello into two handshake records, split
+    /// at byte `at` of the handshake body.
+    fn fragment_into_two_records(single: &[u8], at: usize) -> Vec<u8> {
+        // Strip the original 5-byte record header to get the handshake bytes.
+        let handshake = &single[5..];
+        let (first, second) = handshake.split_at(at);
+        let mut out = Vec::new();
+        for part in [first, second] {
+            out.push(0x16);
+            out.extend_from_slice(&[0x03, 0x01]);
+            out.extend_from_slice(&(part.len() as u16).to_be_bytes());
+            out.extend_from_slice(part);
+        }
+        out
+    }
+
+    #[test]
+    fn a_clienthello_split_across_two_records_is_reassembled() {
+        // The bug Codex found: only the first record was inspected, so a hello
+        // split before its ALPN extension was misrouted. Split it right in the
+        // middle and confirm ALPN is still found.
+        let hello = client_hello_with_alpn(&[b"acme-tls/1"]);
+        let split = fragment_into_two_records(&hello, (hello.len() - 5) / 2);
+        assert!(matches!(decide(&split), AlpnParse::Decided(true)));
+    }
+
+    #[test]
+    fn a_split_hello_missing_its_second_record_asks_for_more() {
+        let hello = client_hello_with_alpn(&[b"acme-tls/1"]);
+        let split = fragment_into_two_records(&hello, (hello.len() - 5) / 2);
+        // Keep only the first record + its header: the handshake is incomplete.
+        let first_rec_end = 5 + u16::from_be_bytes([split[3], split[4]]) as usize;
+        assert!(matches!(
+            decide(&split[..first_rec_end]),
+            AlpnParse::NeedMore
+        ));
+    }
+
+    #[test]
+    fn trailing_bytes_after_the_clienthello_are_not_parsed_as_extensions() {
+        // A record carrying the ClientHello plus extra crafted handshake bytes
+        // must be walked only to the declared ClientHello length, so the extras
+        // can't forge an ALPN decision.
+        let mut hello = client_hello_with_alpn(&[b"h2"]);
+        // Append junk inside the record by growing the record length and adding
+        // bytes after the handshake. The declared handshake length is unchanged,
+        // so the walk must ignore them.
+        let extra = vec![0xAAu8; 16];
+        let new_rec_len = (u16::from_be_bytes([hello[3], hello[4]]) as usize + extra.len()) as u16;
+        hello[3..5].copy_from_slice(&new_rec_len.to_be_bytes());
+        hello.extend_from_slice(&extra);
+        // Still decides on the real ALPN (h2), not confused by the trailing junk.
+        assert!(matches!(decide(&hello), AlpnParse::Decided(false)));
+    }
+
+    #[test]
+    fn proxy_v2_header_encodes_ipv4_addresses() {
+        use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+        let src = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 7), 51000));
+        let dst = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 443));
+        let h = proxy_v2_header(src, dst);
+
+        // Signature + v2/PROXY + INET/STREAM + 12-byte address block.
+        assert_eq!(
+            &h[..12],
+            &[
+                0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A
+            ]
+        );
+        assert_eq!(h[12], 0x21);
+        assert_eq!(h[13], 0x11);
+        assert_eq!(u16::from_be_bytes([h[14], h[15]]), 12);
+        assert_eq!(&h[16..20], &[203, 0, 113, 7]); // source IP
+        assert_eq!(&h[20..24], &[127, 0, 0, 1]); // dest IP
+        assert_eq!(u16::from_be_bytes([h[24], h[25]]), 51000); // source port
+        assert_eq!(u16::from_be_bytes([h[26], h[27]]), 443); // dest port
+        assert_eq!(h.len(), 28);
+    }
+}

--- a/tests/e2e/acme/compose.acme.yaml
+++ b/tests/e2e/acme/compose.acme.yaml
@@ -45,7 +45,9 @@ services:
       SOZUNE_ACME_TEST_CA: /config/pebble-ca.pem
       RUST_LOG: sozune=debug
     volumes:
-      - "./config.acme.yaml:/config/config.yaml:ro"
+      # Which config to mount is chosen by the runner: config.acme.yaml for
+      # HTTP-01, config.alpn.yaml for TLS-ALPN-01.
+      - "./${SOZUNE_CONFIG:-config.acme.yaml}:/config/config.yaml:ro"
       - "./entrypoints.acme.yaml:/config/entrypoints.acme.yaml:ro"
       - "./pebble-ca.pem:/config/pebble-ca.pem:ro"
     networks:

--- a/tests/e2e/acme/config.alpn.yaml
+++ b/tests/e2e/acme/config.alpn.yaml
@@ -1,0 +1,33 @@
+# Sōzune config for the TLS-ALPN-01 e2e. Same shape as config.acme.yaml, but
+# the resolver is tls-alpn-01: declaring it flips the HTTPS listener into the
+# ALPN-aware gate on 443, so Pebble can validate over the handshake.
+providers:
+  config_file:
+    enabled: true
+    path: /config/entrypoints.acme.yaml
+  docker:
+    enabled: false
+
+api:
+  enabled: true
+  listen_address: "0.0.0.0:8081"
+  users:
+    - name: admin
+      # sha256 of "admin"
+      hash: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+      role: admin
+
+proxy:
+  http:
+    listen_address: 80
+  https:
+    listen_address: 443
+
+acme:
+  enabled: true
+  email: "e2e@acme.test"
+  certs_dir: /tmp/acme-certs
+  resolvers:
+    pebble:
+      challenge: tls-alpn-01
+      ca_server: "https://pebble:14000/dir"

--- a/tests/e2e/acme/run-alpn.sh
+++ b/tests/e2e/acme/run-alpn.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# TLS-ALPN-01 e2e harness. Same setup as run-acme.sh, but Sōzune uses a
+# tls-alpn-01 resolver: declaring it flips the HTTPS listener into the
+# ALPN-aware gate on 443, and Pebble validates the challenge over the TLS
+# handshake (ALPN acme-tls/1) instead of an HTTP request. Proves the gate
+# routes acme-tls/1 to the responder AND keeps normal HTTPS working.
+#
+# Hermetic: no public ACME. Not run by run-all.sh; invoke directly.
+#
+# Requirements: docker (compose v2), openssl, curl
+
+set -euo pipefail
+
+ACME_DIR="$(cd "$(dirname "$0")" && pwd)"
+export SOZUNE_CONFIG="config.alpn.yaml"
+COMPOSE="docker compose -p sozune-alpn -f $ACME_DIR/compose.acme.yaml"
+
+PASSED=0
+FAILED=0
+pass() { echo -e "\033[0;32m[PASS]\033[0m $*"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "\033[0;31m[FAIL]\033[0m $*"; FAILED=$((FAILED + 1)); }
+log()  { echo -e "\033[1;33m[ALPN]\033[0m $*"; }
+
+cleanup() {
+    log "Cleaning up..."
+    $COMPOSE down --remove-orphans --volumes >/dev/null 2>&1 || true
+    rm -f "$ACME_DIR/pebble-ca.pem"
+}
+trap cleanup EXIT
+
+$COMPOSE down --remove-orphans --volumes >/dev/null 2>&1 || true
+rm -rf "$ACME_DIR/pebble-ca.pem"
+: > "$ACME_DIR/pebble-ca.pem"
+
+# --- Pebble's minica root (signs the directory endpoint) ------------------
+log "Extracting Pebble's minica root..."
+cid=$(docker create ghcr.io/letsencrypt/pebble:latest 2>/dev/null)
+if ! docker cp "$cid:/test/certs/pebble.minica.pem" "$ACME_DIR/pebble-ca.pem" 2>/dev/null; then
+    docker rm "$cid" >/dev/null 2>&1 || true
+    fail "could not extract minica root from the Pebble image"
+    exit 1
+fi
+docker rm "$cid" >/dev/null 2>&1 || true
+pass "minica root extracted"
+
+log "Starting Pebble + backend..."
+$COMPOSE up -d pebble backend >/dev/null 2>&1
+for _ in $(seq 1 30); do
+    if docker run --rm --network sozune-alpn_default curlimages/curl:latest \
+        -sk --max-time 3 https://pebble:14000/dir 2>/dev/null | grep -q newOrder; then
+        break
+    fi
+    sleep 1
+done
+
+log "Building and starting Sōzune (TLS-ALPN-01 gate on 443)..."
+$COMPOSE up -d --build sozune >/dev/null 2>&1
+
+# --- Wait for the certificate ---------------------------------------------
+# Pebble validates by connecting to acme.test:443 with ALPN acme-tls/1; the
+# gate must route that to the responder, which presents cheti's challenge cert.
+log "Waiting for Sōzune to provision the certificate via TLS-ALPN-01..."
+issued=0
+for _ in $(seq 1 60); do
+    certs=$(curl -s -u admin:admin --max-time 3 \
+        http://127.0.0.1:18081/certificates 2>/dev/null || true)
+    if [[ "$certs" == *"acme.test"* ]]; then
+        issued=1
+        break
+    fi
+    sleep 2
+done
+
+if [[ $issued -eq 1 ]]; then
+    pass "certificate for acme.test provisioned through TLS-ALPN-01"
+else
+    fail "no certificate for acme.test after 120s"
+    echo "--- last API response ---"; echo "$certs"
+    echo "--- sozune logs (tail) ---"
+    $COMPOSE logs --tail=50 sozune 2>/dev/null || true
+fi
+
+# --- Normal HTTPS still works through the gate ----------------------------
+# The whole point of the gate: acme-tls/1 goes to the responder, but ordinary
+# HTTPS (no acme-tls/1 in ALPN) must still reach the HTTPS worker and serve the
+# real, Pebble-issued certificate.
+if [[ $issued -eq 1 ]]; then
+    log "Checking normal HTTPS still serves the issued cert through the gate..."
+    served=$(timeout 5 openssl s_client -connect 127.0.0.1:18443 \
+        -servername acme.test -alpn h2,http/1.1 </dev/null 2>/dev/null |
+        openssl x509 -noout -issuer 2>/dev/null || true)
+    if [[ "$served" == *"Pebble"* || "$served" == *"minica"* ]]; then
+        pass "normal HTTPS reaches the worker and serves the issued cert"
+    else
+        fail "normal HTTPS did not serve the expected cert (got: '$served')"
+    fi
+
+    # And a real HTTP request over that TLS reaches the backend.
+    log "Checking a request flows end-to-end through the gate..."
+    body=$(curl -sk --max-time 5 --resolve acme.test:18443:127.0.0.1 \
+        https://acme.test:18443/ 2>/dev/null || true)
+    if [[ -n "$body" ]]; then
+        pass "an HTTPS request reaches the backend through the gate"
+    else
+        fail "no response body from an HTTPS request through the gate"
+    fi
+fi
+
+echo ""
+echo "=============================="
+echo -e "  \033[0;32mPassed: $PASSED\033[0m  \033[0;31mFailed: $FAILED\033[0m"
+echo "=============================="
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
Adds the ACME **TLS-ALPN-01** challenge (RFC 8737): Sōzune can now obtain Let's Encrypt certificates with **neither port 80** (HTTP-01) **nor DNS API credentials** (DNS-01). The validation happens over the TLS handshake on 443 itself. Built on cheti's new `TlsAlpn01Solver`.

## Usage

```yaml
acme:
  enabled: true
  email: ops@example.com
  resolvers:
    edge:
      challenge: tls-alpn-01
```

An entrypoint (or Docker label) points at the resolver: `sozune.http.app.acme.resolver=edge`.

## How it works

Answering the challenge means intercepting the handshake on 443, which the HTTPS worker can't do alone. So — **only when a `tls-alpn-01` resolver is configured** — Sōzune fronts 443 with an ALPN-aware gate:

- the gate binds public 443 and prereads each ClientHello's ALPN;
- `acme-tls/1` handshakes go to a local rustls responder that presents cheti's challenge certificate;
- everything else is spliced, undecrypted, to the HTTPS worker (now on a loopback port).

The real client IP is preserved: the gate prepends a PROXY-v2 header the worker consumes (`with_expect_proxy`), so client-IP allow-lists, access logs and metrics stay accurate. **Without a `tls-alpn-01` resolver, none of this happens** — 443 stays a direct HTTPS listener, byte-for-byte the old path.

## Three commits

1. Bump cheti to the revision with the TLS-ALPN-01 solver.
2. The responder + resolver wiring (rustls loopback listener, `Resolver::TlsAlpn01`, config). Safe in isolation — nothing routes to it yet.
3. The 443 gate that routes `acme-tls/1` to the responder. This is the part that touches the production HTTPS path.

## Verified end-to-end

A Pebble-based harness (`tests/e2e/acme/run-alpn.sh`) issues a real certificate over a real TLS-ALPN-01 challenge, hermetically, and asserts normal HTTPS still flows through the gate and reaches the backend.

## Hardening

The 443 gate is the riskiest code here — it fronts all HTTPS traffic — so it went through two Codex review rounds, nine issues fixed:

- client IP loss → PROXY-v2 header + `with_expect_proxy`, destination taken from `local_addr()`;
- ClientHello fragmented across TLS records → handshake reassembly;
- per-read timeout (slowloris) → single absolute preread deadline;
- silent gate bind failure → error propagates and fails the process;
- unbounded handshake framing → walk bounded by the ClientHello's declared length;
- byte-cap tuning and honest documentation of its one theoretical (non-reachable) edge.

The hand-rolled ClientHello ALPN parse has unit tests for each case (fragmentation, trailing-byte rejection, non-TLS, truncation, PROXY-v2 encoding).

## Limitation

Wildcards are not supported (a TLS-ALPN-01 validator connects to a concrete name). Use DNS-01 for `*.example.com`.
