### PR TITLE
Let the middleware chain short-circuit with a response clippy 1.98 calls large

### DIFF
--- a/src/middleware/chain.rs
+++ b/src/middleware/chain.rs
@@ -65,6 +65,11 @@ pub trait Middleware: Send + Sync {
 /// Run the request phase of every middleware in order. Returns `Err(response)`
 /// the moment one short-circuits, so the caller can return it without touching
 /// the backend.
+///
+/// The `Err` variant is a ready response, not an error: `result_large_err`
+/// wants it boxed, which would put an allocation on the request path to
+/// describe a short-circuit that is already the uncommon case.
+#[allow(clippy::result_large_err)]
 pub async fn run_request_phase(
     middlewares: &[Arc<dyn Middleware>],
     ctx: &mut RequestCtx,


### PR DESCRIPTION
CI runs `dtolnay/rust-toolchain@stable` and picked up clippy 1.98, which fires `result_large_err` on `run_request_phase`. Every PR fails lint on this, including ones that do not touch the file; main last went green on 25 July, before the release.

The `Err` variant here is a ready response, not an error: a middleware returning it is short-circuiting the request. Boxing it as clippy suggests would put an allocation on the request path to describe the uncommon case, so the lint is allowed on that one function with the reason written down.