### PR TITLE
Refuse a hostname that would match hosts the service was never given

### DIFF
--- a/src/labels/fields/host.rs
+++ b/src/labels/fields/host.rs
@@ -1,6 +1,26 @@
 use crate::labels::diagnostic::{Diagnostic, DiagnosticCode};
 use std::collections::HashMap;
 
+/// Whether a name can be installed as a route.
+///
+/// Sozu reads a hostname containing `/` as a regex and a bare `*` as
+/// `DomainRule::Any`, so an unvalidated label could claim every host on the
+/// proxy — frontends go in at `RulePosition::Pre`, ahead of every legitimate
+/// route. Only a leading `*.` is a wildcard, which Sozu handles natively.
+///
+/// Same shapes `AcmeManager::validate_hostname` already refuses; the routing
+/// path had no equivalent gate.
+pub fn is_routable_hostname(hostname: &str) -> bool {
+    let trailing = hostname.strip_prefix("*.").unwrap_or(hostname);
+    !trailing.is_empty()
+        && !trailing.contains('*')
+        && !trailing.contains('/')
+        && !trailing.contains('\\')
+        && !trailing.contains('\0')
+        && trailing != "."
+        && !trailing.contains("..")
+}
+
 /// Parse the required `host` label, comma-separated. Emits `E002` and returns
 /// `None` when the label is absent — this blocks routing for the service.
 pub fn parse_hostnames(
@@ -29,6 +49,23 @@ pub fn parse_hostnames(
         .map(|h| h.trim().to_string())
         .filter(|h| !h.is_empty())
         .collect();
+
+    if let Some(bad) = hosts.iter().find(|h| !is_routable_hostname(h)) {
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticCode::E002MissingHost,
+                "host label contains a name that is not a hostname",
+            )
+            .with_label(&key)
+            .with_value(bad)
+            .with_hint(
+                "use a plain hostname, or `*.example.com` for a wildcard: a name holding \
+                 `/` or a bare `*` is read as a pattern and would match hosts this service \
+                 was never given",
+            ),
+        );
+        return None;
+    }
 
     if hosts.is_empty() {
         diagnostics.push(
@@ -87,6 +124,65 @@ mod tests {
         )
         .unwrap();
         assert_eq!(hosts, vec!["a.com", "b.com", "c.com"]);
+    }
+
+    /// Sozu reads any hostname containing `/` as a regex, and a bare `*` as
+    /// "every host". A container that can set its own labels could therefore
+    /// claim the whole proxy:
+    ///
+    /// ```yaml
+    /// sozune.http.evil.host: "/.*/"
+    /// ```
+    ///
+    /// Frontends are installed at `RulePosition::Pre`, so that rule sits in
+    /// front of every legitimate route and captures other tenants' traffic —
+    /// credentials and session cookies included. ACME already refused these
+    /// shapes; the routing path did not.
+    #[test]
+    fn a_regex_hostname_is_refused() {
+        for raw in ["/.*/", "/example\\.com/", "*", "a/b.com"] {
+            let mut diags = Vec::new();
+            assert!(
+                parse_hostnames(
+                    &labels(&[("sozune.http.web.host", raw)]),
+                    "sozune.http.web.",
+                    &mut diags,
+                )
+                .is_none(),
+                "`{raw}` must not become a route"
+            );
+            assert_eq!(diags[0].code, DiagnosticCode::E002MissingHost);
+        }
+    }
+
+    /// One bad name must not carry the usable ones with it, and must not let
+    /// them through either: the entrypoint is refused as a whole, so an
+    /// operator sees the mistake instead of half a route.
+    #[test]
+    fn one_bad_name_refuses_the_whole_label() {
+        let mut diags = Vec::new();
+        assert!(
+            parse_hostnames(
+                &labels(&[("sozune.http.web.host", "good.example.com,/.*/")]),
+                "sozune.http.web.",
+                &mut diags,
+            )
+            .is_none()
+        );
+    }
+
+    /// A leading `*.` is a wildcard Sozu handles natively, and the shape ACME
+    /// already accepts. It must keep working.
+    #[test]
+    fn a_leading_wildcard_is_still_accepted() {
+        let mut diags = Vec::new();
+        let hosts = parse_hostnames(
+            &labels(&[("sozune.http.web.host", "*.example.com")]),
+            "sozune.http.web.",
+            &mut diags,
+        )
+        .unwrap();
+        assert_eq!(hosts, vec!["*.example.com"]);
     }
 
     #[test]

--- a/src/provider/http.rs
+++ b/src/provider/http.rs
@@ -31,8 +31,26 @@ impl HttpProvider {
         let entrypoints: Vec<Entrypoint> = serde_json::from_str(&body)
             .map_err(|e| anyhow::anyhow!("Failed to parse HTTP provider response: {}", e))?;
 
+        // Same gate the label path applies: a name holding `/` is a regex to
+        // Sozu and a bare `*` matches every host, so an entrypoint from an
+        // upstream control plane could otherwise claim the whole proxy.
         Ok(entrypoints
             .into_iter()
+            .filter(|ep| {
+                let bad = ep
+                    .config
+                    .hostnames
+                    .iter()
+                    .find(|h| !crate::labels::fields::host::is_routable_hostname(h));
+                if let Some(bad) = bad {
+                    warn!(
+                        "dropping entrypoint `{}` from the HTTP provider: `{}` is not a hostname",
+                        ep.id, bad
+                    );
+                    return false;
+                }
+                true
+            })
             .map(|ep| (ep.id.clone(), ep))
             .collect())
     }


### PR DESCRIPTION
`parse_hostnames` split on commas, trimmed, and dropped empties. Nothing checked the shape of what came out, and Sozu reads two of those shapes as patterns:

- a name containing `/` becomes a regex (`DomainRule::Regex`)
- a bare `*` becomes `DomainRule::Any`

So a container that can set its own labels could claim the whole proxy:

```yaml
sozune.http.evil.host: "/.*/"
```

Frontends are installed at `RulePosition::Pre`, ahead of every legitimate route, so that one rule captures other tenants' traffic — credentials and session cookies included. The same applies to an entrypoint served by the HTTP provider, which deserializes straight into the store.

ACME already refused these shapes in `validate_hostname`; the routing path had no equivalent gate. It does now, on both doors: the label parser emits E002 and refuses the entrypoint, and the HTTP provider drops it with a warning naming the offending value. A leading `*.` stays accepted — that is a wildcard Sozu handles natively, and the shape ACME already allows.

One bad name refuses the whole label rather than silently routing the rest, so an operator sees the mistake instead of half a route.

Sixth of the findings from a full audit, after #140 to #144.