### PR TITLE
refactor(dashboard): extract shared ResourceTable

### DIFF
--- a/dashboard/src/lib/ResourceTable.svelte
+++ b/dashboard/src/lib/ResourceTable.svelte
@@ -1,0 +1,249 @@
+<script lang="ts" generics="T">
+  /**
+   * The list-page shell shared by the resource listings: page header with an
+   * optional refresh control, error and empty states, and the table itself —
+   * plus the load-and-poll lifecycle.
+   *
+   * Pages own their columns and cells (via the `row` snippet) and anything
+   * specific that sits between the header and the table (stat cards, filters)
+   * via the `beforeTable` snippet. Everything that was duplicated verbatim
+   * across the listing pages lives here instead.
+   */
+  import { onDestroy, onMount } from 'svelte';
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title: string;
+    subtitle: string;
+    /** Column headers, in order. `align: 'right'` gets tabular numerals. */
+    columns: Array<{ label: string; align?: 'right' }>;
+    /** Fetches the full list; re-run on refresh and on every poll tick. */
+    load: () => Promise<T[]>;
+    /** Stable key per item, for keyed `{#each}`. */
+    key: (item: T) => string;
+    /** Poll interval in ms; `0` disables polling. */
+    pollMs?: number;
+    /** Show the header's Refresh button and "updated …" marker. */
+    refreshable?: boolean;
+    /** One `<tr>` per item. */
+    row: Snippet<[T]>;
+    /** Text shown when the list comes back empty. */
+    emptyText?: string;
+    /** Rendered between the header and the table — stat cards, filters, … */
+    beforeTable?: Snippet<[T[]]>;
+  }
+
+  let {
+    title,
+    subtitle,
+    columns,
+    load,
+    key,
+    pollMs = 5000,
+    refreshable = true,
+    row,
+    emptyText = 'Nothing to show.',
+    beforeTable
+  }: Props = $props();
+
+  let items = $state<T[]>([]);
+  let loading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let lastFetch = $state<Date | null>(null);
+  let poll: ReturnType<typeof setInterval> | null = null;
+
+  export async function refresh(): Promise<void> {
+    try {
+      items = await load();
+      errorMsg = null;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+      lastFetch = new Date();
+    }
+  }
+
+  function timeAgo(d: Date | null): string {
+    if (!d) return '';
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 5) return 'just now';
+    if (s < 60) return `${s}s ago`;
+    return `${Math.floor(s / 60)}m ago`;
+  }
+
+  onMount(() => {
+    void refresh();
+    if (pollMs > 0) {
+      poll = setInterval(() => void refresh(), pollMs);
+    }
+  });
+
+  onDestroy(() => {
+    if (poll) {
+      clearInterval(poll);
+    }
+  });
+</script>
+
+<header class="page-header">
+  <div>
+    <h1>{title}</h1>
+    <p class="subtitle">{subtitle}</p>
+  </div>
+  {#if refreshable}
+    <div class="header-actions">
+      {#if lastFetch}
+        <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
+      {/if}
+      <button class="btn-secondary" onclick={refresh} disabled={loading}>
+        {loading ? 'loading…' : 'Refresh'}
+      </button>
+    </div>
+  {/if}
+</header>
+
+{#if beforeTable}
+  {@render beforeTable(items)}
+{/if}
+
+{#if errorMsg}
+  <div class="alert">
+    <strong>error</strong>
+    {errorMsg}
+  </div>
+{/if}
+
+{#if !loading && items.length > 0}
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          {#each columns as col}
+            <th class:num={col.align === 'right'}>{col.label}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each items as item (key(item))}
+          {@render row(item)}
+        {/each}
+      </tbody>
+    </table>
+  </section>
+{/if}
+
+{#if !loading && items.length === 0 && !errorMsg}
+  <div class="empty">{emptyText}</div>
+{/if}
+
+<style>
+  /* These primitives live in each page's own <style> rather than app.css, so
+   * the component carries the shape it renders. Svelte scopes both sides, and
+   * a page keeps whatever it still defines locally for its own markup. */
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 1.75rem;
+  }
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--fg-2);
+    font-size: 0.825rem;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .refresh-meta {
+    color: var(--fg-3);
+    font-size: 0.75rem;
+  }
+  .btn-secondary {
+    background: var(--bg-2);
+    color: var(--fg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.875rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .btn-secondary:hover {
+    background: var(--bg-hover);
+    color: var(--fg-0);
+  }
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .card {
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0;
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th {
+    text-align: left;
+    padding: 0.7rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-weight: 500;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-2);
+    background: var(--bg-0);
+  }
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  /* Both the <tr> and its <td>s come from the caller's `row` snippet, so they
+   * carry the page's scope rather than this component's — a scoped selector
+   * here would match nothing and be pruned. Only this last-row border needs to
+   * reach into the snippet; every other cell rule stays with the page that
+   * renders the cells. */
+  tbody :global(tr:last-child td) {
+    border-bottom: none;
+  }
+
+  .alert {
+    background: var(--danger-bg);
+    border: 1px solid var(--danger);
+    color: var(--fg-0);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 1.25rem;
+    font-size: 0.825rem;
+  }
+  .alert strong {
+    color: var(--danger);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+
+  .empty {
+    color: var(--fg-2);
+    font-size: 0.85rem;
+    padding: 1.5rem;
+    text-align: center;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+</style>

--- a/dashboard/src/routes/providers/+page.svelte
+++ b/dashboard/src/routes/providers/+page.svelte
@@ -1,43 +1,16 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import ResourceTable from '$lib/ResourceTable.svelte';
   import { listProviders, type Provider } from '$lib/api';
 
-  let providers = $state<Provider[]>([]);
-  let loading = $state(true);
-  let errorMsg = $state<string | null>(null);
-  let lastFetch = $state<Date | null>(null);
+  const columns = [
+    { label: 'Provider' },
+    { label: 'Status' },
+    { label: 'Entrypoints', align: 'right' as const }
+  ];
 
-  let poll: ReturnType<typeof setInterval> | null = null;
-
-  async function refresh() {
-    try {
-      const res = await listProviders();
-      providers = res.providers;
-      errorMsg = null;
-    } catch (e) {
-      errorMsg = e instanceof Error ? e.message : String(e);
-    } finally {
-      loading = false;
-      lastFetch = new Date();
-    }
-  }
-
-  onMount(() => {
-    void refresh();
-    // Counts come from live storage — refresh on the same cadence as Health.
-    poll = setInterval(() => void refresh(), 5000);
-  });
-
-  onDestroy(() => {
-    if (poll) clearInterval(poll);
-  });
-
-  function timeAgo(d: Date | null): string {
-    if (!d) return '';
-    const s = Math.floor((Date.now() - d.getTime()) / 1000);
-    if (s < 5) return 'just now';
-    if (s < 60) return `${s}s ago`;
-    return `${Math.floor(s / 60)}m ago`;
+  // Counts come from live storage — refresh on the same cadence as Health.
+  async function load(): Promise<Provider[]> {
+    return (await listProviders()).providers;
   }
 
   function statusOf(p: Provider): 'active' | 'disabled' | 'unconfigured' {
@@ -56,135 +29,60 @@
         return 'not configured';
     }
   }
-
-  // Pre-compute the totals shown above the table.
-  let activeCount = $derived(providers.filter((p) => p.enabled).length);
-  let totalEntrypoints = $derived(
-    providers.reduce((acc, p) => acc + p.entrypoint_count, 0)
-  );
 </script>
 
-<header class="page-header">
-  <div>
-    <h1>Providers</h1>
-    <p class="subtitle">Service discovery sources sōzune knows about</p>
-  </div>
-  <div class="header-actions">
-    {#if lastFetch}
-      <span class="refresh-meta">updated {timeAgo(lastFetch)}</span>
-    {/if}
-    <button class="btn-secondary" onclick={refresh} disabled={loading}>
-      {loading ? 'loading…' : 'Refresh'}
-    </button>
-  </div>
-</header>
+<ResourceTable
+  title="Providers"
+  subtitle="Service discovery sources sōzune knows about"
+  {columns}
+  {load}
+  key={(p: Provider) => p.name}
+  emptyText="No providers reported."
+>
+  {#snippet beforeTable(providers: Provider[])}
+    <section class="stats">
+      <div class="stat-card">
+        <div class="stat-label">Enabled</div>
+        <div class="stat-value">
+          {providers.filter((p) => p.enabled).length}<span class="unit">/ {providers.length}</span>
+        </div>
+        <div class="stat-sub">providers currently active</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Entrypoints</div>
+        <div class="stat-value">
+          {providers.reduce((acc, p) => acc + p.entrypoint_count, 0)}
+        </div>
+        <div class="stat-sub">across every provider</div>
+      </div>
+    </section>
+  {/snippet}
 
-<section class="stats">
-  <div class="stat-card">
-    <div class="stat-label">Enabled</div>
-    <div class="stat-value">{activeCount}<span class="unit">/ {providers.length}</span></div>
-    <div class="stat-sub">providers currently active</div>
-  </div>
-  <div class="stat-card">
-    <div class="stat-label">Entrypoints</div>
-    <div class="stat-value">{totalEntrypoints}</div>
-    <div class="stat-sub">across every provider</div>
-  </div>
-</section>
-
-{#if errorMsg}
-  <div class="alert">
-    <strong>error</strong> {errorMsg}
-  </div>
-{/if}
-
-{#if !loading && providers.length > 0}
-  <section class="card">
-    <table>
-      <thead>
-        <tr>
-          <th>Provider</th>
-          <th>Status</th>
-          <th class="num">Entrypoints</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each providers as p (p.name)}
-          {@const s = statusOf(p)}
-          {@const canDrill = p.entrypoint_count > 0}
-          <tr class:disabled={s !== 'active'} class:clickable={canDrill}>
-            <td>
-              {#if canDrill}
-                <a class="provider-link" href={`../entrypoints?source=${encodeURIComponent(p.name)}`}>
-                  <span class="provider-name">{p.name}</span>
-                </a>
-              {:else}
-                <span class="provider-name">{p.name}</span>
-              {/if}
-            </td>
-            <td>
-              <span class="status-pill" class:active={s === 'active'} class:warn={s === 'disabled'}>
-                <span class="dot" class:active={s === 'active'} class:warn={s === 'disabled'}></span>
-                {statusLabel(s)}
-              </span>
-            </td>
-            <td class="num mono">{p.entrypoint_count}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </section>
-{/if}
-
-{#if !loading && providers.length === 0 && !errorMsg}
-  <div class="empty">No providers reported.</div>
-{/if}
+  {#snippet row(p: Provider)}
+    {@const s = statusOf(p)}
+    {@const canDrill = p.entrypoint_count > 0}
+    <tr class:disabled={s !== 'active'} class:clickable={canDrill}>
+      <td>
+        {#if canDrill}
+          <a class="provider-link" href={`../entrypoints?source=${encodeURIComponent(p.name)}`}>
+            <span class="provider-name">{p.name}</span>
+          </a>
+        {:else}
+          <span class="provider-name">{p.name}</span>
+        {/if}
+      </td>
+      <td>
+        <span class="status-pill" class:active={s === 'active'} class:warn={s === 'disabled'}>
+          <span class="dot" class:active={s === 'active'} class:warn={s === 'disabled'}></span>
+          {statusLabel(s)}
+        </span>
+      </td>
+      <td class="num mono">{p.entrypoint_count}</td>
+    </tr>
+  {/snippet}
+</ResourceTable>
 
 <style>
-  .page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    margin-bottom: 1.75rem;
-  }
-  h1 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-  }
-  .subtitle {
-    margin: 0.25rem 0 0;
-    color: var(--fg-2);
-    font-size: 0.825rem;
-  }
-  .header-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-  .refresh-meta {
-    color: var(--fg-3);
-    font-size: 0.75rem;
-  }
-  .btn-secondary {
-    background: var(--bg-2);
-    color: var(--fg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.5rem 0.875rem;
-    font-size: 0.8rem;
-    font-weight: 500;
-  }
-  .btn-secondary:hover {
-    background: var(--bg-hover);
-    color: var(--fg-0);
-  }
-  .btn-secondary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .stats {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
@@ -223,36 +121,15 @@
     margin-top: 0.25rem;
   }
 
-  .card {
-    background: var(--bg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    padding: 0;
-    overflow: hidden;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-  th, td {
+  /* Cell rules stay here: the `row` snippet is compiled into this page, so its
+   * <td>s carry this component's scope, not ResourceTable's. */
+  td {
     text-align: left;
     padding: 0.7rem 1rem;
     font-size: 0.85rem;
     border-bottom: 1px solid var(--border);
   }
-  tbody tr:last-child td {
-    border-bottom: none;
-  }
-  th {
-    font-weight: 500;
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--fg-2);
-    background: var(--bg-0);
-  }
-  td.num, th.num {
+  td.num {
     text-align: right;
     font-variant-numeric: tabular-nums;
   }
@@ -316,32 +193,5 @@
   }
   .dot.warn {
     background: var(--fg-2);
-  }
-
-  .alert {
-    background: var(--danger-bg);
-    border: 1px solid var(--danger);
-    color: var(--fg-0);
-    padding: 0.85rem 1rem;
-    border-radius: var(--radius);
-    margin-bottom: 1.25rem;
-    font-size: 0.825rem;
-  }
-  .alert strong {
-    color: var(--danger);
-    margin-right: 0.5rem;
-    text-transform: uppercase;
-    font-size: 0.7rem;
-    letter-spacing: 0.08em;
-  }
-
-  .empty {
-    color: var(--fg-2);
-    font-size: 0.85rem;
-    padding: 1.5rem;
-    text-align: center;
-    background: var(--bg-1);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
   }
 </style>


### PR DESCRIPTION
The listing pages each reimplement the same shell: page header with refresh marker, load-and-poll lifecycle, error banner, empty state, table skeleton. `src/lib/` held no components at all, so every page carried its own copy.

This adds `ResourceTable.svelte` and migrates the providers page onto it as the first consumer.

## Changes

- New `$lib/ResourceTable.svelte`: header (optional Refresh + "updated …"), load/poll lifecycle, error and empty states, table skeleton. Callers pass columns and a `row` snippet, plus an optional `beforeTable` snippet for anything page-specific between header and table (providers uses it for its stat cards).
- Providers migrated: 276 lines down to ~140 of page-specific code.

## No visual change

The component carries the primitives (`.page-header`, `.card`, `.alert`, `.empty`, `.btn-secondary`, …) because this dashboard keeps them in each page's `<style>` rather than in `app.css`.

Verified by diffing the *compiled* CSS before and after, comparing the page scope and the component scope together: zero declarations lost or altered for the providers page.

## Notes

Cell rules stay with the page — the `row` snippet is compiled into the caller, so its `<td>`s carry the page's scope, not the component's. The one exception is the last-row border, which needs `tbody :global(tr:last-child td)` to reach into the snippet; a scoped selector there matches nothing and is pruned (the compiler reports it as unused CSS).

## Checks

`svelte-check` (0 errors), `biome check` and `build` pass, with no unused-CSS warnings. Not exercised against a running server.