### PR TITLE
Build the image with a Rust that does not segfault on this crate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ RUN bun install --frozen-lockfile
 COPY dashboard/ ./
 RUN bun run build
 
-# Pinned to 1.95.0: rustc 1.96 SIGSEGVs in thin-LTO codegen on this dependency set.
-FROM rust:1.95.0-bookworm AS builder
+# Pinned so a toolchain release cannot change what this image compiles to.
+# 1.95.0 was chosen when 1.96 SIGSEGVd in thin-LTO codegen on this dependency
+# set; 1.95.0 now does the same as the crate has grown, and 1.98.0 does not.
+FROM rust:1.98.0-bookworm AS builder
 # protobuf-compiler: sozu's build.rs runs protoc to generate command.rs.
 # rustfmt: that same build.rs calls prost_build with .format(true), which shells
 # out to rustfmt — absent from the base image, so the generated module is never


### PR DESCRIPTION
`docker build` fails on the release build:

```
error: rustc interrupted by SIGSEGV, printing backtrace
  llvm::PassManager<llvm::Module, ...>::run
error: could not compile `sozune` (bin "sozune") (signal: 11, SIGSEGV)
```

The builder was pinned to 1.95.0 because 1.96 segfaulted in thin-LTO codegen on this dependency set. That bug now reaches 1.95.0 too as the crate has grown — the pin protected against a future toolchain while freezing one that was going to stop working.

1.98.0 compiles it. The pin stays, so a toolchain release still cannot change what this image produces; the comment now records why this version rather than the history of the last one.

Not a stack limit, for the record: raising `RUST_MIN_STACK` to 16 MiB then 64 MiB made the build fail sooner (106s, then 15s), not later.